### PR TITLE
build(deps): bump lodash from 4.17.19 to 4.18.1 in /osprey_ui

### DIFF
--- a/osprey_ui/package-lock.json
+++ b/osprey_ui/package-lock.json
@@ -27,7 +27,7 @@
         "highlight.js": "10.6.0",
         "history": "4.7.2",
         "invariant": "2.2.4",
-        "lodash": "4.17.19",
+        "lodash": "4.18.1",
         "rc-select": "11.3.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -9185,12 +9185,6 @@
         "eslint": "^8.1.0"
       }
     },
-    "node_modules/eslint-plugin-flowtype/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "license": "MIT"
-    },
     "node_modules/eslint-plugin-import": {
       "version": "2.32.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
@@ -11217,12 +11211,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/html-webpack-plugin/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "license": "MIT"
     },
     "node_modules/htmlparser2": {
       "version": "6.1.0",
@@ -14646,9 +14634,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -17162,12 +17150,6 @@
         "renderkid": "^3.0.0"
       }
     },
-    "node_modules/pretty-error/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "license": "MIT"
-    },
     "node_modules/pretty-format": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
@@ -18648,12 +18630,6 @@
         "lodash": "^4.17.21",
         "strip-ansi": "^6.0.1"
       }
-    },
-    "node_modules/renderkid/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "license": "MIT"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -21748,12 +21724,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/workbox-build/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "license": "MIT"
     },
     "node_modules/workbox-build/node_modules/source-map": {
       "version": "0.8.0-beta.0",

--- a/osprey_ui/package.json
+++ b/osprey_ui/package.json
@@ -22,7 +22,7 @@
     "highlight.js": "10.6.0",
     "history": "4.7.2",
     "invariant": "2.2.4",
-    "lodash": "4.17.19",
+    "lodash": "4.18.1",
     "rc-select": "11.3.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
Split out from #263. lodash 4.17.19 → 4.18.1.

Note: 4.18 is the first non-patch lodash release since 4.17.21 (which sat unchanged for ~5 years). Despite the minor bump, the 4.18 line is brand new (March/April 2026), so worth eyeballing CI carefully.

All call sites use stable named helpers (`isEmpty`, `debounce`, `isEqual`, `sum`, `set`, `chunk`, `memoize`, `sample`, `max`, `findIndex`) — no usage of anything that's been documented as changed.

Build verified locally (\`npm run build\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)