### PR TITLE
renamed kafka to osprey-kafka

### DIFF
--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -43,9 +43,9 @@ services:
       context: .
       dockerfile: osprey_worker/Dockerfile
     depends_on:
-      kafka:
+      osprey-kafka:
         condition: service_healthy
-      kafka-topic-creator:
+      osprey-kafka-topic-creator:
         condition: service_completed_successfully
       bigtable:
         condition: service_healthy
@@ -67,7 +67,7 @@ services:
       - PYTHONPATH=/osprey
       - OSPREY_INPUT_STREAM_SOURCE=kafka
       - OSPREY_STDOUT_OUTPUT_SINK=True
-      - OSPREY_KAFKA_BOOTSTRAP_SERVERS=["kafka:29092"]
+      - OSPREY_KAFKA_BOOTSTRAP_SERVERS=["osprey-kafka:29092"]
       - OSPREY_KAFKA_INPUT_STREAM_TOPIC=osprey.actions_input
       - OSPREY_KAFKA_INPUT_STREAM_CLIENT_ID=localhost
       - OSPREY_KAFKA_OUTPUT_SINK=True

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,20 +10,20 @@ volumes:
   minio_data: {}
 
 services:
-  kafka:
+  osprey-kafka:
     image: confluentinc/cp-kafka:7.4.0
-    hostname: kafka
-    container_name: kafka
+    hostname: osprey-kafka
+    container_name: osprey-kafka
     ports:
       - "9092:9092"
     environment:
       KAFKA_NODE_ID: 1
       KAFKA_PROCESS_ROLES: "broker,controller"
-      KAFKA_CONTROLLER_QUORUM_VOTERS: "1@kafka:29093"
+      KAFKA_CONTROLLER_QUORUM_VOTERS: "1@osprey-kafka:29093"
       KAFKA_CONTROLLER_LISTENER_NAMES: "CONTROLLER"
       KAFKA_INTER_BROKER_LISTENER_NAME: "INTERNAL"
-      KAFKA_LISTENERS: "INTERNAL://kafka:29092,EXTERNAL://0.0.0.0:9092,CONTROLLER://kafka:29093"
-      KAFKA_ADVERTISED_LISTENERS: "INTERNAL://kafka:29092,EXTERNAL://localhost:9092"
+      KAFKA_LISTENERS: "INTERNAL://osprey-kafka:29092,EXTERNAL://0.0.0.0:9092,CONTROLLER://osprey-kafka:29093"
+      KAFKA_ADVERTISED_LISTENERS: "INTERNAL://osprey-kafka:29092,EXTERNAL://localhost:9092"
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: "INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT,CONTROLLER:PLAINTEXT"
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
@@ -36,7 +36,7 @@ services:
           "CMD",
           "bash",
           "-c",
-          "kafka-topics --bootstrap-server kafka:29092 --list",
+          "kafka-topics --bootstrap-server osprey-kafka:29092 --list",
         ]
       interval: 10s
       timeout: 5s
@@ -71,16 +71,16 @@ services:
       - ./init-minio-bucket.sh:/init-minio-bucket.sh
     restart: "no"
 
-  kafka-topic-creator:
+  osprey-kafka-topic-creator:
     image: confluentinc/cp-kafka:7.4.0
     depends_on:
-      kafka:
+      osprey-kafka:
         condition: service_healthy
     command: >
       bash -c "
-        kafka-topics --bootstrap-server kafka:29092 --create --if-not-exists --topic osprey.actions_input --partitions 3 --replication-factor 1 &&
-        kafka-topics --bootstrap-server kafka:29092 --create --if-not-exists --topic osprey.execution_results --partitions 3 --replication-factor 1 &&
-        kafka-topics --bootstrap-server kafka:29092 --list
+        kafka-topics --bootstrap-server osprey-kafka:29092 --create --if-not-exists --topic osprey.actions_input --partitions 3 --replication-factor 1 &&
+        kafka-topics --bootstrap-server osprey-kafka:29092 --create --if-not-exists --topic osprey.execution_results --partitions 3 --replication-factor 1 &&
+        kafka-topics --bootstrap-server osprey-kafka:29092 --list
       "
 
   osprey-worker:
