### PR TITLE
fix: engine tests for labels

### DIFF
--- a/osprey_worker/src/osprey/engine/executor/tests/test_render_graph.py
+++ b/osprey_worker/src/osprey/engine/executor/tests/test_render_graph.py
@@ -4,19 +4,15 @@ from typing import Any, Dict, Set
 
 import pytest
 from osprey.engine.ast_validator.validation_context import ValidatedSources
-from osprey.engine.ast_validator.validator_registry import ValidatorRegistry
 from osprey.engine.ast_validator.validators.unique_stored_names import UniqueStoredNames
 from osprey.engine.ast_validator.validators.validate_call_kwargs import ValidateCallKwargs
-from osprey.engine.ast_validator.validators.validate_dynamic_calls_have_annotated_rvalue import (
-    ValidateDynamicCallsHaveAnnotatedRValue,
-)
 from osprey.engine.conftest import RunValidationFunction
 from osprey.engine.executor.execution_graph import ExecutionGraph, compile_execution_graph
 from osprey.engine.executor.execution_visualizer import _render_graph
-from osprey.engine.stdlib import get_config_registry
 
 pytestmark = [
-    pytest.mark.use_validators([ValidateCallKwargs, ValidateDynamicCallsHaveAnnotatedRValue, UniqueStoredNames]),
+    pytest.mark.use_validators([ValidateCallKwargs, UniqueStoredNames]),
+    pytest.mark.use_standard_rules_validators,
     pytest.mark.use_osprey_stdlib,
 ]
 
@@ -147,9 +143,7 @@ def execution_graph(run_validation: RunValidationFunction) -> ExecutionGraph:
     """
     Compiles an ExecutionGraph based on the above Osprey Rules configs
     """
-    config_validator = get_config_registry().get_validator()
-    validator_registry = ValidatorRegistry.get_instance().instance_with_additional_validators(config_validator)
-    validated_sources: ValidatedSources = run_validation(config, validator_registry=validator_registry)
+    validated_sources: ValidatedSources = run_validation(config)
     execution_graph = compile_execution_graph(validated_sources)
     return execution_graph
 

--- a/osprey_worker/src/osprey/engine/query_language/__init__.py
+++ b/osprey_worker/src/osprey/engine/query_language/__init__.py
@@ -3,11 +3,10 @@ from osprey.engine.ast_validator.validation_context import ValidatedSources, Val
 from osprey.engine.ast_validator.validators.unique_stored_names import UniqueStoredNames
 from osprey.engine.ast_validator.validators.validate_static_types import ValidateStaticTypes
 from osprey.engine.ast_validator.validators.variables_must_be_defined import VariablesMustBeDefined
+from osprey.engine.query_language import udfs
+from osprey.engine.query_language.ast_validator import REGISTRY
+from osprey.engine.query_language.udfs.registry import UDF_REGISTRY
 from osprey.engine.utils.imports import import_all_direct_children
-
-from . import udfs
-from .ast_validator import REGISTRY
-from .udfs.registry import UDF_REGISTRY
 
 
 def parse_query_to_validated_ast(query: str, rules_sources: ValidatedSources) -> ValidatedSources:

--- a/osprey_worker/src/osprey/engine/query_language/udfs/did_declare_verdict.py
+++ b/osprey_worker/src/osprey/engine/query_language/udfs/did_declare_verdict.py
@@ -1,11 +1,10 @@
 from typing import Dict
 
+from osprey.engine import shared_constants
 from osprey.engine.ast_validator.validation_context import ValidationContext
+from osprey.engine.query_language.udfs.registry import register
 from osprey.engine.udf.arguments import ArgumentsBase, ConstExpr
 from osprey.engine.udf.base import QueryUdfBase
-
-from ... import shared_constants
-from .registry import register
 
 
 class Arguments(ArgumentsBase):

--- a/osprey_worker/src/osprey/engine/query_language/udfs/regex_match.py
+++ b/osprey_worker/src/osprey/engine/query_language/udfs/regex_match.py
@@ -3,10 +3,9 @@ from typing import Dict
 
 from osprey.engine.ast import grammar
 from osprey.engine.ast_validator.validation_context import ValidationContext
