### PR TITLE
Add validator to handle extractable features types

### DIFF
--- a/osprey_worker/src/osprey/engine/ast_validator/validators/tests/test_validate_extractable_feature_types.py
+++ b/osprey_worker/src/osprey/engine/ast_validator/validators/tests/test_validate_extractable_feature_types.py
@@ -1,0 +1,116 @@
+from dataclasses import dataclass
+from typing import Any, Callable, List, Optional
+
+import pytest
+from osprey.engine.ast_validator.validators.unique_stored_names import UniqueStoredNames
+from osprey.engine.ast_validator.validators.validate_extractable_feature_types import (
+    ValidateExtractableFeatureTypes,
+    _is_extractable_type,
+)
+from osprey.engine.conftest import CheckFailureFunction, RunValidationFunction
+from osprey.engine.executor.execution_context import ExecutionContext
+from osprey.engine.language_types.entities import EntityT
+from osprey.engine.udf.arguments import ArgumentsBase
+from osprey.engine.udf.base import UDFBase
+from osprey.engine.udf.registry import UDFRegistry
+
+
+# Custom class type that should not be extractable
+@dataclass
+class CustomResultT:
+    value: str
+
+
+class EmptyArguments(ArgumentsBase):
+    pass
+
+
+class ReturnsCustomType(UDFBase[EmptyArguments, CustomResultT]):
+    """UDF that returns a custom class type."""
+
+    def execute(self, execution_context: ExecutionContext, arguments: EmptyArguments) -> CustomResultT:
+        return CustomResultT(value='test')
+
+
+class ReturnsPrimitive(UDFBase[EmptyArguments, str]):
+    """UDF that returns a primitive type."""
+
+    def execute(self, execution_context: ExecutionContext, arguments: EmptyArguments) -> str:
+        return 'test'
+
+
+class TestIsExtractableType:
+    """Unit tests for the _is_extractable_type function."""
+
+    def test_primitives_are_extractable(self) -> None:
+        assert _is_extractable_type(str) is True
+        assert _is_extractable_type(int) is True
+        assert _is_extractable_type(float) is True
+        assert _is_extractable_type(bool) is True
+        assert _is_extractable_type(type(None)) is True
+
+    def test_optional_primitives_are_extractable(self) -> None:
+        assert _is_extractable_type(Optional[str]) is True
+        assert _is_extractable_type(Optional[int]) is True
+        assert _is_extractable_type(Optional[float]) is True
+        assert _is_extractable_type(Optional[bool]) is True
+
+    def test_list_of_primitives_is_extractable(self) -> None:
+        assert _is_extractable_type(List[str]) is True
+        assert _is_extractable_type(List[int]) is True
+        assert _is_extractable_type(List[float]) is True
+        assert _is_extractable_type(List[bool]) is True
+
+    def test_nested_optionals_and_lists_are_extractable(self) -> None:
+        assert _is_extractable_type(Optional[List[str]]) is True
+        assert _is_extractable_type(List[Optional[int]]) is True
+
+    def test_entity_is_extractable(self) -> None:
+        # EntityT converts to int post-execution
+        assert _is_extractable_type(EntityT[str]) is True
+
+    def test_custom_class_is_not_extractable(self) -> None:
+        assert _is_extractable_type(CustomResultT) is False
+
+    def test_optional_custom_class_is_not_extractable(self) -> None:
+        assert _is_extractable_type(Optional[CustomResultT]) is False
+
+    def test_list_of_custom_class_is_not_extractable(self) -> None:
+        assert _is_extractable_type(List[CustomResultT]) is False
+
+
+# Integration tests using the validator
+pytestmark: List[Callable[[Any], Any]] = [
+    pytest.mark.use_validators([ValidateExtractableFeatureTypes, UniqueStoredNames]),
+    pytest.mark.use_udf_registry(UDFRegistry.with_udfs(ReturnsCustomType, ReturnsPrimitive)),
+]
+
+
+def test_primitive_features_are_allowed(run_validation: RunValidationFunction) -> None:
+    """Primitive types should be allowed as extracted features."""
+    run_validation(
+        """
+        MyString = "hello"
+        MyInt = 123
+        MyFloat = 1.5
+        MyBool = True
+        """
+    )
+
+
+def test_primitive_udf_result_is_allowed(run_validation: RunValidationFunction) -> None:
+    """UDFs returning primitive types should be allowed as extracted features."""
+    run_validation('MyResult = ReturnsPrimitive()')
+
+
+def test_local_variables_with_custom_type_are_allowed(run_validation: RunValidationFunction) -> None:
+    """Local variables (starting with _) are not extracted, so custom types are OK."""
+    run_validation('_LocalResult = ReturnsCustomType()')
+
+
+def test_custom_type_as_extracted_feature_fails(
+    run_validation: RunValidationFunction, check_failure: CheckFailureFunction
+) -> None:
+    """UDFs returning custom types should fail when assigned to extracted features."""
+    with check_failure():
+        run_validation('MyResult = ReturnsCustomType()')

