### PR TITLE
Add per-action health metrics to executor

### DIFF
--- a/osprey_worker/src/osprey/engine/executor/executor.py
+++ b/osprey_worker/src/osprey/engine/executor/executor.py
@@ -419,7 +419,7 @@ def execute(
     ]
     metrics.increment('osprey.action_health', tags=action_tags)
     if total_errors > 0:
-        metrics.histogram('osprey.action_error_count', total_errors, tags=[f'action:{action.action_name}'], sample_rate=0.1)
+        metrics.histogram('osprey.action_error_count', total_errors, tags=[f'action:{action.action_name}'])
 
     result = ExecutionResult(
         extracted_features=context.get_extracted_features(),

--- a/osprey_worker/src/osprey/engine/executor/executor.py
+++ b/osprey_worker/src/osprey/engine/executor/executor.py
@@ -406,10 +406,25 @@ def execute(
         ]
     )
 
+    effects = context.get_effects()
+
+    total_errors = len(error_infos)
+    unexpected_errors = len(unexpected_error_infos)
+    has_effects = len(effects) > 0
+    action_tags = [
+        f'action:{action.action_name}',
+        f'had_errors:{total_errors > 0}',
+        f'had_unexpected_errors:{unexpected_errors > 0}',
+        f'had_effects:{has_effects}',
+    ]
+    metrics.increment('osprey.action_health', tags=action_tags)
+    if total_errors > 0:
+        metrics.histogram('osprey.action_error_count', total_errors, tags=[f'action:{action.action_name}'], sample_rate=0.1)
+
     result = ExecutionResult(
         extracted_features=context.get_extracted_features(),
         action=action,
-        effects=context.get_effects(),
+        effects=effects,
         validator_results=validator_results,
         error_infos=unexpected_error_infos,
         sample_rate=sample_rate,


### PR DESCRIPTION
## Summary

- Adds `osprey.action_health` metric emitted once per action after execution completes
- Adds `osprey.action_error_count` histogram for actions that had errors (10% sampled)
- Tags are all bounded: `action` (~100 values), `had_errors` (bool), `had_unexpected_errors` (bool), `had_effects` (bool)
- No behavioral changes — purely additive observability

## Why

We need to quantify what % of Osprey actions execute to completion without failures. Currently there is no per-action health signal — failures are only visible at the UDF level, and "spammy" exceptions are suppressed from existing metrics entirely.

## What it measures

- `had_errors: True/False` — whether ANY node errors occurred (including `ExpectedUdfException`)
- `had_unexpected_errors: True/False` — whether non-expected errors occurred (excludes `ExpectedUdfException`)
- `had_effects: True/False` — whether the action produced any effects (verdicts, labels, etc.)

## Key queries

```
// % of actions with any failure
sum:osprey.action_health{had_errors:true} by {action}.as_count()
/ sum:osprey.action_health{*} by {action}.as_count() * 100

// % of actions with zero effects (potential enforcement failure)
sum:osprey.action_health{had_effects:false} by {action}.as_count()
/ sum:osprey.action_health{*} by {action}.as_count() * 100
```

## Test plan

- [ ] Verify syntax validity (done — `ast.parse` passes)
- [ ] Run full test suite via Docker (`./run-tests.sh`)
- [ ] Deploy to staging and verify metrics appear in Datadog
- [ ] Monitor cardinality for 24h — estimated ~800 series