### PR TITLE
Use _is_spammy_exception for action_health metric filtering

### DIFF
--- a/osprey_worker/src/osprey/engine/executor/executor.py
+++ b/osprey_worker/src/osprey/engine/executor/executor.py
@@ -408,9 +408,7 @@ def execute(
 
     effects = context.get_effects()
 
-    actionable_error_infos = [
-        error_info for error_info in error_infos if not _is_spammy_exception(error_info.error)
-    ]
+    actionable_error_infos = [error_info for error_info in error_infos if not _is_spammy_exception(error_info.error)]
     has_effects = len(effects) > 0
     has_actionable_errors = len(actionable_error_infos) > 0
     action_tags = [
@@ -420,7 +418,9 @@ def execute(
     ]
     metrics.increment('osprey.action_health', tags=action_tags)
     if has_actionable_errors:
-        metrics.histogram('osprey.action_error_count', len(actionable_error_infos), tags=[f'action:{action.action_name}'])
+        metrics.histogram(
+            'osprey.action_error_count', len(actionable_error_infos), tags=[f'action:{action.action_name}']
+        )
 
     result = ExecutionResult(
         extracted_features=context.get_extracted_features(),

--- a/osprey_worker/src/osprey/engine/executor/executor.py
+++ b/osprey_worker/src/osprey/engine/executor/executor.py
@@ -408,7 +408,11 @@ def execute(
 
     effects = context.get_effects()
 
-    actionable_error_infos = [error_info for error_info in error_infos if not _is_spammy_exception(error_info.error)]
+    actionable_error_infos = [
+        error_info
+        for error_info in error_infos
+        if isinstance(error_info.error, Exception) and not _is_spammy_exception(error_info.error)
+    ]
     has_effects = len(effects) > 0
     has_actionable_errors = len(actionable_error_infos) > 0
     action_tags = [

--- a/osprey_worker/src/osprey/engine/executor/executor.py
+++ b/osprey_worker/src/osprey/engine/executor/executor.py
@@ -408,18 +408,19 @@ def execute(
 
     effects = context.get_effects()
 
-    total_errors = len(error_infos)
-    unexpected_errors = len(unexpected_error_infos)
+    actionable_error_infos = [
+        error_info for error_info in error_infos if not _is_spammy_exception(error_info.error)
+    ]
     has_effects = len(effects) > 0
+    has_actionable_errors = len(actionable_error_infos) > 0
     action_tags = [
         f'action:{action.action_name}',
-        f'had_errors:{total_errors > 0}',
-        f'had_unexpected_errors:{unexpected_errors > 0}',
+        f'had_actionable_errors:{has_actionable_errors}',
         f'had_effects:{has_effects}',
     ]
     metrics.increment('osprey.action_health', tags=action_tags)
-    if total_errors > 0:
-        metrics.histogram('osprey.action_error_count', total_errors, tags=[f'action:{action.action_name}'])
+    if has_actionable_errors:
+        metrics.histogram('osprey.action_error_count', len(actionable_error_infos), tags=[f'action:{action.action_name}'])
 
     result = ExecutionResult(
         extracted_features=context.get_extracted_features(),


### PR DESCRIPTION
## Summary

Fixes the `osprey.action_health` metric (added in #191) to use `_is_spammy_exception` for filtering errors instead of just `ExpectedUdfException`.

## Problem

The previous filter counted `MissingJsonPath`, `TypeError`, and `NodeFailurePropagationException` as "unexpected" errors. These are operationally expected — `MissingJsonPath` fires for every optional `JsonData` field not present in the payload, and `NodeFailurePropagationException` cascades from those. This caused ~100% "unexpected error" rate for action types like `payment_blocked` that import models with many optional fields (~211 errors per action, all from cascade).

## Changes

- Uses `_is_spammy_exception` (same filter as the existing `udf_execution` metric) to only count truly actionable errors
- Renames tag from `had_unexpected_errors` → `had_actionable_errors`
- Drops the always-true `had_errors` tag

## Test plan

- [ ] Run full test suite via Docker (`./run-tests.sh`)
- [ ] Deploy and verify `had_actionable_errors` tag appears in Datadog
- [ ] Confirm `payment_blocked` no longer shows ~100% error rate