### PR TITLE
cli: small tweaks to get `push-rules` working

### DIFF
--- a/osprey_worker/pyproject.toml
+++ b/osprey_worker/pyproject.toml
@@ -8,5 +8,7 @@ dependencies = [
     "flask-cors>=6.0.1",
     "osprey_rpc",
 ]
+[project.scripts]
+osprey-cli = "osprey.worker.lib.cli:cli"
 [project.entry-points."osprey_plugin"]
 stdlib = "osprey.worker._stdlibplugin"

--- a/osprey_worker/src/osprey/worker/lib/cli.py
+++ b/osprey_worker/src/osprey/worker/lib/cli.py
@@ -30,7 +30,7 @@ from osprey.worker.lib.storage import (  # noqa: E402
     labels,
     stored_execution_result,
 )
-from osprey.worker.lib.utils.click_utils import EnumChoicePb2  # noqa: E402
+from osprey.worker.lib.utils.click_utils import EnumChoice  # noqa: E402
 
 
 @click.group()
@@ -204,7 +204,7 @@ def get_lines_from_file_as_set(file_path: str) -> Set[str]:
 @click.argument('entity_type')
 @click.argument('entity_id')
 @click.argument('label_name')
-@click.argument('label_status', type=EnumChoicePb2(LabelStatus))
+@click.argument('label_status', type=EnumChoice(LabelStatus))
 @click.option(
     '--reason',
     help=(
@@ -267,7 +267,7 @@ def apply_label(
 @click.argument('entity_type')
 @click.argument('entity_ids_file_path')
 @click.argument('label_name')
-@click.argument('label_status', type=EnumChoicePb2(LabelStatus))
+@click.argument('label_status', type=EnumChoice(LabelStatus))
 @click.option(
     '--reason',
     help=(

--- a/osprey_worker/src/osprey/worker/lib/sources_publisher.py
+++ b/osprey_worker/src/osprey/worker/lib/sources_publisher.py
@@ -52,11 +52,13 @@ def validate_and_push(
 
     Returns False if rules failed validation, True otherwise.
     """
+    # bootstrap validators before instance_with_additional_validators copies the validator registry
+    udf_registry, _ = bootstrap_udfs()
+    bootstrap_ast_validators()
+
     lib_validator_registry = ValidatorRegistry.instance_with_additional_validators(
         get_config_registry().get_validator()
     )
-    udf_registry, _ = bootstrap_udfs()
-    bootstrap_ast_validators()
 
     try:
         validated_sources = validate_sources(
@@ -102,11 +104,13 @@ def upload_dependencies_mapping(
     suppress_warnings: bool = False,
 ) -> bool:
     """Create a mapping of Osprey Rules/UDFs/variables to their dependencies and upload to BigQuery."""
+    # bootstrap validators before instance_with_additional_validators copies the validator registry
+    udf_registry, _ = bootstrap_udfs()
+    bootstrap_ast_validators()
+
     lib_validator_registry = ValidatorRegistry.instance_with_additional_validators(
         get_config_registry().get_validator()
     )
-    udf_registry, _ = bootstrap_udfs()
-    bootstrap_ast_validators()
 
     try:
         validated_sources = validate_sources(

--- a/osprey_worker/src/osprey/worker/lib/utils/click_utils.py
+++ b/osprey_worker/src/osprey/worker/lib/utils/click_utils.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Dict, Generic, Optional, Type, TypeVar, Union
+from typing import Dict, Generic, Optional, Type, TypeVar, Union
 
 import click
 from click import Context, Parameter
@@ -34,48 +34,6 @@ class EnumChoice(click.Choice, Generic[T]):
         # This is to support when click is given a default that is a variant. If we have a value that is our variant,
         # we can just return it without trying to coerce.
         if isinstance(value, self.enum):
-            return value
-
-        assert isinstance(value, str)
-        try:
-            return self.choice_map[_to_kebab_case(value)]
-        except KeyError:
-            self.fail('invalid choice: %s. (choose from %s)' % (value, ', '.join(self.choices)), param, ctx)
-
-        return None
-
-
-class EnumChoicePb2(click.Choice):
-    """For use with `@click.option(...)` in order to support for choosing a single value of a protobuf enum.
-
-    Example usage:
-    ```
-    from some_pb2 import SomeEnum
-
-    @click.option('--choice', type=EnumChoicePb2(SomeEnum), default=SomeEnum.SOME_VALUE)
-    def func(choice):
-        click.echo(f"Your choice was: {choice}")
-    ```
-    """
-
-    choice_map: Dict[str, int]
-    enum_class: Any
-
-    def __init__(self, enum_class: Any):
-        self.enum_class = enum_class
-        # Build choice map from enum descriptor
-        self.choice_map = {}
-
-        # Get the enum descriptor and build choices from value names
-        for value_descriptor in enum_class.DESCRIPTOR.values:
-            kebab_name = _to_kebab_case(value_descriptor.name)
-            self.choice_map[kebab_name] = value_descriptor.number
-
-        super().__init__(choices=list(self.choice_map.keys()))
-
-    def convert(self, value: Union[str, int], param: Optional[Parameter], ctx: Optional[Context]) -> Optional[int]:
-        # If we already have an int (protobuf enum value), return it
-        if isinstance(value, int):
             return value
 
         assert isinstance(value, str)


### PR DESCRIPTION
Trying to get CI tests and etcd rule pushing working, ran into a couple of problems/quirks.

- No clear way to run any of the commands inside of `cli.py` (might actually want to add this to `entrypoint.sh` too? :woman_shrugging:)
- When running `cli.py`, being yelled at about a missing `DESCRIPTOR` attribute because of using `EnumChoicePb2`
- Not bootstrapping AST validators before copying the validator registry that gets passed to `validate_sources`

Cleaning up all of those here. Not 100% sure why the decision for `EnumChoicePb2` was there, so that in particularly might need to get changed back/tweaked

Can test these changes by running `uv run osprey-cli push-rules example_rules/ --dry-run` after pulling this branch.

Also eventually worth documenting that you can do rules validation locally like this, cc @julietshen (or...whoever is going to write docs... :sweat_smile:)