### PR TITLE
add missing test files for string slice

### DIFF
--- a/osprey_worker/src/osprey/engine/stdlib/udfs/tests/test_strings/test_string_slice_validation[Result = StringSlice(s='abcdef', start=-1, end=3)].txt
+++ b/osprey_worker/src/osprey/engine/stdlib/udfs/tests/test_strings/test_string_slice_validation[Result = StringSlice(s='abcdef', start=-1, end=3)].txt
@@ -1,0 +1,5 @@
+error: invalid `start`
+--> main.sml:1:40
+     |
+   1 | Result = StringSlice(s="abcdef", start=-1, end=3)
+     |                                         ^ `start` must be a non-negative integer

--- a/osprey_worker/src/osprey/engine/stdlib/udfs/tests/test_strings/test_string_slice_validation[Result = StringSlice(s='abcdef', start=0, end=-1)].txt
+++ b/osprey_worker/src/osprey/engine/stdlib/udfs/tests/test_strings/test_string_slice_validation[Result = StringSlice(s='abcdef', start=0, end=-1)].txt
@@ -1,0 +1,11 @@
+2 errors occurred while validating:
+[1/2] error: invalid `start`
+--> main.sml:1:39
+     |
+   1 | Result = StringSlice(s="abcdef", start=0, end=-1)
+     |                                        ^ `start` must be less than or equal to `end`
+[2/2] error: invalid `end`
+--> main.sml:1:47
+     |
+   1 | Result = StringSlice(s="abcdef", start=0, end=-1)
+     |                                                ^ `end` must be a non-negative integer

--- a/osprey_worker/src/osprey/engine/stdlib/udfs/tests/test_strings/test_string_slice_validation[Result = StringSlice(s='abcdef', start=5, end=2)].txt
+++ b/osprey_worker/src/osprey/engine/stdlib/udfs/tests/test_strings/test_string_slice_validation[Result = StringSlice(s='abcdef', start=5, end=2)].txt
@@ -1,0 +1,5 @@
+error: invalid `start`
+--> main.sml:1:39
+     |
+   1 | Result = StringSlice(s="abcdef", start=5, end=2)
+     |                                        ^ `start` must be less than or equal to `end`


### PR DESCRIPTION
## Description

Followup to  https://github.com/roostorg/osprey/pull/189

Looks like I fogot to commit the files generated from running the tests with` --write-outputs` argument.   Which caused a "Works on my machine" situation that wasn't caught until the tests finally ran when we merged. 

## Checklist

- [X] Tests pass locally
- [X] `uv run ruff check .` passes (no unused imports or other lint errors)
- [X] `uv tool run fawltydeps --check-unused --pyenv .venv` passes (no unused dependencies)

