### PR TITLE
move engine initialization to a standardized location

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -123,7 +123,7 @@ services:
       - ./osprey_worker:/osprey/osprey_worker
       - ./osprey_rpc:/osprey/osprey_rpc
       - ./example_rules:/osprey/example_rules
-
+      - ./entrypoint.sh:/osprey/entrypoint.sh
   osprey_ui_api:
     container_name: osprey_ui_api
     build:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -118,6 +118,7 @@ services:
       - OSPREY_RULES_SINK_NUM_WORKERS=1
       - BIGTABLE_EMULATOR_HOST=bigtable:8361
       - SNOWFLAKE_API_ENDPOINT=http://snowflake:8080
+      - OSPREY_RULES_PATH=./example_rules
     volumes:
       - ./osprey_worker:/osprey/osprey_worker
       - ./osprey_rpc:/osprey/osprey_rpc

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -155,11 +155,10 @@ def register_ast_validators() -> None:
 
 #### Rules
 
-Rules are written in SML, some examples are provided in `example_rules/` with YAML config, the rules are mounted to the worker processes when the containers start via:
+Rules are written in SML, some examples are provided in `example_rules/` with YAML config, the rules are mounted to the worker processes when the containers start via environment variables. ex:
 
 ```bash
-uv run python3.11 osprey_worker/src/osprey/worker/sinks/cli.py run-rules-sink \
-  --input kafka --output stdout --rules-path ./example_rules
+OSPREY_RULES= uv run python3.11 osprey_worker/src/osprey/worker/sinks/cli.py run-rules-sink
 ```
 
 #### Test Data

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -158,7 +158,7 @@ def register_ast_validators() -> None:
 Rules are written in SML, some examples are provided in `example_rules/` with YAML config, the rules are mounted to the worker processes when the containers start via environment variables. ex:
 
 ```bash
-OSPREY_RULES= uv run python3.11 osprey_worker/src/osprey/worker/sinks/cli.py run-rules-sink
+OSPREY_RULES=./example_rules uv run python3.11 osprey_worker/src/osprey/worker/sinks/cli.py run-rules-sink
 ```
 
 #### Test Data

--- a/druid/environment
+++ b/druid/environment
@@ -49,3 +49,6 @@ druid_processing_numThreads=2
 druid_processing_numMergeBuffers=2
 
 DRUID_LOG4J=<?xml version="1.0" encoding="UTF-8" ?><Configuration status="WARN"><Appenders><Console name="Console" target="SYSTEM_OUT"><PatternLayout pattern="%d{ISO8601} %p [%t] %c - %m%n"/></Console></Appenders><Loggers><Root level="info"><AppenderRef ref="Console"/></Root><Logger name="org.apache.druid.jetty.RequestLog" additivity="false" level="DEBUG"><AppenderRef ref="Console"/></Logger></Loggers></Configuration>
+
+# 100MB
+druid.coordinator.compaction.config=[{"dataSource":"osprey.execution_results","taskPriority":25,"inputSegmentSizeBytes":100000000}]

