### PR TITLE
docs: Correct mdbook build command in CI

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -37,11 +37,11 @@ jobs:
         id: pages
         uses: actions/configure-pages@v5
       - name: Build with mdBook
-        run: mdbook build docs
+        run: mdbook build
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./docs/book
+          path: ./book
 
   # Deployment job
   deploy:


### PR DESCRIPTION
Fixes this CI failure when building docs: https://github.com/roostorg/osprey/actions/runs/21372228782/job/61519476619#step:5:10