### PR TITLE
ui: fix event stream card empty/no features height

### DIFF
--- a/osprey_ui/src/components/event_stream/EventStream.tsx
+++ b/osprey_ui/src/components/event_stream/EventStream.tsx
@@ -28,6 +28,7 @@ const QUERY_ROW_LIMIT = 100;
 const HEADER_HEIGHT = 44;
 const ADDITIONAL_PADDING = 4;
 const ROW_HEIGHT = 44;
+const EMPTY_ROW_HEIGHT = 116;
 const NUM_COLUMNS = 3;
 
 const calculateCardHeight = (currentHeight: number, featureBlock: readonly string[], item: OspreyEvent) => {
@@ -159,6 +160,10 @@ const EventStream: React.FC = () => {
       customSummaryFeatures == null
         ? getSummaryFeatures(eventStream[index].extracted_features.ActionName)
         : [customSummaryFeatures];
+
+    if (!features.length) {
+      return EMPTY_ROW_HEIGHT;
+    }
 
     return features.reduce(
       (height: number, featureBlock: readonly string[]) =>


### PR DESCRIPTION
the virtualized list needs pre-calculated row heights before rendering, but the current logic for calcing that height doesn't gives us a good value if there are no default features selected for an event/the data for selected features doesn't exist.

## Before

<img width="1119" height="534" alt="old" src="https://github.com/user-attachments/assets/9a56dd26-d6a0-4c9b-934a-2c4bc53709f6" />

## After

<img width="1124" height="639" alt="new" src="https://github.com/user-attachments/assets/08f82458-079e-4c4c-9ff2-424db4443371" />
