### PR TITLE
Fix osprey coordinator compilation

### DIFF
--- a/osprey_coordinator/Cargo.toml
+++ b/osprey_coordinator/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "smite_coordinator"
+name = "osprey_coordinator"
 version = "0.1.0"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -20,7 +20,7 @@ convert_case = "0.6.0"
 dynamic-pool = "0.2.2"
 env_logger = "0.7"
 etcd = { git = "https://github.com/discord/rust-etcd", rev = "e3fc8242de7303582feca89d90230e89e744d06e" }
-etcd_config_derive = { path = "etcd_config_derive", package = "smite_coordinator_etcd_config_derive" }
+etcd_config_derive = { path = "etcd_config_derive", package = "osprey_coordinator_etcd_config_derive" }
 futures = "0.3"
 fxhash = "0.2"
 goauth = "0.10.0"
@@ -35,7 +35,7 @@ indexmap = "1.9"
 lazy_static = "1.4.0"
 log = "0.4"
 md5 = "0.7.0"
-metrics_derive = { path = "metrics_derive", package = "smite_coordinator_metrics_derive" }
+metrics_derive = { path = "metrics_derive", package = "osprey_coordinator_metrics_derive" }
 msgpack_simple = "1.0.2"
 num_cpus = "1.0"
 opentelemetry = "0.23"
@@ -56,7 +56,6 @@ sentry = "0.31.8"
 serde = { version = "1.0", features = ["rc", "derive"] }
 serde-transcode = "1.1.1"
 serde_json = "1.0"
-smite_data_services_common = { path = "../common" }
 smpl_jwt = "0.6.0"
 strum_macros = "0.24"
 thiserror = "2.0.12"
@@ -87,5 +86,5 @@ tonic-build = "0.11"
 [dev-dependencies]
 
 [[bin]]
-name = "smite_coordinator"
+name = "osprey_coordinator"
 path = "src/main.rs"

--- a/osprey_coordinator/build.rs
+++ b/osprey_coordinator/build.rs
@@ -1,13 +1,13 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let proto_root = std::path::Path::new("../../proto");
-    let includes = vec!["../../proto/"];
+    let proto_root = std::path::Path::new("../proto");
+    let includes = vec!["../proto/"];
 
     let proto_paths = [
-        proto_root.join("proto/osprey/rpc/actions/v1/action.proto"),
-        proto_root.join("proto/osprey/rpc/smite_coordinator/sync_action/v1/service.proto"),
+        proto_root.join("osprey/rpc/actions/v1/action.proto"),
+        proto_root.join("osprey/rpc/osprey_coordinator/sync_action/v1/service.proto"),
         proto_root
-            .join("proto/osprey/rpc/smite_coordinator/bidirectional_stream/v1/service.proto"),
-        proto_root.join("proto/osprey/rpc/common/v1/*.proto"),
+            .join("osprey/rpc/osprey_coordinator/bidirectional_stream/v1/service.proto"),
+        proto_root.join("osprey/rpc/common/v1/*.proto"),
     ]
     .into_iter()
     .map(|pattern| glob::glob(pattern.to_str().unwrap()))
