### PR TITLE
fix more label tests

### DIFF
--- a/osprey_worker/src/osprey/worker/lib/osprey_shared/labels.py
+++ b/osprey_worker/src/osprey/worker/lib/osprey_shared/labels.py
@@ -32,6 +32,10 @@ class MutationDropReason(IntEnum):
     CONFLICTING_MUTATION = 0
     # If the existing label status was manual and the attempted mutation was not
     CANNOT_OVERRIDE_MANUAL = 1
+    # if the label name was an empty string
+    INVALID_LABEL_NAME = 2
+    # if the entity id was an empty string
+    INVALID_ENTITY_ID = 3
 
 
 class LabelStatus(IntEnum):

--- a/osprey_worker/src/osprey/worker/lib/storage/tests/test_bulk_action_task.py
+++ b/osprey_worker/src/osprey/worker/lib/storage/tests/test_bulk_action_task.py
@@ -26,6 +26,8 @@ def sqlalchemy_session() -> Iterator[Session]:
         yield session
 
 
+# TODO: Stop skipping these tests once bulk action capability is supported
+@pytest.mark.skip(reason='Bulk actions are not yet supported')
 def test_create_job(sqlalchemy_session):
     user_id = '123'
     gcs_path = 'gcs://bucket/path'
@@ -59,6 +61,8 @@ def test_create_job(sqlalchemy_session):
     assert job.status == BulkActionJobStatus.PENDING_UPLOAD
 
 
