### PR TITLE
use `read_rows` for `select_all` in Bigtable result store

### DIFF
--- a/osprey_worker/src/osprey/worker/lib/storage/stored_execution_result.py
+++ b/osprey_worker/src/osprey/worker/lib/storage/stored_execution_result.py
@@ -210,11 +210,7 @@ class StoredExecutionResultBigTable(ExecutionResultStore):
         for row in rows:
             if not row:
                 continue
-
-            try:
-                results.append(StoredExecutionResultBigTable._execution_result_dict_from_row(row))
-            except Exception as e:
-                logger.error(f'Failed to parse row {row.row_key}: {e}')
+            results.append(StoredExecutionResultBigTable._execution_result_dict_from_row(row))
 
         return results
 

--- a/osprey_worker/src/osprey/worker/lib/storage/stored_execution_result.py
+++ b/osprey_worker/src/osprey/worker/lib/storage/stored_execution_result.py
@@ -11,7 +11,7 @@ import gevent
 import google.cloud.storage as storage
 import pytz
 from google.api_core import retry
-from google.cloud.bigtable import row_filters
+from google.cloud.bigtable import row_filters, row_set
 from google.cloud.bigtable.row import Row
 from minio import Minio
 from minio.error import S3Error
@@ -193,11 +193,30 @@ class StoredExecutionResultBigTable(ExecutionResultStore):
     # TODO: Add `select_*_minimal` methods
 
     def select_many(self, action_ids: List[int]) -> List[Dict[str, Any]]:
-        return [
-            row
-            for row in gevent.pool.Pool(BIGTABLE_CONCURRENCY_LIMIT).imap(self.select_one, action_ids)
-            if row is not None
-        ]
+        if not action_ids:
+            return []
+
+        row_set_obj = row_set.RowSet()
+        for action_id in action_ids:
+            row_set_obj.add_row_key(StoredExecutionResultBigTable._encode_action_id(action_id))
+
+        rows = osprey_bigtable.table('stored_execution_result').read_rows(
+            row_set=row_set,
+            filter_=row_filters.CellsColumnLimitFilter(1),
+            retry=self.retry_policy,
+        )
+
+        results: List[Dict[str, Any]] = []
+        for row in rows:
+            if not row:
+                continue
+
+            try:
+                results.append(StoredExecutionResultBigTable._execution_result_dict_from_row(row))
+            except Exception as e:
+                logger.error(f'Failed to parse row {row.row_key}: {e}')
+
+        return results
 
     def insert(
         self,


### PR DESCRIPTION
this fixes the second Bigtable woe that I was running into gevent timeouts with. if i were to run a query that returned just a few action IDs (e.g. < 5 or so), things would work fine. but as soon as there was a large enough query to create enough requests, i'd start getting timeouts. in any case, this seems to be the better way of handling this anyway.

appears to be the same behavior that you'd get from the current implementation.