--- a/osprey_worker/src/osprey/engine/ast_validator/validators/tests/test_validate_extractable_feature_types/test_custom_type_as_extracted_feature_fails.txt
+++ b/osprey_worker/src/osprey/engine/ast_validator/validators/tests/test_validate_extractable_feature_types/test_custom_type_as_extracted_feature_fails.txt
@@ -1,0 +1,9 @@
+error: cannot extract feature with type `CustomResultT`
+--> main.sml:1:0
+     |
+   1 | MyResult = ReturnsCustomType()
+     | ^ type `CustomResultT` cannot be serialized for extraction.
+       | Extracted features must be primitive types (str, int, float, bool), Optional[T], List[T], or EntityT.
+       |
+       | To use this value without extraction, prefix the variable name with `_`:
+       |     _MyResult = ...  # local variable, not extracted

--- a/osprey_worker/src/osprey/engine/ast_validator/validators/validate_extractable_feature_types.py
+++ b/osprey_worker/src/osprey/engine/ast_validator/validators/validate_extractable_feature_types.py
@@ -1,0 +1,114 @@
+"""
+Validator to ensure that only serializable types are used as extracted features.
+
+Extracted features are exposed in the UI and stored in BigQuery, so they must be
+types that can be serialized to JSON. This validator prevents custom class types
+(like custom dataclasses, EffectBase, etc.) from being assigned to non-local
+variables that would be extracted.
+
+To use a custom type without extraction, prefix the variable name with `_` to make
+it a local variable:
+    _VC1 = CustomUdf(entity=TestUser)  # OK - not extracted
+    VC1 = CustomUdf(entity=TestUser)   # ERROR - would be extracted
+"""
+
+from typing import TYPE_CHECKING
+
+import typing_inspect
+from osprey.engine.ast import grammar
+from osprey.engine.language_types.entities import EntityT
+from osprey.engine.udf.type_helpers import to_display_str
+
+from ..base_validator import SourceValidator
+from .validate_static_types import ValidateStaticTypes, ValidateStaticTypesResult
+
+if TYPE_CHECKING:
+    from ..validation_context import ValidationContext
+
+
+# Types that are allowed as extracted features
+_PRIMITIVE_TYPES = {str, int, bool, float, type(None)}
+
+
+def _is_extractable_type(t: type) -> bool:
+    """
+    Check if a type can be serialized for extraction.
+
+    Allowed types:
+    - Primitives: str, int, float, bool, NoneType
+    - Optional[T] where T is extractable
+    - List[T] where T is extractable
+    - EntityT[...] (converts to int post-execution)
+    """
+    # Check primitives
+    if t in _PRIMITIVE_TYPES:
+        return True
+
+    # Check EntityT (these convert to int post-execution)
+    origin = typing_inspect.get_origin(t)
+    if origin is EntityT:
+        return True
+
+    # Check Optional[T] (which is Union[T, None] at runtime)
+    if typing_inspect.is_union_type(t):
+        args = typing_inspect.get_args(t)
+        non_none_args = [a for a in args if a is not type(None)]  # noqa: E721
+        # Optional is a Union with exactly one non-None type
+        if len(non_none_args) == 1:
+            return _is_extractable_type(non_none_args[0])
+        # Other Union types are not supported
+        return False
+
+    # Check List[T]
+    if origin is list:
+        args = typing_inspect.get_args(t)
+        if len(args) == 1:
+            return _is_extractable_type(args[0])
+        return False
+
+    # Any other type is not extractable
+    return False
+
+
+class ValidateExtractableFeatureTypes(SourceValidator):
+    """
+    Validates that extracted features have types that can be serialized.
+
+    This prevents custom class types (like custom dataclasses, EffectBase, LabelEffect, etc.)
+    from being assigned to non-local variables, which would cause serialization errors in the UI.
+    """
+
+    def __init__(self, context: 'ValidationContext'):
+        super().__init__(context)
+        # Depend on ValidateStaticTypes to get type information
+        context.validator_depends_on([ValidateStaticTypes])
+        self._static_types_result: ValidateStaticTypesResult = context.get_validator_result(ValidateStaticTypes)
+
+    def validate_source(self, source: grammar.Source) -> None:
+        # Check each feature that will be extracted
+        for name, type_and_span in self._static_types_result.name_type_and_span_cache.items():
+            # Skip if this feature won't be extracted (local variables starting with _)
+            if not type_and_span.should_extract:
+                continue
+
+            # Skip if this feature is from a different source file
+            if type_and_span.span.source != source:
+                continue
+
+            # Check if the type is extractable
+            if not _is_extractable_type(type_and_span.type):
+                type_str = to_display_str(type_and_span.type)
+                # Get a simple name for the type
+                simple_type_name = getattr(type_and_span.type, '__name__', type_str)
+
+                self.context.add_error(
+                    message=f'cannot extract feature with type `{simple_type_name}`',
+                    span=type_and_span.span,
+                    hint=(
+                        f'type `{type_str}` cannot be serialized for extraction.\n'
+                        f'Extracted features must be primitive types (str, int, float, bool), '
+                        f'Optional[T], List[T], or EntityT.\n\n'
+                        f'To use this value without extraction, prefix the variable name with `_`:\n'
+                        f'    _{name} = ...  # local variable, not extracted'
+                    ),
+                )

