### PR TITLE
chore: fix development docs and startup helper typos

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -162,7 +162,7 @@ OSPREY_RULES=./example_rules uv run python3.11 osprey_worker/src/osprey/worker/c
 
 Generate sample JSON actions:
 ```bash
-docker compose --profile test_data up kafka_test_data_producer -d
+docker compose --profile test_data up kafka-test-data-producer -d
 ```
 
 Produces user login events with timestamps, user IDs, and IP addresses to `osprey.actions_input` topic.

--- a/start.sh
+++ b/start.sh
@@ -55,7 +55,7 @@ if [ "$USE_COORDINATOR" = true ]; then
     echo "Starting Osprey with Coordinator..."
     COMPOSE_FILES="$COMPOSE_FILES -f example_docker_compose/run_osprey_with_coordinator/docker-compose.coordinator.yaml"
 else
-    echo "Starting Osprey without Coordiantor (direct Kafka consumption)..."
+    echo "Starting Osprey without Coordinator (direct Kafka consumption)..."
 fi
 
 # If no compose args provided, default to 'up'


### PR DESCRIPTION
- Correct the example docker-compose service name in `docs/DEVELOPMENT.md` (use `kafka-test-data-producer` instead of `kafka_test_data_producer`).
- Fix typo in `start.sh` ("Coordiantor" -> "Coordinator")