### PR TITLE
Make BT Client a cached instance

### DIFF
--- a/osprey_worker/src/osprey/worker/lib/storage/bigtable.py
+++ b/osprey_worker/src/osprey/worker/lib/storage/bigtable.py
@@ -28,6 +28,7 @@ class BigTableClient(ABC):
     _gcp_project: str
     _instance_id: str
     _admin_enabled: bool
+    _cached_instance: Instance | None = None
 
     def _setup_client_instance(self) -> Instance:
         client = Client(project=self._gcp_project, admin=self._admin_enabled)
@@ -37,9 +38,9 @@ class BigTableClient(ABC):
 
     @property
     def _instance(self) -> Instance:
-        if not getattr(self, '__instance', None):
-            self.__instance = self._setup_client_instance()
-        return self.__instance
+        if self._cached_instance is None:
+            self._cached_instance = self._setup_client_instance()
+        return self._cached_instance
 
     @abstractmethod
     def init_from_config(self, config: Config) -> None: ...


### PR DESCRIPTION

## Bug

**Python name mangling issue** in lines 38-42:

```python
@property
def _instance(self) -> Instance:
    if not getattr(self, '__instance', None):  # ❌ Looking for '__instance'
        self.__instance = self._setup_client_instance()  # Stores as '_BigTableClient__instance'
    return self.__instance
```

- `self.__instance` gets mangled to `self._BigTableClient__instance` by Python
- But `getattr(self, '__instance', None)` looks for the literal `__instance` which never exists
- **Result**: New BigTable client created on EVERY property access
- Since `insert()` accesses `_instance` twice (via `.table()`), that's **2 new connections per write**

## Fix

```python
_cached_instance: Instance | None = None

@property
def _instance(self) -> Instance:
    if self._cached_instance is None:
        self._cached_instance = self._setup_client_instance()
    return self._cached_instance
```

Uses a properly named class attribute that doesn't trigger name mangling.


