### PR TITLE
fix: declare worker dependencies, support Python 3.14

### DIFF
--- a/osprey_worker/pyproject.toml
+++ b/osprey_worker/pyproject.toml
@@ -5,13 +5,48 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "osprey-worker"
 version = "0.1.0"
-description = "Add your description here"
+description = "Osprey rules engine worker"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "flask-cors>=6.0.1",
     "osprey_rpc",
+    # cli + web
+    "click>=7.1",
+    "flask>=1.1",
+    "flask-cors>=6.0",
+    "werkzeug>=1.0",
+    # engine core
+    "gevent>=24.2",
+    "greenlet>=3.0",
+    "pydantic>=1.10,<2",
+    "typing-extensions>=4.6",
+    "typing-inspect>=0.9",
+    "result>=0.5",
+    "deepmerge>=0.3",
+    "pyyaml>=6.0",
+    "jsonpath-rw>=1.4",
+    "pluggy>=1.5",
+    "ply>=3.11",
+    # engine UDFs
+    "python-dateutil>=2.8",
+    "dnspython>=2.0",
+    "tld>=0.12",
+    "unidecode>=1.3",
+    "python-Levenshtein>=0.12",
+    "mmh3>=3.0",
+    "phone-iso3166>=0.3",
+    "graphviz>=0.20",
+    # tracing + metrics
+    "ddtrace>=2.17",
+    "datadog>=0.51",
+    # networking
+    "grpcio>=1.49",
+    "requests>=2.28",
+    "protobuf>=4.25",
+    # observability
+    "sentry-sdk>=1.5",
 ]
+
 [project.scripts]
 osprey-cli = "osprey.worker.lib.cli:cli"
 

--- a/osprey_worker/src/osprey/engine/executor/executor.py
+++ b/osprey_worker/src/osprey/engine/executor/executor.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple
 import gevent
 import gevent.pool
 from ddtrace import tracer
