### PR TITLE
[SMITE] fix: restore delay_action_by for label arguments

### DIFF
--- a/osprey_worker/src/osprey/engine/language_types/labels.py
+++ b/osprey_worker/src/osprey/engine/language_types/labels.py
@@ -32,8 +32,8 @@ class LabelEffect(EffectToCustomExtractedFeatureBase[List[str]]):
     expires_after: Optional[timedelta] = None
     """If set, the label effect has a timed expiration, which means that the reason will expire after this time."""
 
-    # delay_action_by: Optional[timedelta] = None
-    # """If set, the propagation of the effect to the upstream (if configured via LabelsService.after_add or LabelsService.after_remove) will be delayed."""
+    delay_action_by: Optional[timedelta] = None
+    """If set, the propagation of the effect to the upstream (if configured via LabelsService.after_add or LabelsService.after_remove) will be delayed."""
 
     dependent_rule: Optional[RuleT] = None
     """If set, the effect will only be applied if the dependent rule evaluates to true."""

--- a/osprey_worker/src/osprey/engine/language_types/labels.py
+++ b/osprey_worker/src/osprey/engine/language_types/labels.py
@@ -33,7 +33,7 @@ class LabelEffect(EffectToCustomExtractedFeatureBase[List[str]]):
     """If set, the label effect has a timed expiration, which means that the reason will expire after this time."""
 
     delay_action_by: Optional[timedelta] = None
-    """If set, the propagation of the effect to the upstream (if configured via LabelsService.after_add or LabelsService.after_remove) will be delayed."""
+    """Osprey can be configured to respond to this duration downstream to delay when a label is applied and/or causes an effect"""
 
     dependent_rule: Optional[RuleT] = None
     """If set, the effect will only be applied if the dependent rule evaluates to true."""

--- a/osprey_worker/src/osprey/engine/stdlib/udfs/labels.py
+++ b/osprey_worker/src/osprey/engine/stdlib/udfs/labels.py
@@ -41,8 +41,9 @@ class LabelArguments(ArgumentsBase):
     #               that a better abstraction would be to have any sort of "external impact" come
     #               from verdicts, which were created to be an output (whereas labels were created
     #               to simply store state, thus making label webhooks a leaky abstraction)
-    # delay_action_by: Optional[TimeDeltaT] = None
-    # """Optional: Delays a label action by a specified `TimeDeltaT` time."""
+    # NOTE(@elijaharita): this is being re-added because removing it breaks backwards compatibility.
+    delay_action_by: Optional[TimeDeltaT] = None
+    """Optional: Delays a label action by a specified `TimeDeltaT` time."""
     apply_if: Optional[RuleT] = None
     """Optional: Conditions that must be met for the label mutation to succeed."""
     expires_after: Optional[TimeDeltaT] = None
@@ -55,7 +56,7 @@ def synthesize_effect(status: LabelStatus, arguments: LabelArguments) -> LabelEf
         status=status,
         name=arguments.label.value,
         expires_after=TimeDeltaT.inner_from_optional(arguments.expires_after),
-        # delay_action_by=TimeDeltaT.inner_from_optional(arguments.delay_action_by),
+        delay_action_by=TimeDeltaT.inner_from_optional(arguments.delay_action_by),
         dependent_rule=arguments.apply_if,
         # NOTE: This is fairly significant, if this call node has an `apply_if` ast, but
         # the resolved apply_if is None, that means that the evaluation of the rule failed.

--- a/osprey_worker/src/osprey/engine/stdlib/udfs/labels.py
+++ b/osprey_worker/src/osprey/engine/stdlib/udfs/labels.py
@@ -43,7 +43,7 @@ class LabelArguments(ArgumentsBase):
     #               to simply store state, thus making label webhooks a leaky abstraction)
     # NOTE(@elijaharita): this is being re-added because removing it breaks backwards compatibility.
     delay_action_by: Optional[TimeDeltaT] = None
-    """Optional: Delays a label action by a specified `TimeDeltaT` time."""
+    """Optional: Delays a label action by a specified `TimeDeltaT` time if Osprey is configured to."""
     apply_if: Optional[RuleT] = None
     """Optional: Conditions that must be met for the label mutation to succeed."""
     expires_after: Optional[TimeDeltaT] = None


### PR DESCRIPTION
This does nothing functionally. But we need this field to be here for backwards compatibility.