### PR TITLE
add option to suppress cached errors to reduce metric bloat

### DIFF
--- a/osprey_worker/src/osprey/engine/executor/external_service_utils.py
+++ b/osprey_worker/src/osprey/engine/executor/external_service_utils.py
@@ -32,11 +32,11 @@ class ExternalService(ABC, Generic[KeyT, ValueT]):
         """
         return None
 
-    def suppress_cached_errors(self) -> bool:
+    def count_error_once(self) -> bool:
         """
-        When True, subsequent callers that hit a cached error receive None
-        instead of re-raising the original exception. The caller that initiated
-        the service call still gets the exception raised normally.
+        When True, only the caller that initiated the external service call
+        receives the exception. Subsequent callers that would hit the cached
+        error receive None instead.
 
         Only enable this when ValueT is Optional and None is a safe fallback.
         """
@@ -94,7 +94,7 @@ class ExternalServiceAccessor(Generic[KeyT, ValueT]):
             try:
                 cache_entry[0].set(self._service.get_from_service(key))
             except Exception as e:
-                if self._service.suppress_cached_errors():
+                if self._service.count_error_once():
                     cache_entry[0].set(None)
                 else:
                     cache_entry[0].set_exception(e)

--- a/osprey_worker/src/osprey/engine/executor/external_service_utils.py
+++ b/osprey_worker/src/osprey/engine/executor/external_service_utils.py
@@ -32,6 +32,16 @@ class ExternalService(ABC, Generic[KeyT, ValueT]):
         """
         return None
 
+    def suppress_cached_errors(self) -> bool:
+        """
+        When True, subsequent callers that hit a cached error receive None
+        instead of re-raising the original exception. The caller that initiated
+        the service call still gets the exception raised normally.
+
+        Only enable this when ValueT is Optional and None is a safe fallback.
+        """
+        return False
+
 
 class ExternalServiceAccessor(Generic[KeyT, ValueT]):
     """Facilitates accessing an external service in a way that caches and debounces requests based on a key."""
@@ -84,7 +94,11 @@ class ExternalServiceAccessor(Generic[KeyT, ValueT]):
             try:
                 cache_entry[0].set(self._service.get_from_service(key))
             except Exception as e:
-                cache_entry[0].set_exception(e)
+                if self._service.suppress_cached_errors():
+                    cache_entry[0].set(None)
+                else:
+                    cache_entry[0].set_exception(e)
+                raise
 
         return cast(ValueT, cache_entry[0].get())
 

--- a/osprey_worker/src/osprey/engine/stdlib/udfs/tests/test_external_service_utils.py
+++ b/osprey_worker/src/osprey/engine/stdlib/udfs/tests/test_external_service_utils.py
@@ -1,6 +1,7 @@
-from typing import List
+from typing import List, Optional
 
 import gevent
+import pytest
 from gevent.event import Event
 from osprey.engine.executor.external_service_utils import ExternalService, ExternalServiceAccessor
 
@@ -28,6 +29,31 @@ class BlockingService(CountingService):
         self.blocking_events.remove(event)
 
         return super().get_from_service(key)
+
+
+class FailingService(ExternalService[str, int]):
+    """Always raises on the first call for a key."""
+
+    def __init__(self) -> None:
+        self.calls: List[str] = []
+
+    def get_from_service(self, key: str) -> int:
+        self.calls.append(key)
+        raise RuntimeError(f'timeout for {key}')
+
+
+class SuppressedFailingService(ExternalService[str, Optional[int]]):
+    """Always raises, but opts in to suppress_cached_errors."""
+
+    def __init__(self) -> None:
+        self.calls: List[str] = []
+
+    def suppress_cached_errors(self) -> bool:
+        return True
+
+    def get_from_service(self, key: str) -> Optional[int]:
+        self.calls.append(key)
+        raise RuntimeError(f'timeout for {key}')
 
 
 def test_accessor_caches_values() -> None:
@@ -89,3 +115,68 @@ def test_can_request_different_keys_in_parallel() -> None:
     assert g1.get() == 1
     assert g2.get() == 2
     assert g3.get() == 1
