### PR TITLE
fix: use line continuations in kafka-topics bash command

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -78,15 +78,15 @@ services:
         condition: service_healthy
     command: >
       bash -c "
-        kafka-topics --bootstrap-server osprey-kafka:29092 --create --if-not-exists
-          --topic osprey.actions_input --partitions 3 --replication-factor 1
-          --config retention.ms=172800000
-          --config retention.bytes=8589934592
+        kafka-topics --bootstrap-server osprey-kafka:29092 --create --if-not-exists \
+          --topic osprey.actions_input --partitions 3 --replication-factor 1 \
+          --config retention.ms=172800000 \
+          --config retention.bytes=8589934592 \
           --config segment.bytes=1073741824 &&
-        kafka-topics --bootstrap-server osprey-kafka:29092 --create --if-not-exists
-          --topic osprey.execution_results --partitions 3 --replication-factor 1
-          --config retention.ms=172800000
-          --config retention.bytes=8589934592
+        kafka-topics --bootstrap-server osprey-kafka:29092 --create --if-not-exists \
+          --topic osprey.execution_results --partitions 3 --replication-factor 1 \
+          --config retention.ms=172800000 \
+          --config retention.bytes=8589934592 \
           --config segment.bytes=1073741824 &&
         kafka-topics --bootstrap-server osprey-kafka:29092 --list
       "

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -78,8 +78,16 @@ services:
         condition: service_healthy
     command: >
       bash -c "
-        kafka-topics --bootstrap-server osprey-kafka:29092 --create --if-not-exists --topic osprey.actions_input --partitions 3 --replication-factor 1 &&
-        kafka-topics --bootstrap-server osprey-kafka:29092 --create --if-not-exists --topic osprey.execution_results --partitions 3 --replication-factor 1 &&
+        kafka-topics --bootstrap-server osprey-kafka:29092 --create --if-not-exists
+          --topic osprey.actions_input --partitions 3 --replication-factor 1
+          --config retention.ms=172800000
+          --config retention.bytes=8589934592
+          --config segment.bytes=1073741824 &&
+        kafka-topics --bootstrap-server osprey-kafka:29092 --create --if-not-exists
+          --topic osprey.execution_results --partitions 3 --replication-factor 1
+          --config retention.ms=172800000
+          --config retention.bytes=8589934592
+          --config segment.bytes=1073741824 &&
         kafka-topics --bootstrap-server osprey-kafka:29092 --list
       "
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -143,3 +143,17 @@ docker compose --profile test_data up osprey-kafka-test-data-producer -d
 ```
 
 Produces user login events with timestamps, user IDs, and IP addresses to `osprey.actions_input` topic.
+
+## Troubleshooting
+
+### Kafka topic disk growth
+
+Topics are created with a 48-hour / 8 GB-per-partition retention limit. If you deployed before this was set, apply the config to your existing topics:
+
+```bash
+for topic in osprey.actions_input osprey.execution_results; do
+  kafka-configs --bootstrap-server localhost:9092 \
+    --entity-type topics --entity-name $topic --alter \
+    --add-config retention.ms=172800000,retention.bytes=8589934592,segment.bytes=1073741824
+done
+```


### PR DESCRIPTION
## Problem

  Without `\` line continuations, each indented flag inside `bash -c "..."` in docker-compose.yaml was parsed as a separate shell command rather than part of the `kafka-topics`
  invocation. This caused topic creation to fail silently in CI.

  ## Fix

  Add `\` at the end of each continuation line in both `kafka-topics` commands.