### PR TITLE
Support Optional types in comparison operators (<, >, <=, >=)

### DIFF
--- a/osprey_worker/src/osprey/engine/executor/tests/test_binary_comparison.py
+++ b/osprey_worker/src/osprey/engine/executor/tests/test_binary_comparison.py
@@ -177,9 +177,7 @@ def test_and(execute: ExecuteFunction, statement: str, expected: bool) -> None:
         ('None', False),  # None value - condition short-circuits
     ],
 )
-def test_optional_null_check_before_comparison(
-    execute: ExecuteFunction, opt_val: object, expected: bool
-) -> None:
+def test_optional_null_check_before_comparison(execute: ExecuteFunction, opt_val: object, expected: bool) -> None:
     """Test that type narrowing works for X != None and X >= 90 pattern."""
     data = execute(
         f"""
@@ -214,9 +212,7 @@ def test_optional_null_check_chained_narrowing(execute: ExecuteFunction) -> None
         ('None', True),  # None value - first condition is True, so result is True
     ],
 )
-def test_optional_or_pattern_null_check(
-    execute: ExecuteFunction, opt_val: object, expected: bool
-) -> None:
+def test_optional_or_pattern_null_check(execute: ExecuteFunction, opt_val: object, expected: bool) -> None:
     """Test that type narrowing works for X == None or X >= 90 pattern."""
     data = execute(
         f"""


### PR DESCRIPTION
## Problem

The Osprey type validator rejected comparison operators (`>=`, `<=`, `>`, `<`) on `Optional[int]` / `Optional[float]` types, making it impossible to use these operators with many UDFs that return Optional values.

**Example query that failed validation:**
`ActionName == "space_joined" and Scorre >= 90`

## Solution

Rather than broadly allowing Optional types in numeric comparisons (which could mask bugs), this PR implements **type narrowing** for boolean operations. The type checker now recognizes that after a null check, the variable is narrowed from `Optional[T]` to `T`.

**Supported patterns:**
'and' pattern: X != None narrows X for subsequent expressions
`Score != None and Score >= 90`

'or' pattern: X == None narrows X for the else branch
`Score == None or Score >= 90`

This aligns with type narrowing behavior in TypeScript and mypy, providing type safety while enabling the use of Optional values in comparisons.
