### PR TITLE
refactor: migrate Dict and List to native types in config files

### DIFF
--- a/osprey_worker/src/osprey/engine/stdlib/configs/labels_config.py
+++ b/osprey_worker/src/osprey/engine/stdlib/configs/labels_config.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from typing import Dict, List
 
 from pydantic import BaseModel, root_validator
 
@@ -25,7 +24,7 @@ class LabelConnotation(Enum):
 
 
 class LabelInfo(BaseModel):
-    valid_for: List[str] = []
+    valid_for: list[str] = []
     connotation: LabelConnotation = LabelConnotation.NEUTRAL
     description: str = ''
 
@@ -35,10 +34,10 @@ LABELS_CONFIG_SUBKEY = 'labels'
 
 @register_config_subkey(LABELS_CONFIG_SUBKEY)
 class LabelsConfig(BaseModel):
-    labels: Dict[str, LabelInfo]
+    labels: dict[str, LabelInfo]
 
     @root_validator(pre=True)
-    def root_validator(cls, values: object) -> Dict[str, object]:
+    def root_validator(cls, values: object) -> dict[str, object]:
         # Remove old values so we can be backward compatible during the deploy
         # TODO - Remove this once the new config handling is fully deployed
         assert isinstance(values, dict)

--- a/osprey_worker/src/osprey/worker/ui_api/osprey/views/config.py
+++ b/osprey_worker/src/osprey/worker/ui_api/osprey/views/config.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Set
+from typing import Any
 
 import typing_inspect
 from flask import Blueprint
@@ -22,13 +22,13 @@ class UIConfigMerged(UIConfig):
     """Contains everything in the base ui config, as well as additional fields that are relevant
     to configuring the UI"""
 
-    feature_name_to_entity_type_mapping: Dict[str, str]
-    feature_name_to_value_type_mapping: Dict[str, str]
-    label_info_mapping: Dict[str, LabelInfo]
-    known_feature_locations: List[FeatureLocation]
-    known_action_names: Set[str]
+    feature_name_to_entity_type_mapping: dict[str, str]
+    feature_name_to_value_type_mapping: dict[str, str]
+    label_info_mapping: dict[str, LabelInfo]
+    known_feature_locations: list[FeatureLocation]
+    known_action_names: set[str]
     current_user: User
-    rule_info_mapping: Dict[str, str]
+    rule_info_mapping: dict[str, str]
 
 
 _SIMPLE_TYPE_CONVERTIBLE = {str, int, bool, float}
@@ -59,7 +59,7 @@ def _serialize_type_for_ui(t: type) -> str:
     raise AssertionError(f"Don't know how to serialize {to_display_str(t)}")
 
 
-def _get_feature_name_to_value_type_mapping(engine: OspreyEngine) -> Dict[str, str]:
+def _get_feature_name_to_value_type_mapping(engine: OspreyEngine) -> dict[str, str]:
     return {
         name: _serialize_type_for_ui(t)
         for name, t in engine.get_post_execution_feature_name_to_value_type_mapping().items()


### PR DESCRIPTION
Migrated deprecated typing.Dict and typing.List to native dict and list types in labels_config.py and config.py as part of Python 3.9+ modernization effort.

Changes:
- labels_config.py: Removed Dict, List imports; updated 3 type hints
- config.py: Removed Dict, List, Set imports; updated 8 type hints

All type checking (mypy) and linting (ruff) checks pass.

Part of #25