### PR TITLE
Fix MXLookup UDF timeout errors

### DIFF
--- a/osprey_worker/src/osprey/engine/stdlib/udfs/mx_lookup.py
+++ b/osprey_worker/src/osprey/engine/stdlib/udfs/mx_lookup.py
@@ -1,11 +1,23 @@
+import gevent
+from dns.exception import Timeout as DNSTimeout
 from dns.resolver import NXDOMAIN, YXDOMAIN, LRUCache, NoAnswer, NoNameservers, Resolver
 from osprey.engine.executor.execution_context import ExpectedUdfException
+from osprey.worker.lib.instruments import metrics
 
 from ._prelude import ArgumentsBase, ExecutionContext, UDFBase
 from .categories import UdfCategories
 
+# Timeout per DNS query attempt (seconds)
+DNS_QUERY_TIMEOUT = 0.5
+# Total time allowed for all retries of a single resolve call
+DNS_QUERY_LIFETIME = 1.0
+# Gevent timeout wrapping the entire execute method (covers both MX + A lookups)
+MXLOOKUP_GEVENT_TIMEOUT = 2.0
+
 resolver = Resolver()
 resolver.cache = LRUCache(max_size=1000)
+resolver.timeout = DNS_QUERY_TIMEOUT
+resolver.lifetime = DNS_QUERY_LIFETIME
 
 
 class Arguments(ArgumentsBase):
@@ -21,11 +33,20 @@ class MXLookup(UDFBase[Arguments, str]):
 
     def execute(self, execution_context: ExecutionContext, arguments: Arguments) -> str:
         try:
-            mx_answer = resolver.resolve(arguments.domain, 'MX', raise_on_no_answer=True)[0]
-            domain = mx_answer.exchange.to_text()
-            a_record_answers = resolver.resolve(domain, 'A', raise_on_no_answer=True)
-        except (NoAnswer, NXDOMAIN, YXDOMAIN, NoNameservers):
+            with gevent.Timeout(MXLOOKUP_GEVENT_TIMEOUT, False):
+                try:
+                    mx_answer = resolver.resolve(arguments.domain, 'MX', raise_on_no_answer=True)[0]
+                    domain = mx_answer.exchange.to_text()
+                    a_record_answers = resolver.resolve(domain, 'A', raise_on_no_answer=True)
+                    metrics.increment('mx_lookup.execute.success')
+                    #  Sort lexicographically to keep the UDF deterministic
+                    return min(answer.to_text() for answer in a_record_answers)
+                except DNSTimeout:
+                    metrics.increment('mx_lookup.execute.dns_timeout')
+                    raise ExpectedUdfException()
+                except (NoAnswer, NXDOMAIN, YXDOMAIN, NoNameservers):
+                    metrics.increment('mx_lookup.execute.no_record')
+                    raise ExpectedUdfException()
+        except gevent.Timeout:
+            metrics.increment('mx_lookup.execute.gevent_timeout')
             raise ExpectedUdfException()
-
-        #  Sort lexicographically to keep the UDF deterministic
-        return min(answer.to_text() for answer in a_record_answers)

--- a/osprey_worker/src/osprey/engine/stdlib/udfs/tests/test_mx_lookup.py
+++ b/osprey_worker/src/osprey/engine/stdlib/udfs/tests/test_mx_lookup.py
@@ -2,8 +2,9 @@ from typing import Any, Callable, List
 from unittest.mock import MagicMock, patch
 
 import pytest
+from dns.exception import Timeout as DNSTimeout
 from osprey.engine.ast_validator.validators.validate_call_kwargs import ValidateCallKwargs
-from osprey.engine.conftest import ExecuteFunction
+from osprey.engine.conftest import CheckFailureFunction, ExecuteFunction
 from osprey.engine.stdlib.udfs.mx_lookup import MXLookup
 from osprey.engine.udf.registry import UDFRegistry
 
@@ -27,3 +28,12 @@ def test_golden_path_mx_lookup(execute: ExecuteFunction) -> None:
     with patch(MXLookup.__module__ + '.resolver.resolve', side_effect=fake_resolve):
         result = execute('IP = MXLookup(domain="example.com")')
         assert result == {'IP': '123.456.789'}
+
+
+def test_mx_lookup_dns_timeout(execute: ExecuteFunction, check_failure: CheckFailureFunction) -> None:
+    def timeout_resolve(domain: str, record_type: str, raise_on_no_answer: bool) -> List[Any]:
+        raise DNSTimeout()
+
+    with check_failure():
+        with patch(MXLookup.__module__ + '.resolver.resolve', side_effect=timeout_resolve):
+            execute('IP = MXLookup(domain="slow-domain.com")')


### PR DESCRIPTION
## Summary

- Configure DNS resolver with 0.5s query timeout and 1.0s lifetime (was using defaults which could take 30+ seconds)
- Add 2.0s gevent timeout wrapping entire execute method (covers both MX + A lookups)
- Add metrics: `mx_lookup.execute.{success,dns_timeout,gevent_timeout,no_record}`
- Catch `DNSTimeout` explicitly and convert to `ExpectedUdfException`

## Test plan

- [ ] Added test for DNS timeout scenario
- [ ] Deploy to staging and monitor `mx_lookup.execute.*` metrics
- [ ] Verify timeout errors decrease significantly