### PR TITLE
fix bash for creating kafka topic

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -78,16 +78,8 @@ services:
         condition: service_healthy
     command: >
       bash -c "
-        kafka-topics --bootstrap-server osprey-kafka:29092 --create --if-not-exists \
-          --topic osprey.actions_input --partitions 3 --replication-factor 1 \
-          --config retention.ms=172800000 \
-          --config retention.bytes=8589934592 \
-          --config segment.bytes=1073741824 &&
-        kafka-topics --bootstrap-server osprey-kafka:29092 --create --if-not-exists \
-          --topic osprey.execution_results --partitions 3 --replication-factor 1 \
-          --config retention.ms=172800000 \
-          --config retention.bytes=8589934592 \
-          --config segment.bytes=1073741824 &&
+        kafka-topics --bootstrap-server osprey-kafka:29092 --create --if-not-exists --topic osprey.actions_input --partitions 3 --replication-factor 1 --config retention.ms=172800000 --config retention.bytes=8589934592 --config segment.bytes=1073741824 &&
+        kafka-topics --bootstrap-server osprey-kafka:29092 --create --if-not-exists --topic osprey.execution_results --partitions 3 --replication-factor 1 --config retention.ms=172800000 --config retention.bytes=8589934592 --config segment.bytes=1073741824 &&
         kafka-topics --bootstrap-server osprey-kafka:29092 --list
       "
 


### PR DESCRIPTION
## Description

Fixes the bash that was PR'd by @VINODvoid to fix Kafka retention times. PR was correct, but because YAML (sigh) the backslashes break the command...

## Checklist

- [x] Tests pass locally
- [x] `uv run ruff check .` passes (no unused imports or other lint errors)
- [x] `uv tool run fawltydeps --check-unused --pyenv .venv` passes (no unused dependencies)
- [ ] Updated `CHANGELOG.md` with my changes, if applicable

