### PR TITLE
Allow osprey coordinator to change the service name through config

### DIFF
--- a/osprey_worker/src/osprey/worker/cli/sinks.py
+++ b/osprey_worker/src/osprey/worker/cli/sinks.py
@@ -182,8 +182,11 @@ def _run_rules_worker_process() -> None:
 
     # Input Stream
     input_stream_ready_signaler = InputStreamReadySignaler()
+    coordinator_service_name = config.get_str('OSPREY_COORDINATOR_SERVICE_NAME', 'osprey_coordinator')
     input_stream = OspreyCoordinatorInputStream(
-        client_id=f'{uuid1()}', input_stream_ready_signaler=input_stream_ready_signaler
+        client_id=f'{uuid1()}',
+        input_stream_ready_signaler=input_stream_ready_signaler,
+        coordinator_service_name=coordinator_service_name,
     )
     signal.signal(signal.SIGTERM, lambda *args: input_stream.stop())
     signal.signal(signal.SIGINT, lambda *args: input_stream.stop())

--- a/osprey_worker/src/osprey/worker/sinks/input_stream_chooser.py
+++ b/osprey_worker/src/osprey/worker/sinks/input_stream_chooser.py
@@ -43,7 +43,11 @@ def get_rules_sink_input_stream(
         )
 
     elif input_stream_source == InputStreamSource.OSPREY_COORDINATOR:
-        return OspreyCoordinatorInputStream(client_id='meow')
+        coordinator_service_name = config.get_str('OSPREY_COORDINATOR_SERVICE_NAME', 'osprey_coordinator')
+        return OspreyCoordinatorInputStream(
+            client_id='meow',
+            coordinator_service_name=coordinator_service_name,
+        )
 
     elif input_stream_source == InputStreamSource.SYNTHETIC:
         random_actions = []

--- a/osprey_worker/src/osprey/worker/sinks/sink/osprey_coordinator_input_stream.py
+++ b/osprey_worker/src/osprey/worker/sinks/sink/osprey_coordinator_input_stream.py
@@ -187,12 +187,17 @@ class OspreyCoordinatorInputStream(BaseInputStream[BaseAckingContext[OspreyEngin
 
     _STOP_STREAMING_SIGNAL = object()
 
-    def __init__(self, client_id: str, input_stream_ready_signaler: Optional[InputStreamReadySignaler] = None) -> None:
+    def __init__(
+        self,
+        client_id: str,
+        input_stream_ready_signaler: Optional[InputStreamReadySignaler] = None,
+        coordinator_service_name: str = 'osprey_coordinator',
+    ) -> None:
         super().__init__()
 
         self._outgoing_request_queue: Queue[Request] = Queue()
         self._soft_shutdown_signal_received = False
-        self._channel_pool = GrpcConnectionDiscoveryPool('osprey_coordinator')
+        self._channel_pool = GrpcConnectionDiscoveryPool(coordinator_service_name)
         self._client_id = client_id
         self._input_stream_ready_signaler = input_stream_ready_signaler
         self._current_execution_result: Optional[ExecutionResult] = None


### PR DESCRIPTION
Add service name as a config to the coordinator input stream.

There are situations in local testing where we want this configurable so we can have multiple workers pointing to the same coordinator deployment.