### PR TITLE
CODEOWNERS: Fix * owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,9 @@
 # CODEOWNERS file for managing repository permissions
 # Format: path-pattern @username @org/team-name
 
-# Maintainers; see https://roostorg.github.io/community/roles.html#maintainers
-* @EXBreder @haileyok @vinaysrao1
-
-# Other trusted contributors
-* @roostorg/roosters @roostorg/discord
+# Maintainers, plus ROOST-maintained teams of other trusted contributors
+# See https://roostorg.github.io/community/roles.html#maintainers
+* @EXBreder @haileyok @vinaysrao1 @roostorg/roosters @roostorg/discord
 
 # Docs contributors
 docs/ @roostorg/roosters


### PR DESCRIPTION
In #150 we added a line for @roostorg/roosters and @roostorg/discord, but that overrides the previous line of explicit maintainers. Instead, we must define them on the same line.