### PR TITLE
update submit-specs.sh to use correct host

### DIFF
--- a/druid/specs/submit-specs.sh
+++ b/druid/specs/submit-specs.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 echo "Waiting for Coordinator-Overlord to be ready..."
-while ! curl -f http://coordinator:8081/status >/dev/null 2>&1; do
+while ! curl -f http://druid-coordinator:8081 >/dev/null 2>&1; do
   sleep 5
 done
 echo "Coordinator-Overlord is ready!"
@@ -18,7 +18,7 @@ for spec in /specs/*.json; do
       -H "Content-Type: application/json" \
       -d @"$spec" \
       -v \
-      http://coordinator:8081/druid/indexer/v1/supervisor
+      http://druid-coordinator:8081/druid/indexer/v1/supervisor
 
     echo ""
     echo "========================="


### PR DESCRIPTION
@BinaryFiddler 

Updates `submit-specs.sh` to use the correct Druid coordinator hostname after the docker networking got reworked.