### PR TITLE
build(deps): bump ajv from 8.17.1 to 8.20.0 in /osprey_ui

### DIFF
--- a/osprey_ui/package-lock.json
+++ b/osprey_ui/package-lock.json
@@ -12,7 +12,7 @@
         "@ant-design/icons": "^5.0.0",
         "@juggle/resize-observer": "3.2.0",
         "@sentry/browser": "5.12.1",
-        "ajv": "^8.17.1",
+        "ajv": "^8.20.0",
         "antd": "^5.0.0",
         "axios": "^1.6.0",
         "classnames": "2.2.6",
@@ -5755,9 +5755,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",

--- a/osprey_ui/package.json
+++ b/osprey_ui/package.json
@@ -7,7 +7,7 @@
     "@ant-design/icons": "^5.0.0",
     "@juggle/resize-observer": "3.2.0",
     "@sentry/browser": "5.12.1",
-    "ajv": "^8.17.1",
+    "ajv": "^8.20.0",
     "antd": "^5.0.0",
     "axios": "^1.6.0",
     "classnames": "2.2.6",


### PR DESCRIPTION
Split out from #263. Top-level ajv minor bump (8.17.1 → 8.20.0). Lockfile-only delta on the ajv@8 entry; no source uses ajv directly.

Build verified locally (`npm run build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)