### PR TITLE
pass config as an arg to register_input_stream

### DIFF
--- a/osprey_worker/src/osprey/worker/adaptor/hookspecs/osprey_hooks.py
+++ b/osprey_worker/src/osprey/worker/adaptor/hookspecs/osprey_hooks.py
@@ -43,5 +43,5 @@ def register_action_proto_deserializer() -> ActionProtoDeserializer | None:
 
 
 @hookspec(firstresult=True)
-def register_input_stream() -> BaseInputStream[BaseAckingContext[Action]]:
+def register_input_stream(config: Config) -> BaseInputStream[BaseAckingContext[Action]]:
     raise NotImplementedError('register_input_stream must be implemented by the plugin')

--- a/osprey_worker/src/osprey/worker/adaptor/plugin_manager.py
+++ b/osprey_worker/src/osprey/worker/adaptor/plugin_manager.py
@@ -82,11 +82,11 @@ def bootstrap_action_proto_deserializer() -> ActionProtoDeserializer | None:
         return None
 
 
-def bootstrap_input_stream() -> BaseInputStream[BaseAckingContext[Action]] | None:
+def bootstrap_input_stream(config: Config) -> BaseInputStream[BaseAckingContext[Action]] | None:
     load_all_osprey_plugins()
 
     # spec has firstresult=True set, so it will return the first registered stream if one is registered
-    stream = plugin_manager.hook.register_input_stream()
+    stream = plugin_manager.hook.register_input_stream(config=config)
     if stream:
         return stream
     else:

--- a/osprey_worker/src/osprey/worker/sinks/input_stream_chooser.py
+++ b/osprey_worker/src/osprey/worker/sinks/input_stream_chooser.py
@@ -24,8 +24,9 @@ def get_rules_sink_input_stream(
     """Based on the `input_stream_source` constructs a configured input stream that can be used to source events to
     classify. For more details, see `InputStreamSource`."""
 
+    config = CONFIG.instance()
+
     if input_stream_source == InputStreamSource.PUBSUB:
-        config = CONFIG.instance()
         gcloud_project = config.get_str('PUBSUB_OSPREY_PROJECT_ID', 'osprey-dev')
         pubsub_subscription = config.get_str('PUBSUB_OSPREY_RULES_SINK_SUBSCRIPTION', 'rules-sink')
         subscriber = pubsub_v1.SubscriberClient()
@@ -121,7 +122,7 @@ def get_rules_sink_input_stream(
             kafka_consumer=consumer,
         )
     elif input_stream_source == InputStreamSource.PLUGIN:
-        stream = bootstrap_input_stream()
+        stream = bootstrap_input_stream(config=config)
         if stream is None:
             raise AssertionError('No input stream plugin registered')
         return stream


### PR DESCRIPTION
most likely, someone registering a custom input stream is going to need some values from the config (e.g. in bluesky case, SASL username/password for Kafka). of course, we could just use `CONFIG.instance()` inside of the custom stream, but that feels a little weird since `register_output_sinks` has a `config` argument passed to it. this just aligns the two so there's a similar pattern used for both.