### PR TITLE
Default JsonData required=False to silence missing path errors

### DIFF
--- a/osprey_worker/src/osprey/engine/stdlib/udfs/json_data.py
+++ b/osprey_worker/src/osprey/engine/stdlib/udfs/json_data.py
@@ -14,10 +14,11 @@ class Arguments(ArgumentsBase):
     Must be a string literal and must be valid JSON path syntax.
     """
 
-    required: bool = True
+    required: bool = False
     """Whether or not the value is required to be in the action data.
 
-    Defaults to `True`. If `False`, will gracefully handle both missing and present-but-null values.
+    Defaults to `False`. If `True`, missing values will be reported as errors rather than silently
+    skipping downstream nodes.
     """
 
     coerce_type: bool = False

--- a/osprey_worker/src/osprey/engine/stdlib/udfs/tests/test_entity.py
+++ b/osprey_worker/src/osprey/engine/stdlib/udfs/tests/test_entity.py
@@ -136,7 +136,14 @@ def test_entity_can_be_optional(execute: ExecuteFunction, execute_with_result: E
 
     assert data == {'A': None}
 
+    # Default required=False means missing paths silently skip without errors
     result = execute_with_result("A: Entity[str] = EntityJson(type='A', path='$.missing')")
+
+    assert not result.error_infos
+    assert result.extracted_features['A'] is None
+
+    # Explicit required=True still reports errors for missing paths
+    result = execute_with_result("A: Entity[str] = EntityJson(type='A', path='$.missing', required=True)")
 
     assert len(result.error_infos) == 1
     error_message = str(result.error_infos[0].error)


### PR DESCRIPTION
## Summary

- Changes the default value of `required` in `JsonData.Arguments` from `True` to `False`
- Missing JSON paths now raise `ExpectedUdfException` (silent skip) instead of `MissingJsonPath` (stored as error in BigTable)
- `EntityJson` inherits this change automatically since it extends `JsonData.Arguments`
- Rules that explicitly set `required=True` (8 in production) keep their current error-reporting behavior

## Context

Most actions only have a subset of fields, so missing paths are expected. With `required=True` as the default, every missing path gets serialized into `error_traces_json` and persisted to BigTable, inflating storage costs and creating monitoring noise.

333 rules already explicitly set `required=False`. Only 8 rules explicitly set `required=True`. The remaining ~490 rules use the implicit default -- none of them rely on missing-path errors for correctness.

## Test plan

- [x] Updated `test_entity_can_be_optional` to verify default behavior no longer errors
- [x] Added explicit `required=True` test case to verify opt-in error reporting still works
- [x] All 15 existing JsonData and Entity tests pass