@@ -90,9 +90,9 @@ services:
       context: .
       dockerfile: osprey_worker/Dockerfile
     depends_on:
-      kafka:
+      osprey-kafka:
         condition: service_healthy
-      kafka-topic-creator:
+      osprey-kafka-topic-creator:
         condition: service_completed_successfully
       bigtable:
         condition: service_healthy
@@ -111,7 +111,7 @@ services:
       - POSTGRES_HOSTS={"osprey_db":"postgresql://osprey:FoolishPassword@postgres:5432/osprey"}
       - OSPREY_INPUT_STREAM_SOURCE=kafka
       - OSPREY_STDOUT_OUTPUT_SINK=True
-      - OSPREY_KAFKA_BOOTSTRAP_SERVERS=["kafka:29092"]
+      - OSPREY_KAFKA_BOOTSTRAP_SERVERS=["osprey-kafka:29092"]
       - OSPREY_KAFKA_INPUT_STREAM_TOPIC=osprey.actions_input
       # Client ID will default to the machine hostname if it isn't defined
       - OSPREY_KAFKA_INPUT_STREAM_CLIENT_ID=localhost
@@ -229,22 +229,22 @@ services:
     command: ["/bin/bash", "/init-bigtable.sh"]
 
   # Optional test data generator - run with:
-  # docker compose --profile test_data up kafka-test-data-producer -d
-  kafka-test-data-producer:
+  # docker compose --profile test_data up osprey-kafka-test-data-producer -d
+  osprey-kafka-test-data-producer:
     image: confluentinc/cp-kafka:7.4.0
-    hostname: kafka-test-data-producer
-    container_name: kafka-test-data-producer
+    hostname: osprey-kafka-test-data-producer
+    container_name: osprey-kafka-test-data-producer
     depends_on:
-      kafka:
+      osprey-kafka:
         condition: service_healthy
-      kafka-topic-creator:
+      osprey-kafka-topic-creator:
         condition: service_completed_successfully
     profiles:
       - test_data
       - test-data
     environment:
       KAFKA_TOPIC: "osprey.actions_input"
-      KAFKA_BROKER: "kafka:29092"
+      KAFKA_BROKER: "osprey-kafka:29092"
     volumes:
       - ./example_data:/osprey/example_data
     entrypoint:

--- a/example_docker_compose/run_osprey_with_coordinator/docker-compose.coordinator.yaml
+++ b/example_docker_compose/run_osprey_with_coordinator/docker-compose.coordinator.yaml
@@ -6,9 +6,9 @@ services:
   # Override worker to connect to coordinator instead of Kafka directly
   osprey-worker:
     depends_on:
-      kafka:
+      osprey-kafka:
         condition: service_healthy
-      kafka-topic-creator:
+      osprey-kafka-topic-creator:
         condition: service_completed_successfully
       bigtable:
         condition: service_healthy
@@ -47,7 +47,7 @@ services:
       - OSPREY_COORDINATOR_BIDI_STREAM_PORT=19950
       - OSPREY_COORDINATOR_SYNC_ACTION_PORT=19951
       - POD_IP=osprey-coordinator
-      - OSPREY_KAFKA_BOOTSTRAP_SERVERS=kafka:29092
+      - OSPREY_KAFKA_BOOTSTRAP_SERVERS=osprey-kafka:29092
       - OSPREY_KAFKA_INPUT_STREAM_TOPIC=osprey.actions_input
       - OSPREY_KAFKA_GROUP_ID=osprey_coordinator_group
       - MAX_TIME_TO_SEND_TO_ASYNC_QUEUE_MS=500
@@ -57,9 +57,9 @@ services:
         condition: service_healthy
       snowflake-id-worker:
         condition: service_started
-      kafka:
+      osprey-kafka:
         condition: service_healthy
-      kafka-topic-creator:
+      osprey-kafka-topic-creator:
         condition: service_completed_successfully
 
   # Add etcd service (required by coordinator)


### PR DESCRIPTION
Fixes https://github.com/roostorg/osprey/issues/114

this makes it easier to run multiple projects that use kafka 