### PR TITLE
ci: setup integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,41 @@
+name: Integration Tests
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: [main]
+
+jobs:
+  integration-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Make run-tests.sh executable
+        run: chmod +x run-tests.sh
+
+      - name: Create temp directory for test results
+        run: mkdir -p /tmp/test-results
+
+      - name: Run integration tests
+        run: ./run-tests.sh --junitxml=/tmp/test-results/junit-pytest.xml
+
+      - name: Clean up Docker containers
+        if: always()
+        run: docker compose -f docker-compose.yaml -f docker-compose.test.yaml --profile test down --volumes
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: pytest-results
+          path: /tmp/test-results/junit-pytest.xml
+          retention-days: 30

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Make run-tests.sh executable
         run: chmod +x run-tests.sh
 
+      - name: Pull and build Docker images
+        run: docker compose -f docker-compose.yaml -f docker-compose.test.yaml --profile test build --pull
+
       - name: Create temp directory for test results
         run: mkdir -p /tmp/test-results
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -23,9 +23,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Make run-tests.sh executable
-        run: chmod +x run-tests.sh
-
       - name: Create temp directory for test results
         run: mkdir -p /tmp/test-results
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -34,10 +34,6 @@ jobs:
       - name: Run integration tests
         run: ./run-tests.sh --junitxml=/tmp/test-results/junit-pytest.xml
 
-      - name: Clean up Docker containers
-        if: always()
-        run: docker compose -f docker-compose.yaml -f docker-compose.test.yaml --profile test down --volumes
-
       - name: Upload test results
         uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -26,7 +26,9 @@ jobs:
         run: mkdir -p /tmp/test-results
 
       - name: Pull and build Docker images
-        run: docker compose -f docker-compose.yaml -f docker-compose.test.yaml --profile test build --pull
+        run: |
+          docker compose -f docker-compose.yaml -f docker-compose.test.yaml --profile test pull
+          docker compose -f docker-compose.yaml -f docker-compose.test.yaml --profile test build
 
       - name: Run integration tests
         run: ./run-tests.sh --junitxml=/tmp/test-results/junit-pytest.xml

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -22,11 +22,11 @@ jobs:
       - name: Make run-tests.sh executable
         run: chmod +x run-tests.sh
 
-      - name: Pull and build Docker images
-        run: docker compose -f docker-compose.yaml -f docker-compose.test.yaml --profile test build --pull
-
       - name: Create temp directory for test results
         run: mkdir -p /tmp/test-results
+
+      - name: Pull and build Docker images
+        run: docker compose -f docker-compose.yaml -f docker-compose.test.yaml --profile test build --pull
 
       - name: Run integration tests
         run: ./run-tests.sh --junitxml=/tmp/test-results/junit-pytest.xml

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   integration-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -7,6 +7,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   integration-tests:
     runs-on: ubuntu-latest

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -3,6 +3,7 @@
 
 services:
   postgres:
+    ports: !reset []
     volumes: !reset []
 
   minio:

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -95,5 +95,5 @@ services:
       - ./osprey_rpc:/osprey/osprey_rpc
       - ./example_rules:/osprey/example_rules
       - ./entrypoint.sh:/osprey/entrypoint.sh
-    # entrypoint: "uv run pytest"
+      - /tmp/test-results:/tmp/test-results
     command: ["run-tests"]


### PR DESCRIPTION
Summary
---

Re-use the `run-tests.sh` script in a new `integration-tests.yml` workflow.
Both build the docker images and run the tests to help prevent regressions.

**IMPORTANT:** do not merge this PR until all tests are passing, otherwise it will prevent anyone from merging their PRs.