### PR TITLE
Try last for hookimpl_osprey

### DIFF
--- a/osprey_worker/src/osprey/worker/_stdlibplugin/storage_register.py
+++ b/osprey_worker/src/osprey/worker/_stdlibplugin/storage_register.py
@@ -1,10 +1,12 @@
+from typing import Optional
+
 from osprey.worker.adaptor.plugin_manager import hookimpl_osprey
 from osprey.worker.lib.config import Config
 from osprey.worker.lib.storage.stored_execution_result import ExecutionResultStore, StoredExecutionResultMinIO
 
 
-@hookimpl_osprey
-def register_execution_result_store(config: Config) -> ExecutionResultStore:
+@hookimpl_osprey(trylast=True)
+def register_execution_result_store(config: Config) -> Optional[ExecutionResultStore]:
     endpoint = config.get_str('OSPREY_MINIO_ENDPOINT', 'minio:9000')
     access_key = config.get_str('OSPREY_MINIO_ACCESS_KEY', 'minioadmin')
     secret_key = config.get_str('OSPREY_MINIO_SECRET_KEY', 'minioadmin123')


### PR DESCRIPTION
## Add `trylast=True` to stdlib execution result store registration

### Summary
Modified the stdlib `register_execution_result_store` hookimpl to use `trylast=True`, making it act as a fallback implementation that downstream users can easily override.

### Changes
- Added `trylast=True` to `@hookimpl_osprey` decorator in `storage_register.py`

### Motivation
The `register_execution_result_store` hookspec uses `firstresult=True`, meaning it returns the first non-None result. Previously, the stdlib MinIO implementation would run at normal priority, requiring downstream users to use `tryfirst=True` to override it.

With `trylast=True`, the stdlib MinIO implementation now runs last, acting as a proper fallback. This allows downstream users to override the execution result store with a simple hookimpl (no `tryfirst=True` needed), making the plugin system more intuitive.

### Example Usage (Downstream)
**Before:**
```python
@hookimpl_osprey(tryfirst=True)  # Required to override stdlib
def register_execution_result_store(config: Config) -> None:
    return None  # Disable MinIO
```

**After:**
```python
@hookimpl_osprey  # Simple, no tryfirst needed
def register_execution_result_store(config: Config) -> None:
    return None  # Disable MinIO
```

### Impact
- No breaking changes for existing plugins
- Downstream plugins can now use simpler hook implementations
- Follows the principle of "stdlib provides sensible defaults that users can easily override"