### PR TITLE
ci: update code quality workflow

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -12,16 +12,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: ".python-version"
+
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
           enable-cache: true
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
 
       - name: Install dependencies
         run: uv sync --dev

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -16,20 +16,12 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
+          enable-cache: true
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-
-      - name: Cache uv dependencies
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/uv
-          key: uv-${{ runner.os }}-${{ hashFiles('**/pyproject.toml', '**/uv.lock') }}
-          restore-keys: |
-            uv-${{ runner.os }}-
-            uv-
 
       - name: Install dependencies
         run: uv sync --dev

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   python-quality:
     runs-on: ubuntu-latest

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -35,10 +35,6 @@ jobs:
       - name: Run mypy type checking
         run: uv run mypy .
 
-      - name: Run tests
-        run: uv run pytest
-        continue-on-error: true # Remove once the tests are working
-
   ui-quality:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
           enable-cache: true

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   python-quality:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Summary
---

While testing out CI for integration tests I discovered that we were never caching the uv dependencies.

This fixes the caching based on official docs:
- https://github.com/astral-sh/setup-uv
- https://docs.astral.sh/uv/guides/integration/github/#setting-up-python

Additionally I've also updated the python setup step to get the python version from `.python-version` file, so that we remove a duplicate bit of code here.

Setup a concurrency group, so that any new pushes will cancel the old CI run to reduce runtime cost.

Removed the test step here since it's being handled in a separate workflow.

Pinned the CI runner image from `ubuntu-latest` to `ubuntu-24.04` to prevent possibly breaks when a new image is released.