### PR TITLE
CODEOWNERS: remove explicit docs owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,3 @@
 # Maintainers, plus ROOST-maintained teams of other trusted contributors
 # See https://roostorg.github.io/community/roles.html#maintainers
 * @ayubun @EXBreder @haileyok @vinaysrao1 @roostorg/roosters @roostorg/discord
-
-# Docs contributors
-docs/ @roostorg/roosters


### PR DESCRIPTION
Permissions aren't additive, so this just meant that maintainers couldn't merge docs updates. 🤦🏻