+# TODO: Stop skipping these tests once bulk action capability is supported
+@pytest.mark.skip(reason='Bulk actions are not yet supported')
 def test_get_one_bulk_action_job(sqlalchemy_session):
     job = BulkActionJob.create_job(
         job_id=generate_snowflake().to_int(),
@@ -77,6 +81,8 @@ def test_get_one_bulk_action_job(sqlalchemy_session):
     assert result == job
 
 
+# TODO: Stop skipping these tests once bulk action capability is supported
+@pytest.mark.skip(reason='Bulk actions are not yet supported')
 def test_create_bulk_action_task(sqlalchemy_session):
     job = BulkActionJob.create_job(
         job_id=generate_snowflake().to_int(),
@@ -112,6 +118,8 @@ def test_create_bulk_action_task(sqlalchemy_session):
     assert task.created_at is not None
 
 
+# TODO: Stop skipping these tests once bulk action capability is supported
+@pytest.mark.skip(reason='Bulk actions are not yet supported')
 def test_create_bulk_action_task_persists_to_db(sqlalchemy_session):
     job = BulkActionJob.create_job(
         job_id=generate_snowflake().to_int(),
@@ -146,6 +154,8 @@ def test_create_bulk_action_task_persists_to_db(sqlalchemy_session):
     assert persisted_task.status == BulkActionTaskStatus.PENDING
 
 
+# TODO: Stop skipping these tests once bulk action capability is supported
+@pytest.mark.skip(reason='Bulk actions are not yet supported')
 def test_get_one_task(sqlalchemy_session):
     job = BulkActionJob.create_job(
         job_id=generate_snowflake().to_int(),
@@ -173,12 +183,16 @@ def test_get_one_task(sqlalchemy_session):
     assert result.chunk_number == task.chunk_number
 
 
+# TODO: Stop skipping these tests once bulk action capability is supported
+@pytest.mark.skip(reason='Bulk actions are not yet supported')
 def test_get_one_task_not_found(sqlalchemy_session):
     result = BulkActionTask.get_one(999999)
 
     assert result is None
 
 
+# TODO: Stop skipping these tests once bulk action capability is supported
+@pytest.mark.skip(reason='Bulk actions are not yet supported')
 def test_get_all_by_job_id(sqlalchemy_session):
     job = BulkActionJob.create_job(
         job_id=generate_snowflake().to_int(),
@@ -216,6 +230,8 @@ def test_get_all_by_job_id(sqlalchemy_session):
     assert {task.chunk_number for task in result} == {1, 2, 3}
 
 
+# TODO: Stop skipping these tests once bulk action capability is supported
+@pytest.mark.skip(reason='Bulk actions are not yet supported')
 def test_update_task(sqlalchemy_session):
     job = BulkActionJob.create_job(
         job_id=generate_snowflake().to_int(),
@@ -248,6 +264,8 @@ def test_update_task(sqlalchemy_session):
     assert persisted_task.error == 'test error'
 
 
+# TODO: Stop skipping these tests once bulk action capability is supported
+@pytest.mark.skip(reason='Bulk actions are not yet supported')
 def test_get_next_pending_task(sqlalchemy_session):
     job = BulkActionJob.create_job(
         job_id=generate_snowflake().to_int(),
@@ -272,6 +290,8 @@ def test_get_next_pending_task(sqlalchemy_session):
     assert next_task.status == BulkActionTaskStatus.PENDING
 
 
+# TODO: Stop skipping these tests once bulk action capability is supported
+@pytest.mark.skip(reason='Bulk actions are not yet supported')
 def test_get_next_pending_task_no_pending_tasks(sqlalchemy_session):
     job = BulkActionJob.create_job(
         job_id=generate_snowflake().to_int(),
@@ -292,6 +312,8 @@ def test_get_next_pending_task_no_pending_tasks(sqlalchemy_session):
     assert next_task is None
 
 
+# TODO: Stop skipping these tests once bulk action capability is supported
+@pytest.mark.skip(reason='Bulk actions are not yet supported')
 def test_get_next_pending_task_different_jobs(sqlalchemy_session):
     job1 = BulkActionJob.create_job(
         job_id=generate_snowflake().to_int(),

--- a/osprey_worker/src/osprey/worker/lib/storage/tests/test_bulk_label_task.py
+++ b/osprey_worker/src/osprey/worker/lib/storage/tests/test_bulk_label_task.py
@@ -52,16 +52,22 @@ def enqueue() -> BulkLabelTask:
     return task
 
 
+# TODO: Stop skipping these tests once bulk label capability is supported
+@pytest.mark.skip(reason='Bulk labelling is not yet supported')
 def test_claim__empty() -> None:
     assert BulkLabelTask.claim() is None
 
 
+# TODO: Stop skipping these tests once bulk label capability is supported
+@pytest.mark.skip(reason='Bulk labelling is not yet supported')
 def test_enqueue() -> None:
     task = enqueue()
     db_task = _query_get_one(task.id)
     assert db_task.id == task.id
 
 
+# TODO: Stop skipping these tests once bulk label capability is supported
+@pytest.mark.skip(reason='Bulk labelling is not yet supported')
 def test_claim__one() -> None:
     task = enqueue()
     claimed = BulkLabelTask.claim()
@@ -70,6 +76,8 @@ def test_claim__one() -> None:
     assert claimed.attempts == 1
 
 
+# TODO: Stop skipping these tests once bulk label capability is supported
+@pytest.mark.skip(reason='Bulk labelling is not yet supported')
 def test_claim__many() -> None:
     first = enqueue()
     second = enqueue()
@@ -81,6 +89,8 @@ def test_claim__many() -> None:
     assert second_claimed.id == second.id
 
 
+# TODO: Stop skipping these tests once bulk label capability is supported
+@pytest.mark.skip(reason='Bulk labelling is not yet supported')
 def test_release() -> None:
     enqueue()
     task = BulkLabelTask.claim()
@@ -94,6 +104,8 @@ def test_release() -> None:
     assert updated.updated_at > updated.created_at
 
 
+# TODO: Stop skipping these tests once bulk label capability is supported
+@pytest.mark.skip(reason='Bulk labelling is not yet supported')
 def test_claim_time() -> None:
     enqueue()
     # Get the database time to avoid any future timezone issues
@@ -104,6 +116,8 @@ def test_claim_time() -> None:
     assert task.claim_until >= now + timedelta(seconds=BASE_DELAY_SECONDS)
 
 
+# TODO: Stop skipping these tests once bulk label capability is supported
+@pytest.mark.skip(reason='Bulk labelling is not yet supported')
 def test_get_one() -> None:
     task = enqueue()
     assert task is not None

--- a/osprey_worker/src/osprey/worker/ui_api/osprey/views/tests/test_bulk_history.py
+++ b/osprey_worker/src/osprey/worker/ui_api/osprey/views/tests/test_bulk_history.py
@@ -51,6 +51,8 @@ def test_get_bulk_label_task_missing_ability(app: Flask, client: 'FlaskClient[Re
     assert res.data.decode('utf-8') == "User `local-dev@localhost` doesn't have ability `CAN_BULK_LABEL`"
 
 
+# TODO: Stop skipping these tests once bulk label capability is supported
+@pytest.mark.skip(reason='Bulk labelling is not yet supported')
 @pytest.mark.use_rules_sources(config_b)
 @patch.object(BulkLabelTask, 'get_one')
 def test_get_bulk_label_task(

--- a/osprey_worker/src/osprey/worker/ui_api/osprey/views/tests/test_entities.py
+++ b/osprey_worker/src/osprey/worker/ui_api/osprey/views/tests/test_entities.py
@@ -1,10 +1,15 @@
 import json
+from unittest import mock
 
 import pytest
 from flask import Flask, Response, url_for
 from flask.testing import FlaskClient
 from osprey.worker.lib.osprey_shared.labels import LabelStatus
+from osprey.worker.lib.singleton import Singleton
+from osprey.worker.lib.singletons import LABELS_PROVIDER
 from osprey.worker.lib.snowflake import generate_snowflake
+from osprey.worker.lib.storage.labels import LabelsProvider
+from osprey.worker.lib.storage.tests.test_labels import MockLabelsService
 
 config = {
     'main.sml': '',
@@ -25,6 +30,16 @@ config = {
 }
 
 
+def _mocked_init_labels_provider() -> LabelsProvider:
+    return LabelsProvider(MockLabelsService())
+
+
+MOCK_LABELS_PROVIDER = Singleton(_mocked_init_labels_provider)
+
+
+# @mock.patch('osprey.worker.lib.singletons.LABELS_PROVIDER', new_callable=_mocked_init_labels_provider, spec_set=True)
+# @mock.patch('osprey.worker.adaptor.plugin_manager.bootstrap_labels_provider', new_callable=_mocked_init_labels_provider)
+@mock.patch.object(LABELS_PROVIDER, 'instance', new=_mocked_init_labels_provider)
 @pytest.mark.use_rules_sources(config)
 def test_mutate_entity_labels(app: Flask, client: 'FlaskClient[Response]') -> None:
     res = client.post(
@@ -39,7 +54,8 @@ def test_mutate_entity_labels(app: Flask, client: 'FlaskClient[Response]') -> No
         content_type='application/json',
     )
     assert res.status_code == 200, res.data
-    assert res.json['mutation_result'] == {'added': [], 'dropped': [], 'removed': ['test_label'], 'unchanged': []}
+    print(res.json)
+    assert res.json['mutation_result'] == {'added': [], 'unchanged': [], 'removed': ['test_label'], 'updated': []}
     label = res.json['labels']['test_label']
     reason = label['reasons']['_ManuallyUpdated']
     assert reason['description'] == 'Manual update by {AdminEmail}: {Reason}'
@@ -47,6 +63,7 @@ def test_mutate_entity_labels(app: Flask, client: 'FlaskClient[Response]') -> No
     assert label['status'] == LabelStatus.MANUALLY_REMOVED
 
 
+@mock.patch.object(LABELS_PROVIDER, 'instance', new=_mocked_init_labels_provider)
 @pytest.mark.use_rules_sources(config)
 def test_mutate_entity_labels_empty_entity_str(app: Flask, client: 'FlaskClient[Response]') -> None:
     res = client.post(
@@ -58,7 +75,7 @@ def test_mutate_entity_labels_empty_entity_str(app: Flask, client: 'FlaskClient[
     )
 
     assert res.status_code == 200, res.data
-    assert res.json['mutation_result'] == {'added': [], 'dropped': [], 'removed': [], 'unchanged': ['test_label']}
+    assert res.json['mutation_result'] == {'added': [], 'updated': [], 'removed': [], 'unchanged': ['test_label']}
 
 
 def test_mutate_entity_labels_auth_reject(app: Flask, client: 'FlaskClient[Response]') -> None:


### PR DESCRIPTION
this time, `test_entities.py` was broken; seems i missed it via #44, and it actually revealed a small ui api bug, so yay for tests!
(i also took the liberty of adding pytest skips to bulk action and bulk label task tests, since we do not yet support this)