### PR TITLE
CODEOWNERS: add ROOSTers and Discord teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,11 @@
 # CODEOWNERS file for managing repository permissions
 # Format: path-pattern @username @org/team-name
 
-# Maintainers: Default owners for all files
+# Maintainers; see https://roostorg.github.io/community/roles.html#maintainers
 * @EXBreder @haileyok @vinaysrao1
+
+# Other trusted contributors
+* @roostorg/roosters @roostorg/discord
 
 # Docs contributors
 docs/ @roostorg/roosters


### PR DESCRIPTION
In our last [working group meeting][1] we agreed to add other trusted contributors to CODEOWNERS (in addition to explicit maintainers) to help facilitate code reviews.

As a reminder, membership of these teams are also still maintained by ROOST, so there's another layer of trust—i.e. it's not just anyone who happens to join Discord, but only those who have explicitly been added by ROOST to our @roostorg/discord team.

[1]: https://github.com/roostorg/osprey/discussions/142