### PR TITLE
[CI] Fix code-quality workflow due to missing package index update

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -104,7 +104,8 @@ jobs:
 
       - name: Build Rust project
         run: |
-          sudo apt-get install protobuf-compiler
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
           cargo build --verbose
         working-directory: osprey_coordinator
 


### PR DESCRIPTION
### Summary:

On my pr with mardown only changes I found that the workflow for rust-quality was failing as seen [here](https://github.com/roostorg/osprey/actions/runs/22493463095/job/65162290059)

This was due to a missing package index update before calling install of protobuf compiler. The runner’s cached lists can point to package versions that no longer exist at that URL (e.g. after mirror sync or updates), which leads to 404s.

This pr adds the update here to ensure it has the package index is updated and able to find packages.