### PR TITLE
docs: mention documentation guidelines

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -21,5 +21,3 @@ mdbook serve
 ```
 
 Then make your changes, preview them in your web browser (at [http://localhost:3000](http://localhost:3000) by default), commit, push, and open a pull request like any other git project. 
-
-[kebab-case]: https://developer.mozilla.org/en-US/docs/Glossary/Kebab_case


### PR DESCRIPTION
As we write docs for more than one repo, it's handy to set these conventions.