### PR TITLE
Docs: add quickstart troubleshooting section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,39 @@ This is a working system, not a prototype. Try it locally, connect your data, wr
 
 Your experimentation feedback will directly shape future priorities and help us build the most useful Trust & Safety tooling for the community.
 
+## Quickstart Troubleshooting
+
+### Druid schema not updating
+
+If Druid is not ingesting data or is stuck on a stale schema after changing rule output structure, reset the Kafka supervisor and resubmit the ingestion spec:
+
+```bash
+curl -X POST http://localhost:8888/druid/indexer/v1/supervisor/osprey.execution_results/terminate
+docker compose restart druid-spec-submitter
+```
+
+To wipe all Druid and MinIO state and start fresh (Postgres data is preserved):
+
+```bash
+docker compose down
+docker volume rm osprey_middle_var osprey_historical_var osprey_broker_var osprey_coordinator_var osprey_router_var osprey_druid_shared osprey_minio_data
+docker compose up -d
+```
+
+To wipe everything including Postgres:
+
+```bash
+docker compose down -v && docker compose up -d
+```
+
+### Test data not appearing in the UI
+
+The UI defaults to querying the last 24 hours. If the selected time range is too large (weeks or months), Druid scans across many segments and results can be slow or appear empty.
+
+- narrow the time range to 1–4 hours centered on when you generated test data
+- click the edit icon next to the displayed time range to switch to a custom date/time picker
+- note that Druid's Kafka consumer uses `auto.offset.reset: latest` — it only picks up events produced after `docker compose up` first ran, so events from before that point will not appear regardless of the time range
+
 ## Recognition
 
 Discord uses Osprey to quickly detect and remove new types of harm that put users at risk. Rather than leaving other platforms to build similar tools from scratch, ROOST and Discord have open-sourced this powerful rule engine in collaboration with [internet.dev](https://internet.dev/) to make it available for anyone who needs it.

--- a/README.md
+++ b/README.md
@@ -53,39 +53,6 @@ This is a working system, not a prototype. Try it locally, connect your data, wr
 
 Your experimentation feedback will directly shape future priorities and help us build the most useful Trust & Safety tooling for the community.
 
-## Quickstart Troubleshooting
-
-### Druid schema not updating
-
-If Druid is not ingesting data or is stuck on a stale schema after changing rule output structure, reset the Kafka supervisor and resubmit the ingestion spec:
-
-```bash
-curl -X POST http://localhost:8888/druid/indexer/v1/supervisor/osprey.execution_results/terminate
-docker compose restart druid-spec-submitter
-```
-
-To wipe all Druid and MinIO state and start fresh (Postgres data is preserved):
-
-```bash
-docker compose down
-docker volume rm osprey_middle_var osprey_historical_var osprey_broker_var osprey_coordinator_var osprey_router_var osprey_druid_shared osprey_minio_data
-docker compose up -d
-```
-
-To wipe everything including Postgres:
-
-```bash
-docker compose down -v && docker compose up -d
-```
-
-### Test data not appearing in the UI
-
-The UI defaults to querying the last 24 hours. If the selected time range is too large (weeks or months), Druid scans across many segments and results can be slow or appear empty.
-
-- narrow the time range to 1–4 hours centered on when you generated test data
-- click the edit icon next to the displayed time range to switch to a custom date/time picker
-- note that Druid's Kafka consumer uses `auto.offset.reset: latest` — it only picks up events produced after `docker compose up` first ran, so events from before that point will not appear regardless of the time range
-
 ## Recognition
 
 Discord uses Osprey to quickly detect and remove new types of harm that put users at risk. Rather than leaving other platforms to build similar tools from scratch, ROOST and Discord have open-sourced this powerful rule engine in collaboration with [internet.dev](https://internet.dev/) to make it available for anyone who needs it.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -143,3 +143,36 @@ docker compose --profile test_data up osprey-kafka-test-data-producer -d
 ```
 
 Produces user login events with timestamps, user IDs, and IP addresses to `osprey.actions_input` topic.
+
+## Troubleshooting
+
+### Druid schema not updating
+
+If Druid is not ingesting data or is stuck on a stale schema after changing rule output structure, reset the Kafka supervisor and resubmit the ingestion spec:
+
+```bash
+curl -X POST http://localhost:8888/druid/indexer/v1/supervisor/osprey.execution_results/terminate
+docker compose restart druid-spec-submitter
+```
+
+To wipe all Druid and MinIO state and start fresh (Postgres data is preserved):
+
+```bash
+docker compose down
+docker volume rm osprey_middle_var osprey_historical_var osprey_broker_var osprey_coordinator_var osprey_router_var osprey_druid_shared osprey_minio_data
+docker compose up -d
+```
+
+To wipe everything including Postgres:
+
+```bash
+docker compose down -v && docker compose up -d
+```
+
+### Test data not appearing in the UI
+
+The UI defaults to querying the last 24 hours. If the selected time range is too large (weeks or months), Druid scans across many segments and results can be slow or appear empty.
+
+- Narrow the time range to 1–4 hours centered on when you generated test data
+- Click the edit icon next to the displayed time range to switch to a custom date/time picker
+- Note that Druid's Kafka consumer uses `auto.offset.reset: latest` — it only picks up events produced after `docker compose up` first ran, so events from before that point will not appear regardless of the time range


### PR DESCRIPTION
  ## Description

  Adds a Quickstart Troubleshooting section to the README covering the two issues raised in #131:

  - How to reset Druid schema — soft reset (terminate Kafka supervisor + restart spec-submitter) and hard reset (remove Druid/MinIO volumes, with an option to wipe Postgres too)
  - Why test data may not appear in the UI when the time range is too large, and how to fix it

  ## Checklist

  - [x] Tests pass locally
  - [x] `uv run ruff check .` passes (no unused imports or other lint errors)
  - [x] `uv tool run fawltydeps --check-unused --pyenv .venv` passes (no unused dependencies)
  - [ ] Updated `CHANGELOG.md` with my changes, if applicable