@@ -37,27 +37,27 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Compile Google Cloud protos for inlined gcloud module
     tonic_build::configure().build_server(false).compile(
         &[
-            proto_root.join("proto/google/api/annotations.proto"),
-            proto_root.join("proto/google/api/client.proto"),
-            proto_root.join("proto/google/api/field_behavior.proto"),
-            proto_root.join("proto/google/api/http.proto"),
-            proto_root.join("proto/google/api/resource.proto"),
-            proto_root.join("proto/google/iam/v1/iam_policy.proto"),
-            proto_root.join("proto/google/iam/v1/options.proto"),
-            proto_root.join("proto/google/iam/v1/policy.proto"),
-            proto_root.join("proto/google/longrunning/operations.proto"),
-            proto_root.join("proto/google/rpc/status.proto"),
-            proto_root.join("proto/google/type/expr.proto"),
-            proto_root.join("proto/google/pubsub/v1/pubsub.proto"),
-            proto_root.join("proto/google/cloud/kms/v1/service.proto"),
-            proto_root.join("proto/google/cloud/kms/v1/resources.proto"),
-            proto_root.join("proto/google/crypto/tink/aes_gcm.proto"),
+            proto_root.join("google/api/annotations.proto"),
+            proto_root.join("google/api/client.proto"),
+            proto_root.join("google/api/field_behavior.proto"),
+            proto_root.join("google/api/http.proto"),
+            proto_root.join("google/api/resource.proto"),
+            proto_root.join("google/iam/v1/iam_policy.proto"),
+            proto_root.join("google/iam/v1/options.proto"),
+            proto_root.join("google/iam/v1/policy.proto"),
+            proto_root.join("google/longrunning/operations.proto"),
+            proto_root.join("google/rpc/status.proto"),
+            proto_root.join("google/type/expr.proto"),
+            proto_root.join("google/pubsub/v1/pubsub.proto"),
+            proto_root.join("google/cloud/kms/v1/service.proto"),
+            proto_root.join("google/cloud/kms/v1/resources.proto"),
+            proto_root.join("google/crypto/tink/aes_gcm.proto"),
         ],
         &[proto_root],
     )?;
 
     tonic_build::configure().compile(
-        &[proto_root.join("proto/etcd_watcherd/v1/etcd_watcherd.proto")],
+        &[proto_root.join("etcd_watcherd/v1/etcd_watcherd.proto")],
         &[proto_root],
     )?;
 

--- a/osprey_coordinator/etcd_config_derive/Cargo.toml
+++ b/osprey_coordinator/etcd_config_derive/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "smite_coordinator_etcd_config_derive"
+name = "osprey_coordinator_etcd_config_derive"
 version = "0.1.0"
 edition = "2021"
 

--- a/osprey_coordinator/metrics_derive/Cargo.toml
+++ b/osprey_coordinator/metrics_derive/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "smite_coordinator_metrics_derive"
+name = "osprey_coordinator_metrics_derive"
 version = "0.1.0"
 authors = ["osprey"]
 edition = "2021"

--- a/osprey_coordinator/src/coordinator_metrics.rs
+++ b/osprey_coordinator/src/coordinator_metrics.rs
@@ -1,6 +1,6 @@
 use crate::metrics::define_metrics;
 
