### PR TITLE
explicitly bind to localhost in docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,13 @@ _ROOST (Robust Open Online Safety Tools), a non-profit organization that brings 
 
    alternatively, you can start Osprey with `osprey-coordinator`, refer to the [Coordinator README](./example_docker_compose/run_osprey_with_coordinator/README.md) for more information
 
-6. (Optional) **Port Forward the UI/UI API:**
+6. (Optional) **Open ports for the UI/UI API:**
 
-   If you are running the docker compose on a headless machine, you will need to port forward the UI and UI API.
-   Namely, ports `5002` (UI) and `5004` (UI API). Then, you can connect via http://localhost:5002/ :D
+   By default, the `docker-compose.yaml` binds running services to `127.0.0.1`. If you are running the docker compose on a headless machine, you may need to modify this configuration and/or make changes to your firewall, specifically for ports `5002` and `5004`.
 
+   For example, if you use Tailscale to access your Osprey instance, you may change `127.0.0.1:5002:5002` to `<Tailscale IP>:5002:5002`. Alternatively, if you wish for your instance to be accessible from the public internet, you may set it simply to `5002:5002` to bind to `0.0.0.0`.
+
+   Be aware that some firewalls like iptables/UFW do _not_ prevent access to ports being used by Docker networking. Not explicitly setting a bind address with only UFW as a firewall will not prevent access from the public internet unless [properly configured](https://github.com/chaifeng/ufw-docker).
 
 ### Development Workflow
 

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -13,7 +13,7 @@ services:
     container_name: etcd
     image: quay.io/coreos/etcd:v3.4.18
     ports:
-      - "2379:2379"
+      - "127.0.0.1:2379:2379"
     environment:
       - ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379
       - ETCD_ADVERTISE_CLIENT_URLS=http://etcd:2379

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
     hostname: osprey-kafka
     container_name: osprey-kafka
     ports:
-      - "9092:9092"
+      - "127.0.0.1:9092:9092"
     environment:
       KAFKA_NODE_ID: 1
       KAFKA_PROCESS_ROLES: "broker,controller"
@@ -47,8 +47,8 @@ services:
     container_name: minio
     hostname: minio
     ports:
-      - "9000:9000" # minio API
-      - "9001:9001" # minio Console
+      - "127.0.0.1:9000:9000" # minio API
+      - "127.0.0.1:9001:9001" # minio Console
     environment:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minioadmin123
@@ -103,7 +103,7 @@ services:
       minio-bucket-init:
         condition: service_completed_successfully
     ports:
-      - "5001:5000"
+      - "127.0.0.1:5001:5000"
     command: ["osprey-worker"]
     environment:
       - PYTHONPATH=/osprey
@@ -149,7 +149,7 @@ services:
       - bigtable
       - bigtable-initializer
     ports:
-      - "5004:5004"
+      - "127.0.0.1:5004:5004"
     command: ["osprey-ui-api"]
     environment:
       - PYTHONPATH=/osprey
@@ -180,7 +180,7 @@ services:
     depends_on:
       - osprey-ui-api
     ports:
-      - "5002:5002"
+      - "127.0.0.1:5002:5002"
     environment:
       - NODE_ENV=development
       - REACT_APP_API_BASE_URL=http://localhost:5004
@@ -193,7 +193,7 @@ services:
     container_name: snowflake-id-worker
     image: ghcr.io/ayubun/snowflake-id-worker:0
     ports:
-      - "8088:8088"
+      - "127.0.0.1:8088:8088"
     environment:
       - WORKER_ID=0
       - DATA_CENTER_ID=0
@@ -206,7 +206,7 @@ services:
     container_name: bigtable
     image: gcr.io/google.com/cloudsdktool/cloud-sdk:latest
     ports:
-      - "8361:8361"
+      - "127.0.0.1:8361:8361"
     command: >
       bash -c "
         gcloud beta emulators bigtable start --host-port=0.0.0.0:8361 --project=osprey-dev
@@ -256,7 +256,7 @@ services:
     container_name: postgres
     image: postgres:18
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     volumes:
       - metadata_data:/var/lib/postgresql
     environment:
@@ -277,7 +277,7 @@ services:
     container_name: druid-zookeeper
     image: zookeeper:3.5.10
     ports:
-      - "2181:2181"
+      - "127.0.0.1:2181:2181"
     environment:
       - ZOO_MY_ID=1
 
@@ -292,7 +292,7 @@ services:
       - druid-zookeeper
       - postgres
     ports:
-      - "8081:8081"
+      - "127.0.0.1:8081:8081"
     command:
       - coordinator
     env_file:
@@ -309,7 +309,7 @@ services:
       - postgres
       - druid-coordinator
     ports:
-      - "8082:8082"
+      - "127.0.0.1:8082:8082"
     command:
       - broker
     env_file:
@@ -327,7 +327,7 @@ services:
       - postgres
       - druid-coordinator
     ports:
-      - "8083:8083"
+      - "127.0.0.1:8083:8083"
     command:
       - historical
     env_file:
@@ -345,8 +345,8 @@ services:
       - postgres
       - druid-coordinator
     ports:
-      - "8091:8091"
-      - "8100-8105:8100-8105"
+      - "127.0.0.1:8091:8091"
+      - "127.0.0.1:8100-8105:8100-8105"
     command:
       - middleManager
     env_file:
@@ -363,7 +363,7 @@ services:
       - postgres
       - druid-coordinator
     ports:
-      - "8888:8888"
+      - "127.0.0.1:8888:8888"
     command:
       - router
     env_file:


### PR DESCRIPTION
As discussed [here](https://discord.com/channels/1267513495554097295/1417533394262294650/1453159129622380546), we should be explicitly binding to `127.0.0.1` to avoid letting any of the services be accessible from outside the machine. Docker networking rules punch through other existing iptables rules, so it's easy to inadvertently be exposing your postgres etc. There are [solutions](https://github.com/chaifeng/ufw-docker), though a lot of people do not know about this footgun and instead find out in worse ways...