### PR TITLE
Add error_on_empty parameter to HasLabel UDF

### DIFF
--- a/osprey_worker/src/osprey/engine/stdlib/udfs/labels.py
+++ b/osprey_worker/src/osprey/engine/stdlib/udfs/labels.py
@@ -137,6 +137,10 @@ class HasLabelArguments(ArgumentsBase):
     WARNING: Only use this for safety-critical rules where a false negative (due to labels
     service returning empty data on failure) could cause dangerous rule evaluations, such as
     incorrectly allowing a known-bad entity through. Do not use this for general label checks.
+
+    This parameter should only be used when the entity type is guaranteed to have at least one
+    label in the labels service. If the entity type is not guaranteed to have labels, the rule
+    should add a dummy/sentinel label to the entity before calling HasLabel with error_on_empty=True.
     """
 
 

--- a/osprey_worker/src/osprey/engine/stdlib/udfs/labels.py
+++ b/osprey_worker/src/osprey/engine/stdlib/udfs/labels.py
@@ -134,8 +134,7 @@ class HasLabelArguments(ArgumentsBase):
     error_on_empty: bool = False
     """Optional: If True, raise EmptyEntityError when the entity has no labels at all.
 
-    WARNING: Only use this on entity types that are GUARANTEED to always have at least one
-    label. This is intended for safety-critical rules where a false negative (due to labels
+    WARNING: Only use this for safety-critical rules where a false negative (due to labels
     service returning empty data on failure) could cause dangerous rule evaluations, such as
     incorrectly allowing a known-bad entity through. Do not use this for general label checks.
     """

--- a/osprey_worker/src/osprey/engine/stdlib/udfs/tests/test_labels.py
+++ b/osprey_worker/src/osprey/engine/stdlib/udfs/tests/test_labels.py
@@ -603,7 +603,9 @@ def test_error_on_empty_raises_when_entity_has_no_labels(execute_with_result: Ex
 
 def test_error_on_empty_returns_true_when_label_exists(execute: ExecuteFunction) -> None:
     """error_on_empty=True should return True when the entity has labels and the requested label exists."""
-    labels = EntityLabels(labels={'my_label': LabelState(status=LabelStatus.ADDED, reasons=LabelReasons({'TestReason': LabelReason()}))})
+    labels = EntityLabels(
+        labels={'my_label': LabelState(status=LabelStatus.ADDED, reasons=LabelReasons({'TestReason': LabelReason()}))}
+    )
     label_provider = StaticLabelProvider({EntityT('MyEntity', 'my_id'): labels})
 
     data = execute(
@@ -627,7 +629,11 @@ def test_error_on_empty_returns_false_when_label_missing_but_entity_has_other_la
     execute: ExecuteFunction,
 ) -> None:
     """error_on_empty=True should return False when entity has labels but not the requested one."""
-    labels = EntityLabels(labels={'other_label': LabelState(status=LabelStatus.ADDED, reasons=LabelReasons({'TestReason': LabelReason()}))})
+    labels = EntityLabels(
+        labels={
+            'other_label': LabelState(status=LabelStatus.ADDED, reasons=LabelReasons({'TestReason': LabelReason()}))
+        }
+    )
     label_provider = StaticLabelProvider({EntityT('MyEntity', 'my_id'): labels})
 
     data = execute(


### PR DESCRIPTION
## Summary
- Add optional `error_on_empty` parameter (default `False`) to `HasLabel` UDF
- When `True`, raises `EmptyEntityError` if the entity has no labels at all
- Allows fail-closed behavior for safety-critical label checks

## Motivation
When the labels service is degraded and returns empty default responses instead of actual label data, rules that check `not HasLabel(...)` could incorrectly fire. This parameter provides an opt-in mechanism to detect and fail on potential data fetch failures.

## Usage
```python
# Fail-closed: raise EmptyEntityError if entity has zero labels
HasLabel(entity=SomeEntity, label="some_label", error_on_empty=True)
```

## Important: When to use this parameter

**Only use `error_on_empty=True` when ALL of these conditions apply:**

1. A false negative from `HasLabel` could cause **dangerous rule evaluations** (e.g., incorrectly allowing a known-bad entity through safety checks)
2. You are checking `not HasLabel(...)` where empty data would cause the rule to incorrectly fire

**Do NOT use this for:**
- General label checks where empty is a valid state
- Non-safety-critical rules

## Why not return None instead?
`HasLabel` returns `bool`. Returning `None` would change the signature to `Optional[bool]`, requiring all callers to handle the `None` case and risking subtle bugs where `None` gets coerced to `False`. The exception approach explicitly fails the rule execution rather than silently propagating an unknown state.

## Test plan
- [x] Added unit tests for error_on_empty behavior
- [x] All existing label tests pass