### PR TITLE
refactor: lazily initialize the bigtable client instance 

### DIFF
--- a/osprey_worker/src/osprey/worker/lib/storage/bigtable.py
+++ b/osprey_worker/src/osprey/worker/lib/storage/bigtable.py
@@ -37,7 +37,7 @@ class BigTableClient(ABC):
 
     @property
     def _instance(self) -> Instance:
-        if not hasattr(self, '__instance'):
+        if not getattr(self, '__instance', None):
             self.__instance = self._setup_client_instance()
         return self.__instance
 


### PR DESCRIPTION
Summary
---

Move BigTable client initialization logic out of the `init_from_config` method and into a dedicated method `_setup_client_instance` so that we can transition the `_instance` property to be a `@property` function that lazily initializes the client.

This fixes the issue where when running in environments (like testing) that don't have GCP credentials setup locally, the application would throw the error:
```
google.auth.exceptions.DefaultCredentialsError:
Your default credentials were not found. To set up Application Default Credentials, see
https://cloud.google.com/docs/authentication/external/set-up-adc for more information.
```

There are no logical changes, with the exception that the client instance is now only initialized when it's needed.