### PR TITLE
Add `InExperiment` Udf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🎉 New features
     - Add Postgres execution result store ([#171](https://github.com/roostorg/osprey/pull/171) by [@serendipty01](https://github.com/serendipty01))
     - Add `StringSlice` UDF which extracts a substring by index range ([#189](https://github.com/roostorg/osprey/pull/189) by [@bealsbe](https://github.com/bealsbe))
-    - Add `InExperiment` UDF which checks if a user is in an experiment ([#203](https://github.com/roostorg/osprey/pull/203) by [@bealsbe](https://github.com/bealsbe))
+    - Add `InExperiment` UDF which checks if an entity is in an experiment ([#203](https://github.com/roostorg/osprey/pull/203) by [@bealsbe](https://github.com/bealsbe))
 
 ### 🐛 Bug fixes
     - Default to selecting all for event stream ([#194](https://github.com/roostorg/osprey/pull/194) by [@chimosky](https://github.com/chimosky))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🎉 New features
     - Add Postgres execution result store ([#171](https://github.com/roostorg/osprey/pull/171) by [@serendipty01](https://github.com/serendipty01))
     - Add `StringSlice` UDF which extracts a substring by index range ([#189](https://github.com/roostorg/osprey/pull/189) by [@bealsbe](https://github.com/bealsbe))
+    - Add `InExperiment` UDF which checks if a user is in an experiment ([#203](https://github.com/roostorg/osprey/pull/203) by [@bealsbe](https://github.com/bealsbe))
 
 ### 🐛 Bug fixes
     - Default to selecting all for event stream ([#194](https://github.com/roostorg/osprey/pull/194) by [@chimosky](https://github.com/chimosky))

--- a/osprey_worker/src/osprey/engine/stdlib/udfs/experiments.py
+++ b/osprey_worker/src/osprey/engine/stdlib/udfs/experiments.py
@@ -299,4 +299,20 @@ class ExperimentWhen(UDFBase[ExperimentWhenArguments, List[bool]]):
         return arguments.extra_arguments[bucket]
 
 
+class InExperimentArguments(ArgumentsBase):
+    experiment: ExperimentT
+
+
+class InExperiment(UDFBase[InExperimentArguments, bool]):
+    """
+    Returns True if the entity was assigned to any bucket in the experiment,
+    False if the entity fell outside all bucket ranges (NOT_IN_EXPERIMENT_BUCKET).
+    """
+
+    category = UdfCategories.ENGINE
+
+    def execute(self, execution_context: ExecutionContext, arguments: InExperimentArguments) -> bool:
+        return arguments.experiment.resolved_bucket is not NOT_IN_EXPERIMENT_BUCKET
+
+
 ExperimentsBucketAssignment = Experiment.build_cls('experiment_bucket_assignment')

--- a/osprey_worker/src/osprey/engine/stdlib/udfs/experiments.py
+++ b/osprey_worker/src/osprey/engine/stdlib/udfs/experiments.py
@@ -306,7 +306,7 @@ class InExperimentArguments(ArgumentsBase):
 class InExperiment(UDFBase[InExperimentArguments, bool]):
     """
     Returns True if the entity was assigned to any bucket in the experiment,
-    False if the entity fell outside all bucket ranges (NOT_IN_EXPERIMENT_BUCKET).
+    False if the entity fell outside all bucket ranges
     """
 
     category = UdfCategories.ENGINE

--- a/osprey_worker/src/osprey/engine/stdlib/udfs/tests/test_experiments.py
+++ b/osprey_worker/src/osprey/engine/stdlib/udfs/tests/test_experiments.py
@@ -7,12 +7,18 @@ from osprey.engine.ast_validator.validators.validate_call_kwargs import Validate
 from osprey.engine.conftest import CheckFailureFunction, ExecuteFunction, RunValidationFunction
 from osprey.engine.language_types.experiments import NOT_IN_EXPERIMENT_BUCKET, NOT_IN_EXPERIMENT_BUCKET_INDEX
 from osprey.engine.stdlib.udfs.entity import Entity
-from osprey.engine.stdlib.udfs.experiments import CONTROL_BUCKET, EXPERIMENT_GRANULARITY, Experiment, ExperimentWhen
+from osprey.engine.stdlib.udfs.experiments import (
+    CONTROL_BUCKET,
+    EXPERIMENT_GRANULARITY,
+    Experiment,
+    ExperimentWhen,
+    InExperiment,
+)
 from osprey.engine.stdlib.udfs.rules import Rule
 from osprey.engine.udf.registry import UDFRegistry
 
 pytestmark: List[Callable[[Any], Any]] = [
-    pytest.mark.use_udf_registry(UDFRegistry.with_udfs(Entity, Rule, Experiment, ExperimentWhen)),
+    pytest.mark.use_udf_registry(UDFRegistry.with_udfs(Entity, Rule, Experiment, ExperimentWhen, InExperiment)),
     pytest.mark.use_validators([ValidateCallKwargs, UniqueStoredNames]),
 ]
 
@@ -367,6 +373,32 @@ def test_experimentwhen_results(
     """
     data = execute(experiment)
     assert data['B'] == expected_value
+
+
+@mock.patch.object(Experiment, 'hash_mod')
+def test_inexperiment_returns_true_when_in_experiment(hash_mod_mock: mock.MagicMock, execute: ExecuteFunction) -> None:
+    hash_mod_mock.return_value = 0
+    experiment = f"""
+    E1 = Entity(type='MyEntity', id='entity 1')
+    A = Experiment(entity=E1, buckets=['{CONTROL_BUCKET}', 'b'], bucket_sizes=[50.0, 50.0], version=1, revision=1)
+    B = InExperiment(experiment=A)
+    """
+    data = execute(experiment)
+    assert data['B'] is True
+
+
+@mock.patch.object(Experiment, 'hash_mod')
+def test_inexperiment_returns_false_when_not_in_experiment(
+    hash_mod_mock: mock.MagicMock, execute: ExecuteFunction
+) -> None:
+    hash_mod_mock.return_value = 9999
+    experiment = f"""
+    E1 = Entity(type='MyEntity', id='entity 1')
+    A = Experiment(entity=E1, buckets=['{CONTROL_BUCKET}', 'b'], bucket_sizes=[1.0, 1.0], version=1, revision=1)
+    B = InExperiment(experiment=A)
+    """
+    data = execute(experiment)
+    assert data['B'] is False
 
 
 @mock.patch.object(Experiment, 'hash_mod')

--- a/osprey_worker/src/osprey/worker/_stdlibplugin/udf_register.py
+++ b/osprey_worker/src/osprey/worker/_stdlibplugin/udf_register.py
@@ -9,6 +9,7 @@ from osprey.engine.stdlib.udfs.experiments import (
     Experiment,
     ExperimentsBucketAssignment,
     ExperimentWhen,
+    InExperiment,
 )
 from osprey.engine.stdlib.udfs.extract_cookie import ExtractCookie
 from osprey.engine.stdlib.udfs.get_action_name import GetActionName
@@ -82,6 +83,7 @@ def register_udfs() -> Sequence[Type[UDFBase[Any, Any]]]:
         Experiment,
         ExperimentWhen,
         ExperimentsBucketAssignment,
+        InExperiment,
         ExtractCookie,
         GetActionName,
         HasLabel,


### PR DESCRIPTION
## Description

Adds a new InExperiment UDF to the sml rules language. which returns true if an entity was assigned to any bucket in an experiment, and false if the entity fell outside all bucket ranges.

The goal is to address a shortcoming with `ExperimentWhen`  when an entity falls outside all buckets.  It silently treats them as if they were in the control bucket which makes it impossible to determine if an Entity is part of an experiment.   This makes sense for when you want to test a new version of a rule,  doesn't work for determining participation in an Experiment.  


Example sml

```py
SomeExperiment = Experiment(
    entity=EntityId,
    buckets=['control', 'treatment'],
    bucket_sizes=[10.0, 10.0],
    version=1,
    revision=1,
)

SomeRule = Rule(
    when_all=[not InExperiment(experiment=SomeExperiment)],
    description='The Entity is not in the experiment',
)

```


## Checklist

- [X] Tests pass locally
- [X] `uv run ruff check .` passes (no unused imports or other lint errors)
- [X] `uv tool run fawltydeps --check-unused --pyenv .venv` passes (no unused dependencies)





