### PR TITLE
make kafka client ids unique by hostname

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -77,6 +77,8 @@ services:
       - OSPREY_KAFKA_BOOTSTRAP_SERVERS=["kafka:29092"]
       - OSPREY_KAFKA_INPUT_STREAM_TOPIC=osprey.actions_input
       - OSPREY_KAFKA_INPUT_STREAM_CLIENT_ID=localhost
+      # Leave missing to automatically use hostname for client id suffix
+      # - OSPREY_KAFKA_INPUT_STREAM_CLIENT_ID_SUFFIX=
       - OSPREY_KAFKA_OUTPUT_SINK=True
       - OSPREY_KAFKA_OUTPUT_TOPIC=osprey.execution_results
       - OSPREY_KAFKA_OUTPUT_CLIENT_ID=localhost

--- a/osprey_worker/src/osprey/worker/sinks/__init__.py
+++ b/osprey_worker/src/osprey/worker/sinks/__init__.py
@@ -154,6 +154,8 @@ def get_rules_sink_input_stream(
         if client_id_suffix is None:
             client_hostname = platform.node()
             client_id = f'{client_id}-{client_hostname}'
+        elif client_id_suffix != '':
+            client_id = f'{client_id}-{client_id_suffix}'
 
         consumer: PatchedKafkaConsumer = PatchedKafkaConsumer(
             input_topic,


### PR DESCRIPTION
Generally, client IDs should be unique. There's some different naming patterns for doing this that I've seen:

- An "app name" and use a "client id" as something unique
- A "client id" and use a "suffix" as something unique

I have no preference, but here I just kind of with with [what we do](https://github.com/bluesky-social/go-util/blob/main/pkg/bus/consumer/consumer.go#L113-L118) while trying to remain flexible with it... There's also a question of "do we really want to use hostnames for this". We do, since each pod in a k8s cluster will have a unique hostname. Some people though use UUIDs for this which would also be acceptable.

Notably though, if these are not unique (and - maybe - if the server isn't configured correctly? I'm not really a kafkaer) multiple consumers may receive the same events.

ps:  is there a readme or something that explains all the various env vars? or are we just putting them in the compose?