### PR TITLE
Add per-action health metrics to executor

### DIFF
--- a/osprey_worker/src/osprey/engine/executor/executor.py
+++ b/osprey_worker/src/osprey/engine/executor/executor.py
@@ -419,7 +419,7 @@ def execute(
     ]
     metrics.increment('osprey.action_health', tags=action_tags)
     if total_errors > 0:
-        metrics.histogram('osprey.action_error_count', total_errors, tags=[f'action:{action.action_name}'], sample_rate=0.1)
+        metrics.histogram('osprey.action_error_count', total_errors, tags=[f'action:{action.action_name}'])
 
     result = ExecutionResult(
         extracted_features=context.get_extracted_features(),

--- a/osprey_worker/src/osprey/engine/executor/executor.py
+++ b/osprey_worker/src/osprey/engine/executor/executor.py
@@ -406,10 +406,25 @@ def execute(
         ]
     )
 
+    effects = context.get_effects()
+
+    total_errors = len(error_infos)
+    unexpected_errors = len(unexpected_error_infos)
+    has_effects = len(effects) > 0
+    action_tags = [
+        f'action:{action.action_name}',
+        f'had_errors:{total_errors > 0}',
+        f'had_unexpected_errors:{unexpected_errors > 0}',
+        f'had_effects:{has_effects}',
+    ]
+    metrics.increment('osprey.action_health', tags=action_tags)
+    if total_errors > 0:
+        metrics.histogram('osprey.action_error_count', total_errors, tags=[f'action:{action.action_name}'], sample_rate=0.1)
+
     result = ExecutionResult(
         extracted_features=context.get_extracted_features(),
         action=action,
-        effects=context.get_effects(),
+        effects=effects,
         validator_results=validator_results,
         error_infos=unexpected_error_infos,
         sample_rate=sample_rate,

--- a/osprey_worker/src/osprey/engine/executor/executor.py
+++ b/osprey_worker/src/osprey/engine/executor/executor.py
@@ -408,18 +408,19 @@ def execute(
 
     effects = context.get_effects()
 
-    total_errors = len(error_infos)
-    unexpected_errors = len(unexpected_error_infos)
+    actionable_error_infos = [
+        error_info for error_info in error_infos if not _is_spammy_exception(error_info.error)
+    ]
     has_effects = len(effects) > 0
+    has_actionable_errors = len(actionable_error_infos) > 0
     action_tags = [
         f'action:{action.action_name}',
-        f'had_errors:{total_errors > 0}',
-        f'had_unexpected_errors:{unexpected_errors > 0}',
+        f'had_actionable_errors:{has_actionable_errors}',
         f'had_effects:{has_effects}',
     ]
     metrics.increment('osprey.action_health', tags=action_tags)
-    if total_errors > 0:
-        metrics.histogram('osprey.action_error_count', total_errors, tags=[f'action:{action.action_name}'])
+    if has_actionable_errors:
+        metrics.histogram('osprey.action_error_count', len(actionable_error_infos), tags=[f'action:{action.action_name}'])
 
     result = ExecutionResult(
         extracted_features=context.get_extracted_features(),


### PR DESCRIPTION
## Summary

- Uses `_is_spammy_exception` to filter out MissingJsonPath, TypeError, NodeFailurePropagationException (these are operationally expected, not actionable)

## Why

We need to quantify what % of Osprey actions execute to completion without failures.
## Test plan

- [ ] Verify syntax validity (done — `ast.parse` passes)
- [ ] Run full test suite via Docker (`./run-tests.sh`)
- [ ] Deploy to staging and verify metrics appear in Datadog