--- a/osprey_worker/src/osprey/worker/_stdlibplugin/validator_regsiter.py
+++ b/osprey_worker/src/osprey/worker/_stdlibplugin/validator_regsiter.py
@@ -12,6 +12,7 @@ from osprey.engine.ast_validator.validators.validate_dynamic_calls_have_annotate
     ValidateDynamicCallsHaveAnnotatedRValue,
 )
 from osprey.engine.ast_validator.validators.validate_experiments import ValidateExperiments
+from osprey.engine.ast_validator.validators.validate_extractable_feature_types import ValidateExtractableFeatureTypes
 from osprey.engine.ast_validator.validators.validate_labels import ValidateLabels
 from osprey.engine.ast_validator.validators.validate_static_types import ValidateStaticTypes
 from osprey.engine.ast_validator.validators.variables_must_be_defined import VariablesMustBeDefined
@@ -33,4 +34,5 @@ def register_ast_validators() -> Sequence[Type[BaseValidator]]:
         UniqueStoredNames,
         VariablesMustBeDefined,
         ValidateDynamicCallsHaveAnnotatedRValue,
+        ValidateExtractableFeatureTypes,
     ]


### PR DESCRIPTION
UDFs that return a custom type will break the UI's extracted features -> values mapping, so we need a validator that checks that we aren't implementing any rules that return a custom type.