### PR TITLE
Fix link to labels service example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 This repository is home to one of ROOST’s safety tools, the Osprey rules engine. Osprey is an open-source event stream decisions engine and analysis UI designed to investigate and take automatic action on events and their properties as they happen in real-time. Originally developed internally at [Discord](https://discord.com/) to combat spam, abuse, botting, and scripting across its platform, Osprey has now been open-sourced to help other platforms facing similar challenges.
 
-Osprey is a library for processing actions through human-written rules and outputting verdicts & custom effects back to configurable output sinks. It evaluates events using structured rule logic (SML) that is extendable via user-defined functions (UDFs). Osprey can also track state across events by labelling entities if implementers provide a labels service backend (see [labels_service.py](./example_plugins/src/labels_service.py) for a Postgres-backed labels service example)
+Osprey is a library for processing actions through human-written rules and outputting verdicts & custom effects back to configurable output sinks. It evaluates events using structured rule logic (SML) that is extendable via user-defined functions (UDFs). Osprey can also track state across events by labelling entities if implementers provide a labels service backend (see [labels_service.py](./example_plugins/src/services/labels_service.py) for a Postgres-backed labels service example)
 
 This 'Rules \+ Investigation' tool is able to:
 


### PR DESCRIPTION
Found a moved file typo while reading through the docs.

This, and #92, make me think that the markdown content might benefit from a link linter.  I have had some success with https://github.com/JustinBeckwith/linkinator - but would want to look again to see if there is something ideal from an ergonomics, perhaps-GH-centric, able to traverse PRs, sort of viewpoint.