### PR TITLE
Default to selecting all for event stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,4 +16,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Add Postgres execution result store ([#171](https://github.com/roostorg/osprey/pull/171) by [@serendipty01](https://github.com/serendipty01))
 
 ### 🐛 Bug fixes
-
+    - Default to selecting all for event stream ([#194](https://github.com/roostorg/osprey/pull/194) by [@chimosky](https://github.com/chimosky))

--- a/osprey_ui/src/components/event_stream/FeatureSelectModal.tsx
+++ b/osprey_ui/src/components/event_stream/FeatureSelectModal.tsx
@@ -76,6 +76,12 @@ const FeatureSelectModal = () => {
     return featureCategory.substring(0, featureCategory.lastIndexOf('.')).replace(/_|\//g, ' ');
   };
 
+  const isSetSelected = (feature: string) => {
+    if (!useCustomFeatures) return true;
+
+    return selectedFeatures.has(feature as string);
+  };
+
   const renderModalTitle = () => {
     return (
       <>
@@ -130,7 +136,7 @@ const FeatureSelectModal = () => {
               value={feature}
               disabled={!useCustomFeatures}
               onChange={handleSelectFeature}
-              checked={selectedFeatures.has(feature as string)}
+              checked={isSetSelected(feature)}
               className={styles.featureCheckboxRow}
             >
               <span className={styles.featureSpan}>{feature}</span>


### PR DESCRIPTION
## Description

All features are now selected by default, the existing behavior still works as expected.

I did this because for some reason, it seems setting defaultChecked to true on each checkBox doesn't work.

Fixes #126

@cassidyjames kindly review.

## Checklist

- [x] Tests pass locally
- [x] `uv run ruff check .` passes (no unused imports or other lint errors)
- [x] `uv tool run fawltydeps --check-unused --pyenv .venv` passes (no unused dependencies)

