### PR TITLE
Treat missing JSON paths as expected failures instead of errors

### DIFF
--- a/osprey_worker/src/osprey/engine/executor/executor.py
+++ b/osprey_worker/src/osprey/engine/executor/executor.py
@@ -12,7 +12,6 @@ from osprey.engine.executor.custom_extracted_features import (
     SampleRateExtractedFeature,
     TimestampExtractedFeature,
 )
-from osprey.engine.stdlib.udfs.json_utils import MissingJsonPath
 from osprey.engine.udf.base import BatchableUDFBase
 from osprey.worker.lib.instruments import metrics
 from osprey.worker.lib.osprey_shared.logging import get_logger
@@ -75,7 +74,6 @@ def _is_spammy_exception(e: Optional[Exception]) -> bool:
         e is None
         or isinstance(e, ExpectedUdfException)
         or isinstance(e, NodeFailurePropagationException)
-        or isinstance(e, MissingJsonPath)
         or isinstance(e, TypeError)
     )
 

--- a/osprey_worker/src/osprey/engine/stdlib/udfs/json_utils.py
+++ b/osprey_worker/src/osprey/engine/stdlib/udfs/json_utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, TypeVar
+from typing import Any, Dict
 
 from jsonpath_rw import JSONPath, parse
 from osprey.engine.executor.execution_context import ExpectedUdfException
@@ -19,14 +19,6 @@ def parse_path(path: ConstExpr[str]) -> JSONPath:
             raise
 
 
-class MissingJsonPath(Exception):
-    def __init__(self, path: str) -> None:
-        self.path = path
-
-    def __str__(self) -> str:
-        return f'Missing Json data at path `{self.path}`.'
-
-
 class InvalidJsonType(TypeError):
     def __init__(self, path: str, expected_type: type, actual_type: type) -> None:
         self.path = path
@@ -38,9 +30,6 @@ class InvalidJsonType(TypeError):
             f'Invalid type in Json data at path `{self.path}`.'
             f' Has type {to_display_str(self.actual_type)}, expected {to_display_str(self.expected_type)}.'
         )
-
-
-_T = TypeVar('_T')
 
 
 def get_from_data(
@@ -59,12 +48,8 @@ def get_from_data(
         if rvalue_type_checker.check(None):
             return None
 
-        # Only perform the `required` check if our return type is incompatible with None
-        if required:
-            raise MissingJsonPath(str(expr))
-
-        # Otherwise raise an expected/ignored failure to prevent dependencies from running, but not be reported
-        # as an exception.
+        # Missing paths are expected — most actions only have a subset of fields.
+        # Raise ExpectedUdfException to skip downstream nodes without recording an error.
         raise ExpectedUdfException()
 
     if not rvalue_type_checker.check(value):

--- a/osprey_worker/src/osprey/engine/stdlib/udfs/tests/test_entity.py
+++ b/osprey_worker/src/osprey/engine/stdlib/udfs/tests/test_entity.py
@@ -138,10 +138,7 @@ def test_entity_can_be_optional(execute: ExecuteFunction, execute_with_result: E
 
     result = execute_with_result("A: Entity[str] = EntityJson(type='A', path='$.missing')")
 
-    assert len(result.error_infos) == 1
-    error_message = str(result.error_infos[0].error)
-    assert '$.missing' in error_message
-
+    assert not result.error_infos
     assert result.extracted_features['A'] is None
 
 

--- a/osprey_worker/src/osprey/engine/stdlib/udfs/tests/test_json_data.py
+++ b/osprey_worker/src/osprey/engine/stdlib/udfs/tests/test_json_data.py
@@ -44,9 +44,7 @@ def test_execute_value_not_present(execute: ExecuteFunction, execute_with_result
     assert result.extracted_features['Foo'] is None
 
     result = execute_with_result("Foo: str = JsonData(path='$.foo', required=True)", data={})
-    assert len(result.error_infos) == 1, result.error_infos
-    error_message = str(result.error_infos[0].error)
-    assert '$.foo' in error_message
+    assert not result.error_infos
     assert result.extracted_features['Foo'] is None
 
     result = execute_with_result("Foo: Optional[str] = JsonData(path='$.foo', required=True)", data={})


### PR DESCRIPTION
## Summary

- Remove `MissingJsonPath` exception class from `json_utils.py`
- Missing JSON paths now raise `ExpectedUdfException` instead, which is already filtered from `error_infos` before serialization to BigTable
- Remove `MissingJsonPath` from `_is_spammy_exception` in executor (no longer needed)
- Update `test_json_data` to expect no error_infos for missing paths with `required=True`

This eliminates noisy error traces for the common case where actions only have a subset of JSON fields (~498 `JsonData` calls across ~6000 rules). `InvalidJsonType` still raises for real type mismatches.

## Test plan

- [ ] Existing `test_json_data` tests pass with updated assertions
- [ ] `InvalidJsonType` still raised for real type mismatches
- [ ] Deploy to staging, verify reduced Sentry noise and smaller BigTable payloads