+
+
+def test_cached_errors_re_raise_by_default() -> None:
+    """Without suppress_cached_errors, cached exceptions re-raise for all callers."""
+    service = FailingService()
+    accessor = ExternalServiceAccessor(service)
+
+    with pytest.raises(RuntimeError, match='timeout for a'):
+        accessor.get('a')
+
+    # Subsequent call also raises from cache
+    with pytest.raises(RuntimeError, match='timeout for a'):
+        accessor.get('a')
+
+    # Only one service call was made
+    assert service.calls == ['a']
+
+
+def test_suppress_cached_errors_returns_none_on_subsequent_calls() -> None:
+    """With suppress_cached_errors, the first caller gets the exception but
+    subsequent callers receive None from the cache."""
+    service = SuppressedFailingService()
+    accessor = ExternalServiceAccessor(service)
+
+    with pytest.raises(RuntimeError, match='timeout for a'):
+        accessor.get('a')
+
+    # Subsequent call returns None from cache
+    assert accessor.get('a') is None
+
+    # Only one service call was made
+    assert service.calls == ['a']
+
+
+def test_suppress_cached_errors_concurrent_waiters() -> None:
+    """With suppress_cached_errors, concurrent waiters get None while the
+    initiating greenlet gets the exception."""
+
+    class BlockingThenFailService(ExternalService[str, Optional[int]]):
+        def __init__(self) -> None:
+            self.event = Event()
+
+        def suppress_cached_errors(self) -> bool:
+            return True
+
+        def get_from_service(self, key: str) -> Optional[int]:
+            self.event.wait()
+            raise RuntimeError('timeout')
+
+    service = BlockingThenFailService()
+    accessor = ExternalServiceAccessor(service)
+
+    g1 = gevent.spawn(lambda: accessor.get('a'))
+    g2 = gevent.spawn(lambda: accessor.get('a'))
+    gevent.idle()
+
+    service.event.set()
+    gevent.idle()
+
+    # The initiating greenlet gets the exception
+    assert g1.exception is not None or g2.exception is not None
+
+    # The waiting greenlet gets None
+    results = [g.value for g in [g1, g2] if g.exception is None]
+    assert None in results

--- a/osprey_worker/src/osprey/engine/stdlib/udfs/tests/test_external_service_utils.py
+++ b/osprey_worker/src/osprey/engine/stdlib/udfs/tests/test_external_service_utils.py
@@ -42,13 +42,13 @@ class FailingService(ExternalService[str, int]):
         raise RuntimeError(f'timeout for {key}')
 
 
-class SuppressedFailingService(ExternalService[str, Optional[int]]):
-    """Always raises, but opts in to suppress_cached_errors."""
+class CountErrorOnceFailingService(ExternalService[str, Optional[int]]):
+    """Always raises, but opts in to count_error_once."""
 
     def __init__(self) -> None:
         self.calls: List[str] = []
 
-    def suppress_cached_errors(self) -> bool:
+    def count_error_once(self) -> bool:
         return True
 
     def get_from_service(self, key: str) -> Optional[int]:
@@ -118,7 +118,7 @@ def test_can_request_different_keys_in_parallel() -> None:
 
 
 def test_cached_errors_re_raise_by_default() -> None:
-    """Without suppress_cached_errors, cached exceptions re-raise for all callers."""
+    """Without count_error_once, cached exceptions re-raise for every caller."""
     service = FailingService()
     accessor = ExternalServiceAccessor(service)
 
@@ -133,10 +133,10 @@ def test_cached_errors_re_raise_by_default() -> None:
     assert service.calls == ['a']
 
 
-def test_suppress_cached_errors_returns_none_on_subsequent_calls() -> None:
-    """With suppress_cached_errors, the first caller gets the exception but
+def test_count_error_once_returns_none_on_subsequent_calls() -> None:
+    """With count_error_once, the first caller gets the exception but
     subsequent callers receive None from the cache."""
-    service = SuppressedFailingService()
+    service = CountErrorOnceFailingService()
     accessor = ExternalServiceAccessor(service)
 
     with pytest.raises(RuntimeError, match='timeout for a'):
@@ -149,15 +149,15 @@ def test_suppress_cached_errors_returns_none_on_subsequent_calls() -> None:
     assert service.calls == ['a']
 
 
-def test_suppress_cached_errors_concurrent_waiters() -> None:
-    """With suppress_cached_errors, concurrent waiters get None while the
+def test_count_error_once_concurrent_waiters() -> None:
+    """With count_error_once, concurrent waiters get None while the
     initiating greenlet gets the exception."""
 
     class BlockingThenFailService(ExternalService[str, Optional[int]]):
         def __init__(self) -> None:
             self.event = Event()
 
-        def suppress_cached_errors(self) -> bool:
+        def count_error_once(self) -> bool:
             return True
 
         def get_from_service(self, key: str) -> Optional[int]:


### PR DESCRIPTION
### What
Add an option to allow for setting cached values to None instead of Future

### Why
When set to a future and there is an error, the UDF continues to increase the failures and bloat metrics. This change will allow it so that we only have an exception for the first external call. Following calls will return None for Optional return UDFs.