--- a/druid/specs/execution_results.json
+++ b/druid/specs/execution_results.json
@@ -4,7 +4,8 @@
     "ioConfig": {
       "type": "kafka",
       "consumerProperties": {
-        "bootstrap.servers": "kafka:29092"
+        "bootstrap.servers": "kafka:29092",
+        "auto.offset.reset": "latest"
       },
       "topic": "osprey.execution_results",
       "inputFormat": {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,7 +32,7 @@ cli-osprey-ui-api() {
 }
 
 cli-osprey-worker() {
-    exec uv run python3.11 osprey_worker/src/osprey/worker/cli/sinks.py run-rules-sink --rules-path ./example_rules
+    exec uv run python3.11 osprey_worker/src/osprey/worker/cli/sinks.py run-rules-sink
 }
 
 cli-run-tests() {

--- a/osprey_worker/src/osprey/worker/cli/sinks.py
+++ b/osprey_worker/src/osprey/worker/cli/sinks.py
@@ -107,6 +107,7 @@ def tail_kafka_input_sink() -> None:
         print(event)
 
 
+@cli.command()
 @click.option('--pooled/--no-pooled', default=True, help='Whether to run multiple sinks simultaneously in a pool.')
 @click.option(
     '--bootstrap-pubsub/--no-bootstrap-pubsub',

--- a/osprey_worker/src/osprey/worker/cli/sinks.py
+++ b/osprey_worker/src/osprey/worker/cli/sinks.py
@@ -1,5 +1,6 @@
 # mypy: ignore-errors
 # ruff: noqa: E402, E501
+
 from osprey.worker.lib.patcher import patch_all
 from osprey.worker.sinks.input_stream_chooser import get_rules_sink_input_stream
 from osprey.worker.sinks.sink.output_sink import EventEffectsOutputSink
@@ -12,16 +13,14 @@ from uuid import uuid1
 
 # this is required to avoid memory leaks with gRPC
 from gevent import config as gevent_config
-from osprey.worker.adaptor.plugin_manager import bootstrap_ast_validators, bootstrap_output_sinks, bootstrap_udfs
+from osprey.worker.adaptor.plugin_manager import bootstrap_output_sinks
 
 gevent_config.track_greenlet_tree = False
 
 import multiprocessing
 import os
 from concurrent.futures import ProcessPoolExecutor
-from pathlib import Path
-from typing import Optional, Set, TextIO, cast
-
+from typing import Optional, TextIO
 import click
 import gevent
 import kafka
@@ -36,11 +35,11 @@ configure_logging()
 
 from osprey.worker.lib.bulk_label import TaskStatus
 from osprey.worker.lib.config import Config
-from osprey.worker.lib.osprey_engine import OspreyEngine, get_sources_provider
+
+from osprey.worker.lib.osprey_engine import bootstrap_engine, bootstrap_engine_with_helpers, get_sources_provider
 from osprey.worker.lib.osprey_shared.logging import get_logger
 from osprey.worker.lib.publisher import PubSubPublisher
 from osprey.worker.lib.singletons import CONFIG
-from osprey.worker.lib.sources_provider import EtcdSourcesProvider
 from osprey.worker.lib.storage import postgres
 from osprey.worker.lib.storage.bigtable import osprey_bigtable
 from osprey.worker.lib.storage.bulk_label_task import BulkLabelTask
@@ -108,12 +107,6 @@ def tail_kafka_input_sink() -> None:
         print(event)
 
 
-@cli.command()
-@click.option(
-    '--rules-path',
-    type=click.Path(dir_okay=True, file_okay=False, exists=True),
-    help='Which rules to use. If not provided uses the rules in etcd.',
-)
 @click.option('--pooled/--no-pooled', default=True, help='Whether to run multiple sinks simultaneously in a pool.')
 @click.option(
     '--bootstrap-pubsub/--no-bootstrap-pubsub',
@@ -128,7 +121,6 @@ def tail_kafka_input_sink() -> None:
     help='Create base tables',
 )
 def run_rules_sink(
-    rules_path: Optional[str],
     pooled: bool,
     bootstrap_pubsub: bool,
     bootstrap_bigtable: bool,
@@ -140,12 +132,8 @@ def run_rules_sink(
         _bootstrap_bigtable()
 
     config = init_config()
-    sources_provider = get_sources_provider(Path(rules_path) if rules_path is not None else None)
 
-    udf_registry, udf_helpers = bootstrap_udfs()
-    bootstrap_ast_validators()
-
-    engine = OspreyEngine(sources_provider=sources_provider, udf_registry=udf_registry)
+    engine, udf_helpers = bootstrap_engine_with_helpers()
 
     input_stream_source_string = config.get_str('OSPREY_INPUT_STREAM_SOURCE', 'plugin')
     try:
@@ -202,10 +190,8 @@ def _run_rules_worker_process() -> None:
 
     # Sources and Engine
     sources_provider = get_sources_provider(rules_path=None, input_stream_ready_signaler=input_stream_ready_signaler)
-    udf_registry, udf_helpers = bootstrap_udfs()
-    bootstrap_ast_validators()
 
-    engine = OspreyEngine(sources_provider=sources_provider, udf_registry=udf_registry)
+    engine, udf_helpers = bootstrap_engine_with_helpers(sources_provider=sources_provider)
 
     # Output Sink
     output_sink = bootstrap_output_sinks(config)
@@ -274,13 +260,7 @@ def run_bulk_label_sink(pooled: bool, send_status_webhook: bool) -> None:
 
     postgres.init_from_config('osprey_db')
 
-    sources_provider = EtcdSourcesProvider(
-        etcd_key=config.get_str('OSPREY_ETCD_SOURCES_PROVIDER_KEY', '/config/osprey/rules-sink-sources')
-    )
-    udf_registry, _ = bootstrap_udfs()
-    bootstrap_ast_validators()
-
-    engine = OspreyEngine(sources_provider, udf_registry)
+    engine = bootstrap_engine()
 
     analytics_pubsub_project_id = config.get_str('PUBSUB_DATA_PROJECT_ID', 'osprey-dev')
     analytics_pubsub_topic_id = config.get_str('PUBSUB_ANALYTICS_EVENT_TOPIC_ID', 'osprey-analytics')
@@ -325,14 +305,9 @@ def rollback_bulk_label_effects(
 ) -> None:
     # TODO: Clean up this copy pasta.
     config = init_config()
-    sources_provider = EtcdSourcesProvider(
-        etcd_key=config.get_str('OSPREY_ETCD_SOURCES_PROVIDER_KEY', '/config/osprey/rules-sink-sources')
-    )
     postgres.init_from_config('osprey_db')
-    udf_registry, _ = bootstrap_udfs()
-    bootstrap_ast_validators()
 
-    engine = OspreyEngine(sources_provider, udf_registry)
+    engine = bootstrap_engine()
 
     analytics_pubsub_project_id = config.get_str('PUBSUB_DATA_PROJECT_ID', 'osprey-dev')
     analytics_pubsub_topic_id = config.get_str('PUBSUB_ANALYTICS_EVENT_TOPIC_ID', 'osprey-analytics')

--- a/osprey_worker/src/osprey/worker/cli/sinks.py
+++ b/osprey_worker/src/osprey/worker/cli/sinks.py
@@ -20,7 +20,8 @@ gevent_config.track_greenlet_tree = False
 import multiprocessing
 import os
 from concurrent.futures import ProcessPoolExecutor
-from typing import Optional, TextIO
+from typing import Optional, Set, TextIO, cast
+
 import click
 import gevent
 import kafka
@@ -35,7 +36,6 @@ configure_logging()
 
 from osprey.worker.lib.bulk_label import TaskStatus
 from osprey.worker.lib.config import Config
-
 from osprey.worker.lib.osprey_engine import bootstrap_engine, bootstrap_engine_with_helpers, get_sources_provider
 from osprey.worker.lib.osprey_shared.logging import get_logger
 from osprey.worker.lib.publisher import PubSubPublisher

--- a/osprey_worker/src/osprey/worker/lib/cli.py
+++ b/osprey_worker/src/osprey/worker/lib/cli.py
@@ -31,11 +31,9 @@ from osprey.rpc.labels.v1.service_pb2 import (  # noqa: E402
     EntityMutation,
     LabelStatus,
 )
-from osprey.worker.adaptor.plugin_manager import bootstrap_ast_validators, bootstrap_udfs  # noqa: E402
-from osprey.worker.lib.osprey_engine import OspreyEngine  # noqa: E402
+from osprey.worker.lib.osprey_engine import bootstrap_engine  # noqa: E402
 from osprey.worker.lib.publisher import PubSubPublisher  # noqa: E402
 from osprey.worker.lib.singletons import CONFIG  # noqa: E402
-from osprey.worker.lib.sources_provider import EtcdSourcesProvider  # noqa: E402
 from osprey.worker.lib.sources_publisher import (  # noqa: E402
     upload_dependencies_mapping,
     validate_and_push,
@@ -273,12 +271,7 @@ def get_event_effects_output_sink() -> EventEffectsOutputSink:
     config.configure_from_env()
 
     postgres.init_from_config('osprey_db')
-    sources_provider = EtcdSourcesProvider(
-        etcd_key=config.get_str('OSPREY_ETCD_SOURCES_PROVIDER_KEY', '/config/osprey/rules-sink-sources')
-    )
-    udf_registery, _ = bootstrap_udfs()
-    bootstrap_ast_validators()
-    engine = OspreyEngine(sources_provider, udf_registery)
+    engine = bootstrap_engine()
     analytics_pubsub_project_id = config.get_str('PUBSUB_DATA_PROJECT_ID', 'osprey-dev')
     analytics_pubsub_topic_id = config.get_str('PUBSUB_ANALYTICS_EVENT_TOPIC_ID', 'osprey-analytics')
     analytics_publisher = PubSubPublisher(analytics_pubsub_project_id, analytics_pubsub_topic_id)

--- a/osprey_worker/src/osprey/worker/lib/osprey_engine.py
+++ b/osprey_worker/src/osprey/worker/lib/osprey_engine.py
@@ -306,7 +306,6 @@ def bootstrap_engine_with_helpers(
 ) -> Tuple[OspreyEngine, UDFHelpers]:
     # Avoid circular imports
     from osprey.worker.adaptor.plugin_manager import bootstrap_ast_validators, bootstrap_udfs
-    from osprey.worker.lib.data_exporters.validation_result_exporter import get_validation_result_exporter
 
     udf_registry, udf_helpers = bootstrap_udfs()
     bootstrap_ast_validators()
@@ -323,7 +322,6 @@ def bootstrap_engine_with_helpers(
             sources_provider=sources_provider,
             udf_registry=udf_registry,
             should_yield_during_compilation=should_yield_during_compilation(),
-            validation_exporter=get_validation_result_exporter(),
         ),
         udf_helpers,
     )

--- a/osprey_worker/src/osprey/worker/lib/osprey_engine.py
+++ b/osprey_worker/src/osprey/worker/lib/osprey_engine.py
@@ -2,7 +2,7 @@ import logging
 from dataclasses import dataclass
 from pathlib import Path
 from time import time
-from typing import Callable, Dict, Generic, List, Optional, Set, Type, TypeVar
+from typing import Callable, Dict, Generic, List, Optional, Set, Tuple, Type, TypeVar
 
 import gevent
 import gevent.pool
@@ -299,3 +299,35 @@ def extract_source_snippet(span: Span) -> str:
         start_col = span.start_pos
 
     return '\n'.join(extracted_snippet)
+
+
+def bootstrap_engine_with_helpers(
+    sources_provider: Optional[BaseSourcesProvider] = None,
+) -> Tuple[OspreyEngine, UDFHelpers]:
+    # Avoid circular imports
+    from osprey.worker.adaptor.plugin_manager import bootstrap_ast_validators, bootstrap_udfs
+    from osprey.worker.lib.data_exporters.validation_result_exporter import get_validation_result_exporter
+
+    udf_registry, udf_helpers = bootstrap_udfs()
+    bootstrap_ast_validators()
+
+    if not sources_provider:
+        # Use static rules path if configured, otherwise use etcd
+        config = CONFIG.instance()
+        rules_path_str = config.get_optional_str('OSPREY_RULES_PATH')
+        rules_path = Path(rules_path_str) if rules_path_str else None
+        sources_provider = get_sources_provider(rules_path=rules_path)
+
+    return (
+        OspreyEngine(
+            sources_provider=sources_provider,
+            udf_registry=udf_registry,
+            should_yield_during_compilation=should_yield_during_compilation(),
+            validation_exporter=get_validation_result_exporter(),
+        ),
+        udf_helpers,
+    )
+
+
+def bootstrap_engine(sources_provider: Optional[BaseSourcesProvider] = None) -> OspreyEngine:
+    return bootstrap_engine_with_helpers(sources_provider)[0]

--- a/osprey_worker/src/osprey/worker/lib/singletons.py
+++ b/osprey_worker/src/osprey/worker/lib/singletons.py
@@ -13,32 +13,10 @@ CONFIG: Singleton[Config] = Singleton(Config)
 CONFIG_REGISTRY: Singleton[ConfigRegistry] = Singleton(lambda: get_config_registry().clone())
 
 
-def _init_engine() -> 'OspreyEngine':
-    # Avoid circular imports
-    from pathlib import Path
+def _init_engine():
+    from osprey.worker.lib.osprey_engine import bootstrap_engine
 
-    from osprey.worker.adaptor.plugin_manager import bootstrap_ast_validators, bootstrap_udfs
-    from osprey.worker.lib.data_exporters.validation_result_exporter import get_validation_result_exporter
-    from osprey.worker.lib.osprey_engine import (
-        OspreyEngine,
-        get_sources_provider,
-        should_yield_during_compilation,
-    )
-
-    udf_registry, _ = bootstrap_udfs()
-    bootstrap_ast_validators()
-
-    # Use static rules path if configured, otherwise use etcd
-    config = CONFIG.instance()
-    rules_path_str = config.get_str('OSPREY_RULES_PATH', '')
-    rules_path = Path(rules_path_str) if rules_path_str else None
-
-    return OspreyEngine(
-        sources_provider=get_sources_provider(rules_path=rules_path),
-        udf_registry=udf_registry,
-        should_yield_during_compilation=should_yield_during_compilation(),
-        validation_exporter=get_validation_result_exporter(),
-    )
+    return bootstrap_engine()
 
 
 ENGINE: Singleton['OspreyEngine'] = Singleton(_init_engine)

--- a/osprey_worker/src/osprey/worker/lib/storage/access_audit_log.py
+++ b/osprey_worker/src/osprey/worker/lib/storage/access_audit_log.py
@@ -1,9 +1,7 @@
 import dataclasses
-import datetime
 from typing import Optional
 
 from osprey.engine.utils.types import add_slots
-from osprey.worker.lib.storage.bigtable import osprey_bigtable
 
 
 @add_slots
@@ -25,9 +23,11 @@ class AccessAuditLog:
     response_body: bytes
 
     def persist(self) -> None:
-        row = osprey_bigtable.table('audit_log').row(self.id.to_bytes(8, 'big'))
-        timestamp = datetime.datetime.utcnow()
-        for k in dataclasses.fields(self):
-            v = getattr(self, k.name)
-            row.set_cell('audit_log', k.name.encode(), v.encode() if hasattr(v, 'encode') else v, timestamp=timestamp)
-        osprey_bigtable.table('audit_log').mutate_rows([row])
+        pass
+        # we should move this store to postgres, or some other plugin.
+        # row = osprey_bigtable.table('audit_log').row(self.id.to_bytes(8, 'big'))
+        # timestamp = datetime.datetime.utcnow()
+        # for k in dataclasses.fields(self):
+        #     v = getattr(self, k.name)
+        #     row.set_cell('audit_log', k.name.encode(), v.encode() if hasattr(v, 'encode') else v, timestamp=timestamp)
+        # osprey_bigtable.table('audit_log').mutate_rows([row])

--- a/osprey_worker/src/osprey/worker/lib/tests/test_utils.py
+++ b/osprey_worker/src/osprey/worker/lib/tests/test_utils.py
@@ -5,8 +5,7 @@ from typing import TYPE_CHECKING, Callable, Iterator
 import pytest
 from flask import Flask
 from osprey.engine.ast.sources import Sources
-from osprey.worker.adaptor.plugin_manager import bootstrap_ast_validators, bootstrap_udfs
-from osprey.worker.lib.osprey_engine import OspreyEngine
+from osprey.worker.lib.osprey_engine import bootstrap_engine
 from osprey.worker.lib.singletons import CONFIG, ENGINE
 from osprey.worker.lib.sources_provider import StaticSourcesProvider
 from osprey.worker.lib.sources_publisher import validate_and_push
@@ -86,9 +85,7 @@ def make_app_with_rules_sources_fixture(app_creator: Callable[[], Flask], name: 
         sources = Sources.from_dict(sources_to_use)
         assert validate_and_push(sources, quiet=True, dry_run=True)
         sources_provider = StaticSourcesProvider(sources)
-        udf_registry, _ = bootstrap_udfs()
-        bootstrap_ast_validators()
-        engine = OspreyEngine(sources_provider, udf_registry)
+        engine = bootstrap_engine(sources_provider=sources_provider)
 
         with ENGINE.override_instance_for_test(engine):
             CONFIG.instance().unconfigure_for_tests()


### PR DESCRIPTION
Moves most engine initialization to use `bootstrap_engine()`. This is done to avoid issues with forgetting to bootstrap one or more of the plugin components, and to consolidate a bunch disparate logic.

Some other small changes that went in with this:
- minor druid fixes encountered while testing, including auto offset restarts and default compaction
- removal of the --rules-path on the rules sink, which was a different direction from the other engine invocations which used an env var.
- removal of a BT audit log call