-define_metrics!(SmiteCoordinatorMetrics, [
+define_metrics!(OspreyCoordinatorMetrics, [
     // How long an action has been processed by a worker for before it is acked/nacked
     action_outstanding_duration => StaticHistogram(),
     // How long an action has been held in the async queue for before it is sent to a worker
@@ -13,7 +13,7 @@ define_metrics!(SmiteCoordinatorMetrics, [
     priority_queue_size_async => StaticGauge("priority_queue_size",["type" => "async"]),
 
     // How many receivers are open for the priority queue
-    // can be used as a proxy for number of connections open from the smite worker
+    // can be used as a proxy for number of connections open from the osprey worker
     priority_queue_receiver_count_sync => StaticGauge("priority_queue_receiver_count",["type" => "sync"]),
     priority_queue_receiver_count_async => StaticGauge("priority_queue_receiver_count",["type" => "async"]),
 

--- a/osprey_coordinator/src/priority_queue.rs
+++ b/osprey_coordinator/src/priority_queue.rs
@@ -5,7 +5,7 @@ use tokio::{
     time::{interval, Duration, Instant, MissedTickBehavior},
 };
 
-use crate::{coordinator_metrics::SmiteCoordinatorMetrics, proto};
+use crate::{coordinator_metrics::OspreyCoordinatorMetrics, proto};
 
 use crate::tokio_utils::AbortOnDrop;
 use std::{cell::Cell, sync::Arc};
@@ -26,7 +26,7 @@ impl From<proto::ack_or_nack::AckOrNack> for AckOrNack {
 }
 
 pub struct AckableAction {
-    pub action: proto::SmiteCoordinatorAction,
+    pub action: proto::OspreyCoordinatorAction,
     acking_oneshot_sender: oneshot::Sender<AckOrNack>,
     local_retry_count: Cell<u32>,
     pub created_at: Instant,
@@ -34,7 +34,7 @@ pub struct AckableAction {
 
 impl AckableAction {
     pub fn new(
-        action: proto::SmiteCoordinatorAction,
+        action: proto::OspreyCoordinatorAction,
     ) -> (
         AckableAction,
         oneshot::Receiver<crate::priority_queue::AckOrNack>,
@@ -49,7 +49,7 @@ impl AckableAction {
         (ackable_action, acking_oneshot_receiver)
     }
 
-    pub fn into_action(self) -> (proto::SmiteCoordinatorAction, ActionAcker) {
+    pub fn into_action(self) -> (proto::OspreyCoordinatorAction, ActionAcker) {
         (
             self.action,
             ActionAcker {
@@ -167,7 +167,7 @@ impl PriorityQueueReceiver {
     }
     pub async fn recv(
         &self,
-        metrics: Arc<SmiteCoordinatorMetrics>,
+        metrics: Arc<OspreyCoordinatorMetrics>,
     ) -> Result<AckableAction, async_channel::RecvError> {
         loop {
             let result = tokio::select! {
@@ -223,7 +223,7 @@ pub fn create_ackable_action_priority_queue() -> (PriorityQueueSender, PriorityQ
 
 pub fn spawn_priority_queue_metrics_worker(
     queue_sender: PriorityQueueSender,
-    metrics: Arc<SmiteCoordinatorMetrics>,
+    metrics: Arc<OspreyCoordinatorMetrics>,
 ) -> AbortOnDrop<()> {
     let mut interval = interval(Duration::from_millis(100));
     interval.set_missed_tick_behavior(MissedTickBehavior::Skip);

--- a/osprey_coordinator/src/proto/mod.rs
+++ b/osprey_coordinator/src/proto/mod.rs
@@ -1,66 +1,50 @@
 #![allow(unused_imports)]
 
-pub mod discord_smite_rpc {
-    pub mod actions {
-        pub mod v1 {
-            include!(concat!(env!("OUT_DIR"), "/discord_smite_rpc.actions.v1.rs"));
-        }
-    }
-
-    pub mod common {
-        pub mod v1 {
-            include!(concat!(env!("OUT_DIR"), "/discord_smite_rpc.common.v1.rs"));
-        }
-    }
-
-    pub mod labels {
-        pub mod v1 {
-            include!(concat!(env!("OUT_DIR"), "/discord_smite_rpc.labels.v1.rs"));
-        }
-    }
-
-    pub mod smite_coordinator {
-        pub mod bidirectional_stream {
+pub mod osprey {
+    pub mod rpc {
+        pub mod actions {
             pub mod v1 {
-                include!(concat!(
-                    env!("OUT_DIR"),
-                    "/discord_smite_rpc.smite_coordinator.bidirectional_stream.v1.rs"
-                ));
+                include!(concat!(env!("OUT_DIR"), "/osprey.rpc.actions.v1.rs"));
+            }
+        }
+        pub mod common {
+            pub mod v1 {
+                include!(concat!(env!("OUT_DIR"), "/osprey.rpc.common.v1.rs"));
             }
         }
 
-        pub mod sync_action {
+        pub mod labels {
             pub mod v1 {
-                include!(concat!(
-                    env!("OUT_DIR"),
-                    "/discord_smite_rpc.smite_coordinator.sync_action.v1.rs"
-                ));
+                include!(concat!(env!("OUT_DIR"), "/osprey.rpc.labels.v1.rs"));
+            }
+        }
+
+        pub mod osprey_coordinator {
+            pub mod bidirectional_stream {
+                pub mod v1 {
+                    include!(concat!(
+                        env!("OUT_DIR"),
+                        "/osprey.rpc.osprey_coordinator.bidirectional_stream.v1.rs"
+                    ));
+                }
+            }
+
+            pub mod sync_action {
+                pub mod v1 {
+                    include!(concat!(
+                        env!("OUT_DIR"),
+                        "/osprey.rpc.osprey_coordinator.sync_action.v1.rs"
+                    ));
+                }
             }
         }
     }
 }
 
-pub mod discord_protos {
-    pub mod discord_authentication {
-        pub mod v1 {
-            include!(concat!(
-                env!("OUT_DIR"),
-                "/discord_protos.discord_authentication.v1.rs"
-            ));
-        }
-    }
 
-    pub mod users {
-        pub mod v1 {
-            include!(concat!(env!("OUT_DIR"), "/discord_protos.users.v1.rs"));
-        }
-    }
-}
-
-pub use discord_smite_rpc::actions::v1::*;
-pub use discord_smite_rpc::common::v1::*;
-pub use discord_smite_rpc::labels::v1::*;
-pub use discord_smite_rpc::smite_coordinator::bidirectional_stream::v1::*;
-pub use discord_smite_rpc::smite_coordinator::sync_action::v1 as smite_coordinator_sync_action;
-
+pub use osprey::rpc::actions::v1::*;
+pub use osprey::rpc::common::v1::*;
+pub use osprey::rpc::labels::v1::*;
+pub use osprey::rpc::osprey_coordinator::bidirectional_stream::v1::*;
+pub use osprey::rpc::osprey_coordinator::sync_action::v1 as osprey_coordinator_sync_action;
 pub const PB_DESCRIPTOR_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/descriptor.bin"));

--- a/proto/osprey/rpc/actions/v1/action.proto
+++ b/proto/osprey/rpc/actions/v1/action.proto
@@ -1,9 +1,9 @@
 syntax = "proto3";
 
-package discord_smite_rpc.actions.v1;
+package osprey.rpc.actions.v1;
 
-import "discord_protos/discord_authentication/v1/session.proto";
-import "discord_smite_rpc/actions/v1/action_types.proto";
+
+import "osprey/rpc/actions/v1/action_types.proto";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
 
@@ -140,14 +140,12 @@ message BatchMLCluster {
 }
 
 message UserSession {
+  reserved 2, 6, 7;
+
   bytes id_hash = 1;
-  discord_protos.discord_authentication.v1.UserSessionData.Version session_version = 2;
   google.protobuf.Timestamp creation_time = 3;
   google.protobuf.Timestamp expiration_time = 4;
   google.protobuf.Timestamp approx_last_used_time = 5;
-  discord_protos.discord_authentication.v1.UserSessionData.ClientInfo client_info = 6;
-  // Previous client info of the session if a change was detected
-  discord_protos.discord_authentication.v1.UserSessionData.ClientInfo prev_client_info = 7;
   google.protobuf.Timestamp prev_approx_last_used_time = 8;
 }
 

--- a/proto/osprey/rpc/actions/v1/action_types.proto
+++ b/proto/osprey/rpc/actions/v1/action_types.proto
@@ -1,14 +1,14 @@
 syntax = "proto3";
 
-package discord_smite_rpc.actions.v1;
+package osprey.rpc.actions.v1;
 
-import "discord_smite_rpc/actions/v1/application.proto";
-import "discord_smite_rpc/actions/v1/captcha.proto";
-import "discord_smite_rpc/actions/v1/channel.proto";
-import "discord_smite_rpc/actions/v1/guild.proto";
-import "discord_smite_rpc/actions/v1/invite.proto";
-import "discord_smite_rpc/actions/v1/metadata.proto";
-import "discord_smite_rpc/actions/v1/user.proto";
+import "osprey/rpc/actions/v1/application.proto";
+import "osprey/rpc/actions/v1/captcha.proto";
+import "osprey/rpc/actions/v1/channel.proto";
+import "osprey/rpc/actions/v1/guild.proto";
+import "osprey/rpc/actions/v1/invite.proto";
+import "osprey/rpc/actions/v1/metadata.proto";
+import "osprey/rpc/actions/v1/user.proto";
 
 message GuildCreated {
   User user = 1;

--- a/proto/osprey/rpc/actions/v1/application.proto
+++ b/proto/osprey/rpc/actions/v1/application.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
-package discord_smite_rpc.actions.v1;
+package osprey.rpc.actions.v1;
 
-import "discord_smite_rpc/actions/v1/user.proto";
+import "osprey/rpc/actions/v1/user.proto";
 
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";

--- a/proto/osprey/rpc/actions/v1/captcha.proto
+++ b/proto/osprey/rpc/actions/v1/captcha.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package discord_smite_rpc.actions.v1;
+package osprey.rpc.actions.v1;
 
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";

--- a/proto/osprey/rpc/actions/v1/channel.proto
+++ b/proto/osprey/rpc/actions/v1/channel.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package discord_smite_rpc.actions.v1;
+package osprey.rpc.actions.v1;
 
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";

--- a/proto/osprey/rpc/actions/v1/guild.proto
+++ b/proto/osprey/rpc/actions/v1/guild.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package discord_smite_rpc.actions.v1;
+package osprey.rpc.actions.v1;
 
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";

--- a/proto/osprey/rpc/actions/v1/invite.proto
+++ b/proto/osprey/rpc/actions/v1/invite.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package discord_smite_rpc.actions.v1;
+package osprey.rpc.actions.v1;
 
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";

--- a/proto/osprey/rpc/actions/v1/metadata.proto
+++ b/proto/osprey/rpc/actions/v1/metadata.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package discord_smite_rpc.actions.v1;
+package osprey.rpc.actions.v1;
 
 import "google/protobuf/wrappers.proto";
 

--- a/proto/osprey/rpc/actions/v1/user.proto
+++ b/proto/osprey/rpc/actions/v1/user.proto
@@ -1,13 +1,12 @@
 syntax = "proto3";
 
-package discord_smite_rpc.actions.v1;
+package osprey.rpc.actions.v1;
 
-import "discord_protos/users/v1/user.proto";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
 
 message User {
-  reserved 10;
+  reserved 10, 23;
 
   fixed64 id = 1;
   bool mfa_enabled = 2;
@@ -31,5 +30,4 @@ message User {
   google.protobuf.StringValue global_name = 21;
   // Used by guild automation GUILD_JOINED event
   google.protobuf.StringValue hub_email = 22;
-  discord_protos.users.v1.UserAvatarDecoration avatar_decoration_data = 23;
 }

--- a/proto/osprey/rpc/labels/v1/service.proto
+++ b/proto/osprey/rpc/labels/v1/service.proto
@@ -1,0 +1,36 @@
+syntax = "proto3";
+
+package osprey.rpc.labels.v1;
+
+// Mock proto file for deprecated labels functionality
+// These are marked as DEPRECATED in sync_action service
+// and will be removed once labels are replaced with verdicts
+
+message EntityKey {
+  string entity_type = 1;
+  string entity_id = 2;
+}
+
+message Label {
+  string name = 1;
+  int64 version = 2;
+  int64 expires_at = 3;
+}
+
+message Entity {
+  EntityKey key = 1;
+  repeated Label labels = 2;
+}
+
+message GetEntityRequest {
+  string routing_key = 1;
+  EntityKey key = 2;
+}
+
+message GetEntityResponse {
+  Entity entity = 1;
+}
+
+service LabelService {
+  rpc GetEntity(GetEntityRequest) returns (GetEntityResponse);
+}


### PR DESCRIPTION
This does not run yet, but the code can now compile.

- Fixed all the pathings related to the proto files
- Added some missing proto constructs
- Renamed some smite references to osprey

Next steps:
- Remove deprecated Label service related code
- Compiler shows a fair amount of warnings about unused code, remove them would be a nice next step