### PR TITLE
fix: add retention limits to Kafka topics to prevent unbounded disk growth

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -78,8 +78,16 @@ services:
         condition: service_healthy
     command: >
       bash -c "
-        kafka-topics --bootstrap-server osprey-kafka:29092 --create --if-not-exists --topic osprey.actions_input --partitions 3 --replication-factor 1 &&
-        kafka-topics --bootstrap-server osprey-kafka:29092 --create --if-not-exists --topic osprey.execution_results --partitions 3 --replication-factor 1 &&
+        kafka-topics --bootstrap-server osprey-kafka:29092 --create --if-not-exists
+          --topic osprey.actions_input --partitions 3 --replication-factor 1
+          --config retention.ms=172800000
+          --config retention.bytes=8589934592
+          --config segment.bytes=1073741824 &&
+        kafka-topics --bootstrap-server osprey-kafka:29092 --create --if-not-exists
+          --topic osprey.execution_results --partitions 3 --replication-factor 1
+          --config retention.ms=172800000
+          --config retention.bytes=8589934592
+          --config segment.bytes=1073741824 &&
         kafka-topics --bootstrap-server osprey-kafka:29092 --list
       "
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -143,3 +143,17 @@ docker compose --profile test_data up osprey-kafka-test-data-producer -d
 ```
 
 Produces user login events with timestamps, user IDs, and IP addresses to `osprey.actions_input` topic.
+
+## Troubleshooting
+
+### Kafka topic disk growth
+
+Topics are created with a 48-hour / 8 GB-per-partition retention limit. If you deployed before this was set, apply the config to your existing topics:
+
+```bash
+for topic in osprey.actions_input osprey.execution_results; do
+  kafka-configs --bootstrap-server localhost:9092 \
+    --entity-type topics --entity-name $topic --alter \
+    --add-config retention.ms=172800000,retention.bytes=8589934592,segment.bytes=1073741824
+done
+```


### PR DESCRIPTION
 Fixes #239. Topics `osprey.actions_input` and `osprey.execution_results` are now
  created with 48-hour / 8 GB-per-partition retention and 1 GB segments. Also
  documents the `kafka-configs` command for existing deployments.

  ## Description

  - Added `--config retention.ms`, `--config retention.bytes`, and `--config
  segment.bytes`
    to both `kafka-topics --create` commands in `docker-compose.yaml`
  - Added a Troubleshooting section to `docs/DEVELOPMENT.md` with the `kafka-configs`
    command for operators on existing deployments

  ## Checklist

- [ ] Tests pass locally
- [ ] `uv run ruff check .` passes (no unused imports or other lint errors)
- [ ] `uv tool run fawltydeps --check-unused --pyenv .venv` passes (no unused dependencies)
- [ ] Updated `CHANGELOG.md` with my changes, if applicable

