### PR TITLE
Osprey coordinator dockerization

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -393,16 +393,28 @@ services:
       - POD_IP=127.0.0.1
       - PUBSUB_EMULATOR_HOST=127.0.0.1:8085
     depends_on:
-      - etcd
-      - snowflake-id-worker
+      etcd:
+        condition: service_healthy
+      snowflake-id-worker:
+        condition: service_started
 
   etcd:
-    image: gcr.io/etcd-development/etcd:v3.5.0
-    container_name: etcd
+    image: quay.io/coreos/etcd:v3.5.15
     ports:
       - "2379:2379"
-    command: >
-      /usr/local/bin/etcd
-      --listen-client-urls http://0.0.0.0:2379
-      --advertise-client-urls http://etcd:2379
-      --enable-v2=true
+    environment:
+      - ETCD_ENABLE_V2=true
+      - ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379
+      - ETCD_ADVERTISE_CLIENT_URLS=http://0.0.0.0:2379
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "etcdctl",
+          "--endpoints=http://localhost:2379",
+          "endpoint",
+          "health",
+        ]
+      interval: 5s
+      timeout: 3s
+      retries: 3

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -377,3 +377,32 @@ services:
       - ./druid/specs:/specs
     command: ["/bin/sh", "/specs/submit-specs.sh"]
     restart: "no"
+
+  osprey_coordinator:
+    container_name: osprey_coordinator
+    build:
+      context: .
+      dockerfile: osprey_coordinator/Dockerfile
+    ports:
+      - "19950:19950"
+      - "19951:19951"
+    environment:
+      - RUST_LOG=info
+      - ETCD_PEERS=http://etcd:2379
+      - SNOWFLAKE_API_ENDPOINT=http://snowflake-id-worker:8088
+      - POD_IP=127.0.0.1
+      - PUBSUB_EMULATOR_HOST=127.0.0.1:8085
+    depends_on:
+      - etcd
+      - snowflake-id-worker
+
+  etcd:
+    image: gcr.io/etcd-development/etcd:v3.5.0
+    container_name: etcd
+    ports:
+      - "2379:2379"
+    command: >
+      /usr/local/bin/etcd
+      --listen-client-urls http://0.0.0.0:2379
+      --advertise-client-urls http://etcd:2379
+      --enable-v2=true

--- a/osprey_coordinator/Dockerfile
+++ b/osprey_coordinator/Dockerfile
@@ -1,0 +1,19 @@
+FROM rust:1.91
+
+RUN apt-get update && apt-get install -y protobuf-compiler
+
+ADD ./proto/ /osprey/proto/
+ADD ./osprey_coordinator/ /osprey/osprey_coordinator/
+
+WORKDIR /osprey/osprey_coordinator
+
+
+RUN rustup show
+RUN rustc --version
+
+RUN cargo build --release
+
+RUN mv /osprey/osprey_coordinator/target/release/osprey_coordinator /osprey_coordinator_bin && \
+    rm -rf /osprey
+
+ENTRYPOINT ["/osprey_coordinator_bin"]


### PR DESCRIPTION
Test:

```
docker compose up osprey_coordinator
```

Coordinator successfully announced it self to `etcd`

<img width="1106" height="295" alt="Screenshot 2025-11-18 at 3 50 45 PM" src="https://github.com/user-attachments/assets/05f71a98-851f-4e53-9ca5-1d7de6b29255" />

<img width="577" height="97" alt="Screenshot 2025-11-18 at 3 51 12 PM" src="https://github.com/user-attachments/assets/b794b3ef-8549-4a74-a327-e93b1fd4b488" />