-from ddtrace.span import Span as TracerSpan
+from ddtrace.trace import Span as TracerSpan
 from osprey.engine.ast.grammar import ASTNode
 from osprey.engine.executor.custom_extracted_features import (
     ActionIdExtractedFeature,

--- a/osprey_worker/src/osprey/engine/executor/node_executor/_base_node_executor.py
+++ b/osprey_worker/src/osprey/engine/executor/node_executor/_base_node_executor.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, ClassVar, Generic, Sequence, Type, TypeVar
 
-from ddtrace.span import Span
+from ddtrace.trace import Span
 from osprey.engine.ast.grammar import ASTNode
 
 if TYPE_CHECKING:

--- a/osprey_worker/src/osprey/engine/executor/node_executor/call_executor.py
+++ b/osprey_worker/src/osprey/engine/executor/node_executor/call_executor.py
@@ -6,7 +6,7 @@ from ..node_executor_registry import NodeExecutorRegistry
 from ._base_node_executor import BaseNodeExecutor
 
 if TYPE_CHECKING:
-    from ddtrace.span import Span
+    from ddtrace.trace import Span
     from osprey.engine.ast_validator.validation_context import ValidatedSources
     from osprey.engine.udf.arguments import ArgumentsBase
     from osprey.engine.udf.base import UDFBase

--- a/osprey_worker/src/osprey/worker/lib/ddtrace_utils/__init__.py
+++ b/osprey_worker/src/osprey/worker/lib/ddtrace_utils/__init__.py
@@ -3,7 +3,7 @@ import sys
 from typing import Any, Callable, Dict, Optional, TypeVar, Union
 
 import ddtrace
-from ddtrace.span import Span
+from ddtrace.trace import Span
 from flask import Flask
 from osprey.worker.lib.ddtrace_utils.instrumentation.flask.middleware import TraceMiddleware
 from osprey.worker.lib.ddtrace_utils.internal.baggage import Baggage

--- a/osprey_worker/src/osprey/worker/lib/ddtrace_utils/instrumentation/flask/middleware.py
+++ b/osprey_worker/src/osprey/worker/lib/ddtrace_utils/instrumentation/flask/middleware.py
@@ -5,7 +5,7 @@ import sys
 from typing import Any, Callable, Dict, List, Optional, Union
 
 import flask.templating
-from ddtrace import Span, Tracer
+from ddtrace.trace import Span, Tracer
 from ddtrace.constants import ERROR_MSG, ERROR_TYPE
 from ddtrace.ext import SpanTypes, http
 from ddtrace.internal import compat

--- a/osprey_worker/src/osprey/worker/lib/ddtrace_utils/internal/baggage.py
+++ b/osprey_worker/src/osprey/worker/lib/ddtrace_utils/internal/baggage.py
@@ -1,7 +1,7 @@
 from typing import Dict, List, Optional, Union
 
-from ddtrace.filters import TraceFilter
-from ddtrace.span import Span
+from ddtrace.trace import TraceFilter
+from ddtrace.trace import Span
 
 from ..constants import BaggagePrefix
 

--- a/osprey_worker/src/osprey/worker/lib/osprey_engine.py
+++ b/osprey_worker/src/osprey/worker/lib/osprey_engine.py
@@ -6,7 +6,7 @@ from typing import Callable, Dict, Generic, List, Optional, Set, Tuple, Type, Ty
 
 import gevent
 import gevent.pool
-from ddtrace.span import Span as TracerSpan
+from ddtrace.trace import Span as TracerSpan
 from gevent.threadpool import ThreadPool
 from osprey.engine.ast.grammar import Assign, Span
 from osprey.engine.ast.sources import Sources, SourcesConfig

--- a/osprey_worker/src/osprey/worker/lib/pigeon/client.py
+++ b/osprey_worker/src/osprey/worker/lib/pigeon/client.py
@@ -10,9 +10,9 @@ from typing import Any, Callable, Dict, Generic, List, Optional, Set, Tuple, Typ
 
 import grpc
 from ddtrace.constants import ERROR_MSG
-from ddtrace.contrib.grpc.constants import GRPC_STATUS_CODE_KEY
+GRPC_STATUS_CODE_KEY = "grpc.status.code"
 from ddtrace.ext.http import STATUS_CODE
-from ddtrace.span import Span
+from ddtrace.trace import Span
 from gevent.pool import Pool
 from google.protobuf.message import Message
 from grpc import Channel

--- a/osprey_worker/src/osprey/worker/sinks/sink/rules_sink.py
+++ b/osprey_worker/src/osprey/worker/sinks/sink/rules_sink.py
@@ -7,7 +7,7 @@ from typing import Optional
 import gevent
 import sentry_sdk
 from ddtrace import tracer
-from ddtrace.span import Span as TracerSpan
+from ddtrace.trace import Span as TracerSpan
 from osprey.engine.executor.execution_context import Action, ExecutionResult
 from osprey.engine.executor.udf_execution_helpers import UDFHelpers
 from osprey.engine.utils.types import add_slots

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,26 +186,7 @@ dev = [
 
 
 [tool.uv]
-override-dependencies = ["ddtrace>=2.17.2,<3.0.0"]
 default-groups = ["common", "dev"]
-
-[tool.uv.sources]
-erlpack = { git = "https://github.com/discord/erlpack.git", rev = "b25ebd51ae4c097bd7f756fd4e1c841b61bfe50b" }
-greenlet = { git = "https://github.com/discord/greenlet.git", rev = "a75d78f1547c74a81134644a179467525a255466" }
-gunicorn = { git = "https://github.com/discord/gunicorn.git", rev = "979efdcb918daa536d8923668241c6e6bf1edb58" }
-hash-ring = { url = "https://storage.googleapis.com/discord-devops/hash_ring-src-b4b56bc93053881b68b829ee9d1a4871b4aee592.zip" }
-jsonpath-rw = { url = "https://github.com/kennknowles/python-jsonpath-rw/archive/6f5647bb3ad2395c20f0191fef07a1df51c9fed8.tar.gz" }
-nostril = { url = "https://github.com/casics/nostril/archive/v1.2.0.tar.gz" }
-osprey_rpc = { workspace = true }
-osprey_worker = { workspace = true }
-example_plugins = { workspace = true }
-
-[tool.uv.workspace]
-members = [
-    "osprey_rpc",
-    "osprey_worker",
-    "example_plugins",
-]
 
 
 [tool.ruff]


### PR DESCRIPTION
## Summary

`osprey_worker` only declares `flask-cors` and `osprey_rpc` as dependencies. Everything else (`gevent`, `ddtrace`, `typing-inspect`, `graphviz`, `pyyaml`, etc.) lives in the root workspace's dependency groups, so installing `osprey-worker` standalone fails immediately:

```
$ pip install "osprey-worker @ git+https://github.com/roostorg/osprey.git#subdirectory=osprey_worker"
$ python -c "from osprey.engine.udf.base import UDFBase"
ModuleNotFoundError: No module named 'typing_inspect'
```

This PR:

- **Declares all actual dependencies** in `osprey_worker/pyproject.toml`
- **Migrates ddtrace v2 → v4 imports** (v2 can't build on Python 3.14 — uses `pkg_resources` which was removed):
  - `ddtrace.span.Span` → `ddtrace.trace.Span`
  - `ddtrace.filters.TraceFilter` → `ddtrace.trace.TraceFilter`
  - `ddtrace.contrib.grpc.constants.GRPC_STATUS_CODE_KEY` → inlined string constant
- **Removes root workspace/source overrides** so subdirectory packages can be installed standalone without inheriting workspace constraints

### Before (upstream, Python 3.14)

```
$ uv sync  # installs 10 packages (flask-cors and friends)
$ python -c "from osprey.engine.udf.base import UDFBase"
ModuleNotFoundError: No module named 'typing_inspect'
```

### After (this branch, Python 3.14)

```
$ uv sync  # installs 52 packages (actual dependency tree)
$ python -c "
from osprey.engine.udf.base import UDFBase
from osprey.engine.language_types.effects import EffectBase
from osprey.engine.language_types.entities import EntityT
from osprey.engine.executor.execution_context import Action, ExecutionResult
from osprey.engine.ast.sources import Sources
from osprey.engine.ast_validator import validate_sources
print('all core engine imports OK on Python 3.14')
"
all core engine imports OK on Python 3.14
```

## Context

We're using osprey as a git dependency for a rules engine plugin ([plyr.fm](https://plyr.fm) moderation). Ran into this immediately when trying to install outside the monorepo workspace on Python 3.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)