### PR TITLE
[Osprey] Use Default Timeout for StoredExecutionResultOutputSink

### DIFF
--- a/osprey_worker/src/osprey/worker/sinks/sink/stored_execution_result_output_sink.py
+++ b/osprey_worker/src/osprey/worker/sinks/sink/stored_execution_result_output_sink.py
@@ -6,9 +6,6 @@ from osprey.worker.sinks.sink.output_sink import BaseOutputSink
 class StoredExecutionResultOutputSink(BaseOutputSink):
     """An output sink that persists the execution result to an EventRecord."""
 
-    # BigTable writes can take longer than the default 2s, especially on first connection
-    timeout: float = 10.0
-
     def __init__(self):
         self._service = bootstrap_execution_result_storage_service()
 


### PR DESCRIPTION
Use the default timeout for now to match existing behavior