### PR TITLE
fix `object is not subscriptable` when registering input stream

### DIFF
--- a/osprey_worker/src/osprey/worker/adaptor/plugin_manager.py
+++ b/osprey_worker/src/osprey/worker/adaptor/plugin_manager.py
@@ -85,9 +85,9 @@ def bootstrap_action_proto_deserializer() -> ActionProtoDeserializer | None:
 def bootstrap_input_stream() -> BaseInputStream[BaseAckingContext[Action]] | None:
     load_all_osprey_plugins()
 
+    # spec has firstresult=True set, so it will return the first registered stream if one is registered
     stream = plugin_manager.hook.register_input_stream()
     if stream:
-        # spec has firstresult=True set, so it will return the first registered stream
         return stream
     else:
         return None


### PR DESCRIPTION
locally, easy to miss this one since `stream` would have been `None` (unless you actually registered a stream...). however, since `register_input_stream` just returns a `BaseInputStream`, not a list of them, this logic was incorrect.

@EXBreder