### PR TITLE
docs: fix outdated file path in development instructions

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -155,7 +155,7 @@ def register_ast_validators() -> None:
 Rules are written in SML, some examples are provided in `example_rules/` with YAML config, the rules are mounted to the worker processes when the containers start via environment variables. ex:
 
 ```bash
-OSPREY_RULES=./example_rules uv run python3.11 osprey_worker/src/osprey/worker/sinks/cli.py run-rules-sink
+OSPREY_RULES=./example_rules uv run python3.11 osprey_worker/src/osprey/worker/cli/sinks.py run-rules-sink
 ```
 
 #### Test Data


### PR DESCRIPTION
Fixed incorrect file path from osprey_worker/src/osprey/worker/sinks/cli.py to the correct osprey_worker/src/osprey/worker/cli/sinks.py in the Rules section of DEVELOPMENT.md.

Fixes #73