### PR TITLE
chore: clarify maintainers in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,8 @@
 # CODEOWNERS file for managing repository permissions
-# Format: path-pattern @username @team-name
+# Format: path-pattern @username @org/team-name
 
-# Default owners for all files - team OR any individual can approve
-* @roostorg/roosters @EXBreder @ayubun @haileyok @jaredmiller13 @BinaryFiddler @cmttt
+# Maintainers: Default owners for all files
+* @EXBreder @haileyok @vinaysrao1
+
+# Docs contributors
+docs/ @roostorg/roosters


### PR DESCRIPTION
Following up on the [discussion from our last working group meeting](https://github.com/roostorg/osprey/discussions/104#discussioncomment-15458782). We had basically all contributors as codeowners for convenience, but we'd like to more clearly define the project [maintainers](https://roostorg.github.io/community/roles.html#maintainers).

If this causes too much of a bottleneck for approving stuff needed in production from Discord folks, I'm open to suggestions!