+from osprey.engine.query_language.udfs.registry import register
 from osprey.engine.udf.arguments import ArgumentsBase, ConstExpr
 from osprey.engine.udf.base import QueryUdfBase
-
-from .registry import register
 
 
 class Arguments(ArgumentsBase):

--- a/osprey_worker/src/osprey/engine/stdlib/udfs/tests/test_rules.py
+++ b/osprey_worker/src/osprey/engine/stdlib/udfs/tests/test_rules.py
@@ -13,7 +13,6 @@ from osprey.engine.conftest import (
     RunValidationFunction,
 )
 from osprey.engine.executor.execution_context import (
-    EntityLabelMutation,
     ExecutionContext,
 )
 from osprey.engine.language_types.entities import EntityT
@@ -24,10 +23,8 @@ from osprey.engine.stdlib.udfs.time_delta import TimeDelta
 from osprey.engine.udf.arguments import ArgumentsBase
 from osprey.engine.udf.base import UDFBase
 from osprey.engine.udf.registry import UDFRegistry
-from osprey.rpc.labels.v1.service_pb2 import LabelStatus
+from osprey.worker.lib.osprey_shared.labels import EntityLabelMutation, LabelStatus
 from osprey.worker.sinks.sink.output_sink import _get_label_effects_from_result
-
-# Moved here because WhenRules is not included in the MVP yet
 
 
 class FailingUdf(UDFBase[ArgumentsBase, bool]):

--- a/osprey_worker/src/osprey/engine/udf/registry.py
+++ b/osprey_worker/src/osprey/engine/udf/registry.py
@@ -21,8 +21,12 @@ class UDFRegistry:
         return instance
 
     def register(self, func: Type[UDFBase[Any, Any]]) -> Type[UDFBase[Any, Any]]:
-        if func.__name__ in self._functions:
-            raise Exception(f'A function with the name {func.__name__} is already registered.')
+        # Allow idempotent re-registration of the exact same class.
+        existing = self.get(func.__name__)
+        if existing is not None:
+            if existing is func:
+                return existing
+            raise Exception(f'A function with the name {func.__name__} is already registered with {func}.')
 
         try:
             rvalue_type = func.get_rvalue_type()

--- a/osprey_worker/src/osprey/worker/_stdlibplugin/udf_register.py
+++ b/osprey_worker/src/osprey/worker/_stdlibplugin/udf_register.py
@@ -15,6 +15,7 @@ from osprey.engine.stdlib.udfs.get_action_name import GetActionName
 from osprey.engine.stdlib.udfs.import_ import Import
 from osprey.engine.stdlib.udfs.ip_network import IpNetwork
 from osprey.engine.stdlib.udfs.json_data import JsonData
+from osprey.engine.stdlib.udfs.labels import HasLabel, LabelAdd, LabelRemove
 from osprey.engine.stdlib.udfs.list_length import ListLength
 from osprey.engine.stdlib.udfs.list_read import ListRead
 from osprey.engine.stdlib.udfs.list_sort import ListSort
@@ -82,9 +83,12 @@ def register_udfs() -> Sequence[Type[UDFBase[Any, Any]]]:
         ExperimentsBucketAssignment,
         ExtractCookie,
         GetActionName,
+        HasLabel,
         Import,
         IpNetwork,
         JsonData,
+        LabelAdd,
+        LabelRemove,
         ListLength,
         ListRead,
         ListSort,


### PR DESCRIPTION
Summary
---

Due to [this commit](https://github.com/roostorg/osprey/commit/5e9e5773dd68ad39a4375f3e50567640d9654d5c) the engine tests were broken for a handful of spots but mostly centering around labels. So I've opened this PR to keep the changes small and digestible. 

- Fixes engine test instability caused by mixed import paths and duplicate UDF registrations.
- Aligns tests with the updated labels API and validator setup.
- Restores standard label UDFs in the `stdlib` registry.