### PR TITLE
fix contribution guideline link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ Welcome to the Osprey documentation! This folder contains important information 
 New to the project? We recommend reading the documentation in this order:
 
 1. **[Code of Conduct](CODE_OF_CONDUCT.md)** - Understand our community standards
-2. **[Contributing Guidelines](CONTRIBUTING.md)** - Learn how to contribute
+2. **[Contributing Guidelines](https://github.com/roostorg/.github/blob/main/CONTRIBUTING.md)** - Learn how to contribute
 3. **[Development Guide](DEVELOPMENT.md)** - Set up your development environment and get started using Osprey
 4. **[Osprey UI](UI.md)** - Understand how to use and navigate the UI
 


### PR DESCRIPTION
fixed the link to go to https://github.com/roostorg/.github/blob/main/CONTRIBUTING.md