### PR TITLE
add dependabot.yml, stop dependabot from bumping grpcio

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "grpcio"


### PR DESCRIPTION
Adds the dependabot.yml file with `grpcio` as an ignored dependency so it doesn't get bumped.
