### PR TITLE
fix: add pydantic validator to `EntityT`

### DIFF
--- a/osprey_worker/src/osprey/engine/language_types/entities.py
+++ b/osprey_worker/src/osprey/engine/language_types/entities.py
@@ -42,6 +42,22 @@ class EntityT(OspreyInvariantGeneric[_T], PostExecutionConvertible[_T]):
         # the real type. Assumes that this has no subclasses.
         return typing_inspect.get_args(cls)[0]
 
+    @classmethod
+    def __get_validators__(cls):
+        """Pydantic v1 validator"""
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, v):
+        """Validate and convert to EntityT"""
+        if isinstance(v, cls):
+            return v
+        if isinstance(v, dict):
+            if 'type' in v and 'id' in v:
+                return cls(type=v['type'], id=v['id'])
+            raise TypeError(f'EntityT expects dict with "type" and "id" keys, got {v}')
+        raise TypeError(f'EntityT expected EntityT or dict; got {type(v)}')
+
 
 # Make sure this looks as it's used in the Osprey language when used in error messages.
 EntityT.__name__ = 'Entity'


### PR DESCRIPTION
the prior pr #26 has a bug where `EntityT` is being used in places where pydantic expects to be able to validate the model(s):
```
Traceback (most recent call last):
  File "/osprey/osprey_worker/src/osprey/worker/cli/sinks.py", line 413, in <module>
    cli()
  File "/osprey/.venv/lib/python3.11/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/osprey/.venv/lib/python3.11/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/osprey/.venv/lib/python3.11/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/osprey/.venv/lib/python3.11/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/osprey/.venv/lib/python3.11/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/osprey/osprey_worker/src/osprey/worker/cli/sinks.py", line 137, in run_rules_sink
    engine, udf_helpers = bootstrap_engine_with_helpers()
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/osprey/osprey_worker/src/osprey/worker/lib/osprey_engine.py", line 321, in bootstrap_engine_with_helpers
    OspreyEngine(
  File "/osprey/osprey_worker/src/osprey/worker/lib/osprey_engine.py", line 85, in __init__
    config_registry = get_config_registry()
                      ^^^^^^^^^^^^^^^^^^^^^
  File "/osprey/osprey_worker/src/osprey/worker/lib/sources_config/__init__.py", line 29, in get_config_registry
    import_all_direct_children(subkeys)
  File "/osprey/osprey_worker/src/osprey/engine/utils/imports.py", line 22, in import_all_direct_children
    importlib.import_module(f'{module_name}.{child.stem}')
  File "/usr/local/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "/osprey/.venv/lib/python3.11/site-packages/ddtrace/internal/module.py", line 295, in _exec_module
    self.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/osprey/osprey_worker/src/osprey/worker/lib/sources_config/subkeys/acl_config.py", line 6, in <module>
    from osprey.worker.lib.acls.acls import ACL, DEV_ACL_ASSIGNMENTS_FILE
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "/osprey/.venv/lib/python3.11/site-packages/ddtrace/internal/module.py", line 295, in _exec_module
    self.loader.exec_module(module)
  File "/osprey/osprey_worker/src/osprey/worker/lib/acls/acls.py", line 6, in <module>
    from osprey.worker.ui_api.osprey.lib.abilities import Ability
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "/osprey/.venv/lib/python3.11/site-packages/ddtrace/internal/module.py", line 295, in _exec_module
    self.loader.exec_module(module)
  File "/osprey/osprey_worker/src/osprey/worker/ui_api/osprey/lib/abilities.py", line 10, in <module>
    from osprey.worker.ui_api.osprey.validators.entities import (
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "/osprey/.venv/lib/python3.11/site-packages/ddtrace/internal/module.py", line 295, in _exec_module
    self.loader.exec_module(module)
  File "/osprey/osprey_worker/src/osprey/worker/ui_api/osprey/validators/entities.py", line 22, in <module>
    class GetLabelsForEntityRequest(BaseModel, EntityMarshaller):
  File "/osprey/.venv/lib/python3.11/site-packages/pydantic/main.py", line 197, in __new__
    fields[ann_name] = ModelField.infer(
                       ^^^^^^^^^^^^^^^^^
  File "/osprey/.venv/lib/python3.11/site-packages/pydantic/fields.py", line 504, in infer
    return cls(
           ^^^^
  File "/osprey/.venv/lib/python3.11/site-packages/pydantic/fields.py", line 434, in __init__
    self.prepare()
  File "/osprey/.venv/lib/python3.11/site-packages/pydantic/fields.py", line 550, in prepare
    self._type_analysis()
  File "/osprey/.venv/lib/python3.11/site-packages/pydantic/fields.py", line 753, in _type_analysis
    raise TypeError(f'Fields of type "{origin}" are not supported.')
TypeError: Fields of type "<class 'osprey.engine.language_types.entities.EntityT'>" are not supported.
```
this pr gives the class a pydantic validator