### PR TITLE
feat: add postgres result store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-(No changes yet. Add entries here before cutting a release.)
+### 📚 3rd party library updates
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+    - Add Postgres execution result store ([#171](https://github.com/roostorg/osprey/pull/171) by [@serendipty01](https://github.com/serendipty01))
+
+### 🐛 Bug fixes
+

--- a/osprey_worker/src/osprey/worker/_stdlibplugin/execution_result_store_chooser.py
+++ b/osprey_worker/src/osprey/worker/_stdlibplugin/execution_result_store_chooser.py
@@ -8,6 +8,7 @@ from osprey.worker.lib.storage.stored_execution_result import (
     StoredExecutionResultBigTable,
     StoredExecutionResultGCS,
     StoredExecutionResultMinIO,
+    StoredExecutionResultPostgres,
 )
 
 
@@ -33,6 +34,8 @@ def get_rules_execution_result_storage_backend(
         return StoredExecutionResultMinIO(
             endpoint=endpoint, access_key=access_key, secret_key=secret_key, secure=secure, bucket_name=bucket_name
         )
+    elif backend_type == ExecutionResultStorageBackendType.POSTGRES:
+        return StoredExecutionResultPostgres()
     elif backend_type == ExecutionResultStorageBackendType.PLUGIN:
         store = bootstrap_execution_result_store(config=config)
         if store is None:

--- a/osprey_worker/src/osprey/worker/lib/storage/__init__.py
+++ b/osprey_worker/src/osprey/worker/lib/storage/__init__.py
@@ -26,6 +26,11 @@ class ExecutionResultStorageBackendType(StrEnum):
     Minio execution result store
     """
 
+    POSTGRES = auto()
+    """
+    Postgres execution result store
+    """
+
     PLUGIN = auto()
     """
     Execution result store that is defined via register_execution_result_store

--- a/osprey_worker/src/osprey/worker/lib/storage/pg_stored_execution.py
+++ b/osprey_worker/src/osprey/worker/lib/storage/pg_stored_execution.py
@@ -1,0 +1,52 @@
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy import BigInteger, Column
+from sqlalchemy.dialects.postgresql import JSONB
+
+from .postgres import Model, scoped_session
+
+
+class PgStoredExecutionResult(Model):
+    """
+    `stored_execution_result` stores results as jsonb
+    """
+
+    __tablename__ = 'stored_execution_result'
+
+    id = Column(BigInteger, primary_key=True)
+    payload = Column(JSONB, nullable=False)
+
+    @classmethod
+    def insert(
+        cls,
+        id: int,
+        payload: Dict[str, Any],
+    ) -> None:
+        """
+        Adds a single `execution_result` to the database
+        """
+        with scoped_session(commit=True) as session:
+            execution_result = PgStoredExecutionResult(id=id, payload=payload)
+            session.add(execution_result)
+
+    @classmethod
+    def select_one(cls, id: int) -> Optional['PgStoredExecutionResult']:
+        """
+        Gets stored execution result with id if it exists
+        """
+        with scoped_session() as session:
+            execution_result: Optional['PgStoredExecutionResult'] = (
+                session.query(PgStoredExecutionResult).filter(PgStoredExecutionResult.id == id).one_or_none()
+            )
+            return execution_result
+
+    @classmethod
+    def select_many(cls, ids: List[int]) -> List['PgStoredExecutionResult']:
+        """
+        Gets list of stored execution results with given ids
+        """
+        with scoped_session() as session:
+            execution_results: List['PgStoredExecutionResult'] = (
+                session.query(PgStoredExecutionResult).filter(PgStoredExecutionResult.id.in_(ids)).all()
+            )
+            return execution_results

--- a/osprey_worker/src/osprey/worker/lib/storage/postgres.py
+++ b/osprey_worker/src/osprey/worker/lib/storage/postgres.py
@@ -53,6 +53,7 @@ def init_from_config(database: str) -> None:
         from . import (  # noqa: F401
             bulk_action_task,
             bulk_label_task,
+            pg_stored_execution,
             queries,
             temporary_ability_token,
         )

--- a/osprey_worker/src/osprey/worker/lib/storage/stored_execution_result.py
+++ b/osprey_worker/src/osprey/worker/lib/storage/stored_execution_result.py
@@ -5,7 +5,7 @@ import json
 from abc import ABC, abstractmethod
 from datetime import datetime
 from io import BytesIO
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, cast
 
 import gevent
 import google.cloud.storage as storage
@@ -19,8 +19,9 @@ from osprey.engine.executor.execution_context import ExecutionResult
 from osprey.worker.lib.instruments import metrics
 from osprey.worker.lib.osprey_shared.logging import get_logger
 from osprey.worker.lib.snowflake import Snowflake
-from osprey.worker.lib.storage import ExecutionResultStorageBackendType
+from osprey.worker.lib.storage import ExecutionResultStorageBackendType, postgres
 from osprey.worker.lib.storage.bigtable import osprey_bigtable
+from osprey.worker.lib.storage.pg_stored_execution import PgStoredExecutionResult
 from pydantic.main import BaseModel
 
 logger = get_logger()
@@ -456,6 +457,78 @@ class StoredExecutionResultMinIO(ExecutionResultStore):
 
     @staticmethod
     def _execution_result_dict_from_minio_data(data: Dict[str, Any]) -> Dict[str, Any]:
+        execution_result_dict = {
+            'id': data['id'],
+            'extracted_features': data['extracted_features'],
+            'error_traces': data['error_traces'],
+            'timestamp': datetime.fromisoformat(data['timestamp']),
+            'action_data': None,
+        }
+
+        action_data = data.get('action_data')
+        if action_data:
+            execution_result_dict['action_data'] = action_data
+
+        return execution_result_dict
+
+
+class StoredExecutionResultPostgres(ExecutionResultStore):
+    def __init__(self) -> None:
+        postgres.init_from_config('osprey_db')
+
+    def select_one(self, action_id: int) -> Optional[Dict[str, Any]]:
+        try:
+            with metrics.timed('pg_stored_execution_result.get_one'):
+                result = PgStoredExecutionResult.select_one(action_id)
+                if not result:
+                    metrics.increment(
+                        'pg_stored_execution_result.select_one.not_found', tags=[f'action_id:{action_id}']
+                    )
+                    return None
+                payload = cast(Dict[str, Any], result.payload)
+                return StoredExecutionResultPostgres._execution_result_dict_from_pg_data(payload)
+
+        except Exception as e:
+            logger.error(f'Failed to retrieve execution result from PG for action_id {action_id}: {e}')
+            return None
+
+    def select_many(self, action_ids: List[int]) -> List[Dict[str, Any]]:
+        try:
+            with metrics.timed('pg_stored_execution_result.get_many'):
+                results = PgStoredExecutionResult.select_many(action_ids)
+                return [
+                    StoredExecutionResultPostgres._execution_result_dict_from_pg_data(
+                        cast(Dict[str, Any], result.payload)
+                    )
+                    for result in results
+                ]
+        except Exception as e:
+            logger.error(f'Failed to retrieve execution results from PG for action_ids {action_ids}: {e}')
+            return []
+
+    def insert(
+        self,
+        action_id: int,
+        extracted_features_json: str,
+        error_traces_json: str,
+        timestamp: datetime,
+        action_data_json: str,
+    ) -> None:
+        try:
+            with metrics.timed('pg_stored_execution_result.insert'):
+                payload: Dict[str, Any] = {
+                    'id': action_id,
+                    'extracted_features': extracted_features_json,
+                    'error_traces': error_traces_json,
+                    'timestamp': timestamp.isoformat(),
+                    'action_data': action_data_json,
+                }
+                PgStoredExecutionResult.insert(action_id, payload)
+        except Exception as e:
+            logger.error(f'Failed to insert execution result into PG for action_id {action_id}: {e}')
+
+    @staticmethod
+    def _execution_result_dict_from_pg_data(data: Dict[str, Any]) -> Dict[str, Any]:
         execution_result_dict = {
             'id': data['id'],
             'extracted_features': data['extracted_features'],


### PR DESCRIPTION
Added for ease in local development

Need to change below env to enable this
OSPREY_EXECUTION_RESULT_STORAGE_BACKEND=postgres

Note:
I haven't tested with druid setup
Also, I'm not deeply familiar with Python or this codebase, so let me know anything that needs to be changed or improved.

Tested with Hailey's fork
<img width="1042" height="1484" alt="image" src="https://github.com/user-attachments/assets/384e189d-3247-4e9f-8ed2-fd1cad577d5b" />
<img width="2844" height="1086" alt="image" src="https://github.com/user-attachments/assets/2da2af06-fc92-4048-b467-8e8509460d8e" />
