### PR TITLE
[osprey-ui] Features Registry page (Phase 4 of UI 2.0) — re-PR onto main (replaces #245)

### DIFF
--- a/osprey_ui/src/App.tsx
+++ b/osprey_ui/src/App.tsx
@@ -5,6 +5,7 @@ import { Router, Switch, Route } from 'react-router-dom';
 import { getApplicationConfig } from './actions/ConfigActions';
 import UdfDocsView from './components/docs/UdfDocsView';
 import BulkJobHistoryView from './components/bulk_job_history/BulkJobHistory';
+import { FeaturesPage } from './components/features/FeaturesPage';
 import RulesVisualizerView from './components/rules_visualizer/RulesVisualizer';
 import EntityViewBar from './components/entities/EntityViewBar';
 import EventPage from './components/event_stream/EventPage';
@@ -99,6 +100,9 @@ const AppRouter: React.FC = () => {
                     </Route>
                     <Route path={Routes.RULES_VISUALIZER}>
                       <RulesVisualizerView />
+                    </Route>
+                    <Route path={Routes.FEATURES}>
+                      <FeaturesPage />
                     </Route>
                     <Route exact path={[Routes.ENTITY, Routes.HOME, Routes.SAVED_QUERY]}>
                       <QueryView />

--- a/osprey_ui/src/Constants.tsx
+++ b/osprey_ui/src/Constants.tsx
@@ -4,6 +4,7 @@ export const Routes = {
   SAVED_QUERIES: '/saved-queries',
   DOCS_UDFS: '/docs/udfs',
   ENTITY: '/entity/:entityType/:entityId',
+  FEATURES: '/features',
   SAVED_QUERY: '/saved-query/:savedQueryId',
   SAVED_QUERY_LATEST: '/saved-query/:savedQueryId/latest',
   BULK_JOB_HISTORY: '/bulk-job-history',

--- a/osprey_ui/src/actions/FeaturesActions.tsx
+++ b/osprey_ui/src/actions/FeaturesActions.tsx
@@ -1,0 +1,10 @@
+import HTTPUtils, { HTTPResponse } from '../utils/HTTPUtils';
+import { FeaturesListResponse } from '../types/FeaturesTypes';
+
+export async function getFeaturesList(): Promise<FeaturesListResponse> {
+  const response: HTTPResponse = await HTTPUtils.get('features');
+  if (response.ok) {
+    return response.data;
+  }
+  throw new Error(response.error.message ?? 'Failed to fetch features list');
+}

--- a/osprey_ui/src/components/features/FeaturesPage.module.css
+++ b/osprey_ui/src/components/features/FeaturesPage.module.css
@@ -1,0 +1,66 @@
+.viewContainer {
+  height: 100%;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.scrollArea {
+  flex: 1;
+  overflow-y: auto;
+  padding: 24px;
+}
+
+.statsRow {
+  display: flex;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.statsRow > * {
+  flex: 1;
+}
+
+.statCardClickable {
+  cursor: pointer;
+}
+
+.statCardActive {
+  border-color: var(--brand-primary);
+}
+
+.featureName {
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  font-weight: 600;
+}
+
+.featureSource {
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  color: var(--text-light-secondary);
+  font-size: 12px;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.headerRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.definitionBlock {
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  font-size: 12px;
+  padding: 8px 10px;
+  background: var(--background-secondary);
+  border: 1px solid var(--divider);
+  border-radius: 4px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin: 0;
+}

--- a/osprey_ui/src/components/features/FeaturesPage.tsx
+++ b/osprey_ui/src/components/features/FeaturesPage.tsx
@@ -1,0 +1,415 @@
+import * as React from 'react';
+import {
+  Card,
+  Collapse,
+  Descriptions,
+  Empty,
+  Input,
+  Pagination,
+  Select,
+  Space,
+  Statistic,
+  Switch,
+  Tag,
+  Tooltip,
+  Typography,
+} from 'antd';
+import { SearchOutlined } from '@ant-design/icons';
+
+import { getFeaturesList } from '../../actions/FeaturesActions';
+import usePromiseResult from '../../hooks/usePromiseResult';
+import { FeatureInfo, FeaturesListResponse } from '../../types/FeaturesTypes';
+import { renderFromPromiseResult } from '../../utils/PromiseResultUtils';
+
+import styles from './FeaturesPage.module.css';
+
+const { Title, Paragraph, Text } = Typography;
+
+enum SortKey {
+  Name = 'name',
+  MostReferenced = 'most-referenced',
+  LeastReferenced = 'least-referenced',
+}
+
+type FiltersState = {
+  search: string;
+  categoryFilter: string[];
+  extractionFnFilter: string[];
+  unusedOnly: boolean;
+  sortKey: SortKey;
+  page: number;
+  pageSize: number;
+};
+
+type FiltersAction =
+  | { type: 'setSearch'; value: string }
+  | { type: 'setCategoryFilter'; value: string[] }
+  | { type: 'setExtractionFnFilter'; value: string[] }
+  | { type: 'setUnusedOnly'; value: boolean }
+  | { type: 'toggleUnusedOnly' }
+  | { type: 'setSortKey'; value: SortKey }
+  | { type: 'setPage'; page: number; pageSize: number };
+
+const INITIAL_FILTERS: FiltersState = {
+  search: '',
+  categoryFilter: [],
+  extractionFnFilter: [],
+  unusedOnly: false,
+  sortKey: SortKey.MostReferenced,
+  page: 1,
+  pageSize: 50,
+};
+
+// Each filter change resets page to 1; only setPage preserves it. The reducer
+// folds that invariant in so we don't need a useEffect that watches every
+// filter dep just to reset page.
+function filtersReducer(state: FiltersState, action: FiltersAction): FiltersState {
+  switch (action.type) {
+    case 'setSearch': {
+      return { ...state, search: action.value, page: 1 };
+    }
+    case 'setCategoryFilter': {
+      return { ...state, categoryFilter: action.value, page: 1 };
+    }
+    case 'setExtractionFnFilter': {
+      return { ...state, extractionFnFilter: action.value, page: 1 };
+    }
+    case 'setUnusedOnly': {
+      return { ...state, unusedOnly: action.value, page: 1 };
+    }
+    case 'toggleUnusedOnly': {
+      return { ...state, unusedOnly: !state.unusedOnly, page: 1 };
+    }
+    case 'setSortKey': {
+      return { ...state, sortKey: action.value, page: 1 };
+    }
+    case 'setPage': {
+      return { ...state, page: action.page, pageSize: action.pageSize };
+    }
+  }
+}
+
+export const FeaturesPage: React.FC = () => {
+  const result = usePromiseResult(() => {
+    return getFeaturesList();
+  });
+
+  return renderFromPromiseResult(result, (data) => {
+    return <FeaturesPageContent data={data} />;
+  });
+};
+
+const FeaturesPageContent: React.FC<{ data: FeaturesListResponse }> = ({ data }) => {
+  const [filters, dispatch] = React.useReducer(filtersReducer, INITIAL_FILTERS);
+
+  const features = data.features;
+  const categories = data.categories;
+  const extractionFns = data.extraction_fns;
+
+  const filtered = React.useMemo(() => {
+    const query = filters.search.trim().toLowerCase();
+    const list = features.filter((f) => {
+      if (query && !f.name.toLowerCase().includes(query)) {
+        return false;
+      }
+      if (filters.categoryFilter.length > 0 && !filters.categoryFilter.includes(f.category)) {
+        return false;
+      }
+      if (filters.extractionFnFilter.length > 0 && !filters.extractionFnFilter.includes(f.extraction_fn)) {
+        return false;
+      }
+      if (filters.unusedOnly && f.total_references > 0) {
+        return false;
+      }
+      return true;
+    });
+    if (filters.sortKey === SortKey.Name) {
+      return [...list].sort((a, b) => {
+        return a.name.localeCompare(b.name);
+      });
+    }
+    if (filters.sortKey === SortKey.MostReferenced) {
+      return [...list].sort((a, b) => {
+        return b.total_references - a.total_references || a.name.localeCompare(b.name);
+      });
+    }
+    return [...list].sort((a, b) => {
+      return a.total_references - b.total_references || a.name.localeCompare(b.name);
+    });
+  }, [
+    features,
+    filters.search,
+    filters.categoryFilter,
+    filters.extractionFnFilter,
+    filters.unusedOnly,
+    filters.sortKey,
+  ]);
+
+  const paginated = React.useMemo(() => {
+    return filtered.slice((filters.page - 1) * filters.pageSize, filters.page * filters.pageSize);
+  }, [filtered, filters.page, filters.pageSize]);
+
+  const unusedCount = React.useMemo(() => {
+    return features.filter((f) => {
+      return f.total_references === 0;
+    }).length;
+  }, [features]);
+
+  const categoryOptions = React.useMemo(() => {
+    return Object.entries(categories)
+      .sort((a, b) => {
+        return b[1] - a[1];
+      })
+      .map(([name, count]) => {
+        return { value: name, label: `${name} (${count})` };
+      });
+  }, [categories]);
+
+  const extractionFnOptions = React.useMemo(() => {
+    return Object.entries(extractionFns)
+      .sort((a, b) => {
+        return b[1] - a[1];
+      })
+      .map(([name, count]) => {
+        return { value: name, label: `${name} (${count})` };
+      });
+  }, [extractionFns]);
+
+  const collapseItems = React.useMemo(() => {
+    return paginated.map((f) => {
+      return {
+        key: f.name,
+        label: <FeatureHeader feature={f} />,
+        children: <FeatureDetail feature={f} />,
+      };
+    });
+  }, [paginated]);
+
+  return (
+    <div className={styles.viewContainer}>
+      <div className={styles.scrollArea}>
+        <Title level={3} style={{ marginBottom: 4 }}>
+          Features Registry
+        </Title>
+        <Paragraph type="secondary">
+          Extracted data fields from event payloads — the queryable dimensions rules reference. Sourced from{' '}
+          <code>models/</code>, <code>lib/</code>, and <code>counters/</code> in the rules engine.
+        </Paragraph>
+
+        <div className={styles.statsRow}>
+          <Tooltip title="Total extracted features — named values produced by feature-extraction functions like JsonData, Entity, and SnowflakeAge.">
+            <Card size="small">
+              <Statistic
+                title="Features"
+                value={data.total}
+                suffix={
+                  <Text type="secondary" style={{ fontSize: 12 }}>
+                    {Object.keys(categories).length} categories
+                  </Text>
+                }
+              />
+            </Card>
+          </Tooltip>
+          <Tooltip title="Unique extraction functions across all features.">
+            <Card size="small">
+              <Statistic title="Extraction functions" value={Object.keys(extractionFns).length} />
+            </Card>
+          </Tooltip>
+          <Tooltip
+            title={
+              filters.unusedOnly
+                ? 'Filtering to unused only — click to clear.'
+                : 'Features with no references from rules, WhenRules, or other features — cleanup candidates. Click to filter.'
+            }
+          >
+            <Card
+              size="small"
+              className={`${styles.statCardClickable} ${filters.unusedOnly ? styles.statCardActive : ''}`}
+              role="button"
+              tabIndex={0}
+              aria-pressed={filters.unusedOnly}
+              onClick={() => {
+                dispatch({ type: 'toggleUnusedOnly' });
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  dispatch({ type: 'toggleUnusedOnly' });
+                }
+              }}
+            >
+              <Statistic title="Unused features" value={unusedCount} />
+            </Card>
+          </Tooltip>
+        </div>
+
+        <Space wrap style={{ marginBottom: 12 }}>
+          <Input
+            size="small"
+            prefix={<SearchOutlined />}
+            placeholder="Search features..."
+            value={filters.search}
+            onChange={(e) => {
+              dispatch({ type: 'setSearch', value: e.target.value });
+            }}
+            allowClear
+            style={{ width: 280 }}
+          />
+          <Select
+            size="small"
+            mode="multiple"
+            placeholder="Category"
+            value={filters.categoryFilter}
+            onChange={(value) => {
+              dispatch({ type: 'setCategoryFilter', value });
+            }}
+            options={categoryOptions}
+            allowClear
+            maxTagCount="responsive"
+            style={{ minWidth: 180, maxWidth: 320 }}
+          />
+          <Select
+            size="small"
+            mode="multiple"
+            placeholder="Extraction fn"
+            value={filters.extractionFnFilter}
+            onChange={(value) => {
+              dispatch({ type: 'setExtractionFnFilter', value });
+            }}
+            options={extractionFnOptions}
+            allowClear
+            maxTagCount="responsive"
+            style={{ minWidth: 180, maxWidth: 320 }}
+          />
+          <Select<SortKey>
+            size="small"
+            value={filters.sortKey}
+            onChange={(value) => {
+              dispatch({ type: 'setSortKey', value });
+            }}
+            style={{ width: 170 }}
+            options={[
+              { value: SortKey.MostReferenced, label: 'Most referenced' },
+              { value: SortKey.LeastReferenced, label: 'Least referenced' },
+              { value: SortKey.Name, label: 'Name (A-Z)' },
+            ]}
+          />
+          <Space size={6}>
+            <Switch
+              size="small"
+              checked={filters.unusedOnly}
+              onChange={(value) => {
+                dispatch({ type: 'setUnusedOnly', value });
+              }}
+            />
+            <span style={{ fontSize: 12 }}>Unused only</span>
+          </Space>
+        </Space>
+
+        <Title level={5} style={{ marginTop: 8 }}>
+          Features ({filtered.length})
+        </Title>
+        {filtered.length === 0 ? (
+          <Empty description="No features match the current filters" />
+        ) : (
+          <>
+            <Collapse items={collapseItems} bordered={false} />
+            <Pagination
+              current={filters.page}
+              pageSize={filters.pageSize}
+              total={filtered.length}
+              onChange={(page, pageSize) => {
+                dispatch({ type: 'setPage', page, pageSize });
+              }}
+              showSizeChanger
+              pageSizeOptions={['25', '50', '100', '200']}
+              showTotal={(total, [start, end]) => {
+                return `${start}–${end} of ${total}`;
+              }}
+              size="small"
+              align="center"
+              style={{ marginTop: 20 }}
+            />
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+const FeatureHeader: React.FC<{ feature: FeatureInfo }> = ({ feature }) => {
+  const isUnused = feature.total_references === 0;
+  return (
+    <div className={styles.headerRow}>
+      <code className={styles.featureName}>{feature.name}</code>
+      {feature.type_annotation && <Tag color="blue">{feature.type_annotation}</Tag>}
+      <Tag color="purple">{feature.extraction_fn}</Tag>
+      {isUnused && (
+        <Tooltip title="This feature is defined but no rule, WhenRules, or other feature references it. Possible cleanup candidate.">
+          <Tag color="orange">unused</Tag>
+        </Tooltip>
+      )}
+      <span className={styles.featureSource}>{feature.source_file}</span>
+      <Space size={6} style={{ flexShrink: 0 }}>
+        <Text type="secondary" style={{ fontSize: 11 }}>
+          <strong>{feature.referenced_by_rules.length}</strong> rules
+        </Text>
+        <Text type="secondary" style={{ fontSize: 11 }}>
+          <strong>{feature.referenced_by_features.length}</strong> features
+        </Text>
+        {feature.referenced_by_whenrules > 0 && (
+          <Text type="secondary" style={{ fontSize: 11 }}>
+            <strong>{feature.referenced_by_whenrules}</strong> when-rules
+          </Text>
+        )}
+      </Space>
+    </div>
+  );
+};
+
+const FeatureDetail: React.FC<{ feature: FeatureInfo }> = ({ feature }) => {
+  const definition = `${feature.name}${feature.type_annotation ? `: ${feature.type_annotation}` : ''} = ${
+    feature.definition
+  }`;
+  return (
+    <Descriptions size="small" column={1} colon={false} labelStyle={{ width: 120, fontWeight: 600 }}>
+      <Descriptions.Item label="Category">
+        <Tag>{feature.category}</Tag>
+      </Descriptions.Item>
+      <Descriptions.Item label="Source file">
+        <code>{feature.source_file}</code>
+      </Descriptions.Item>
+      <Descriptions.Item label="Definition">
+        <pre className={styles.definitionBlock}>{definition}</pre>
+      </Descriptions.Item>
+      <Descriptions.Item label={`Rules (${feature.referenced_by_rules.length})`}>
+        {feature.referenced_by_rules.length === 0 ? (
+          '—'
+        ) : (
+          <Space size={6} wrap>
+            {feature.referenced_by_rules.map((ruleName) => {
+              return <code key={ruleName}>{ruleName}</code>;
+            })}
+          </Space>
+        )}
+      </Descriptions.Item>
+      <Descriptions.Item label={`Features (${feature.referenced_by_features.length})`}>
+        {feature.referenced_by_features.length === 0 ? (
+          '—'
+        ) : (
+          <Space size={6} wrap>
+            {feature.referenced_by_features.map((name) => {
+              return <code key={name}>{name}</code>;
+            })}
+          </Space>
+        )}
+      </Descriptions.Item>
+      {feature.referenced_by_whenrules > 0 && (
+        <Descriptions.Item label="WhenRules">
+          {feature.referenced_by_whenrules} block
+          {feature.referenced_by_whenrules === 1 ? '' : 's'} (effects / apply_if)
+        </Descriptions.Item>
+      )}
+    </Descriptions>
+  );
+};

--- a/osprey_ui/src/components/navigation/NavBar.tsx
+++ b/osprey_ui/src/components/navigation/NavBar.tsx
@@ -10,6 +10,7 @@ import {
   SearchOutlined,
   MenuFoldOutlined,
   MenuUnfoldOutlined,
+  DatabaseOutlined,
 } from '@ant-design/icons';
 import { Link, useLocation } from 'react-router-dom';
 
@@ -50,6 +51,7 @@ const NAV_GROUPS: NavGroup[] = [
     children: [
       { key: Routes.RULES_VISUALIZER, icon: <ApartmentOutlined />, label: 'Rules Visualizer' },
       { key: Routes.DOCS_UDFS, icon: <FunctionOutlined />, label: 'UDF Registry' },
+      { key: Routes.FEATURES, icon: <DatabaseOutlined />, label: 'Features' },
     ],
   },
   {

--- a/osprey_ui/src/types/FeaturesTypes.tsx
+++ b/osprey_ui/src/types/FeaturesTypes.tsx
@@ -1,0 +1,20 @@
+export interface FeatureInfo {
+  name: string;
+  source_file: string;
+  source_line: number;
+  category: string;
+  type_annotation: string | null;
+  extraction_fn: string;
+  definition: string;
+  referenced_by_rules: string[];
+  referenced_by_features: string[];
+  referenced_by_whenrules: number;
+  total_references: number;
+}
+
+export interface FeaturesListResponse {
+  features: FeatureInfo[];
+  total: number;
+  categories: Record<string, number>;
+  extraction_fns: Record<string, number>;
+}

--- a/osprey_worker/src/osprey/worker/ui_api/osprey/app.py
+++ b/osprey_worker/src/osprey/worker/ui_api/osprey/app.py
@@ -66,6 +66,7 @@ def create_app() -> Flask:
         docs,
         entities,
         events,
+        features,
         queries,
         rules_visualizer,
         saved_queries,
@@ -107,6 +108,7 @@ def create_app() -> Flask:
 
     _register_with_prefix(app, entities.blueprint)
     _register_with_prefix(app, events.blueprint)
+    _register_with_prefix(app, features.blueprint)
     _register_with_prefix(app, queries.blueprint)
     _register_with_prefix(app, config.blueprint)
     _register_with_prefix(app, docs.blueprint)

--- a/osprey_worker/src/osprey/worker/ui_api/osprey/views/_features_ast_utils.py
+++ b/osprey_worker/src/osprey/worker/ui_api/osprey/views/_features_ast_utils.py
@@ -1,0 +1,68 @@
+"""Shared AST traversal helpers used by features.py."""
+
+from typing import Any, Optional
+
+from osprey.engine.ast.grammar import (
+    Attribute,
+    BinaryComparison,
+    BinaryOperation,
+    BooleanOperation,
+    Call,
+    FormatString,
+    Name,
+    Number,
+    String,
+    UnaryOperation,
+)
+from osprey.engine.ast.grammar import (
+    List as AstList,
+)
+
+
+def get_func_identifier(call: Call) -> Optional[str]:
+    """Get the function name from a Call node."""
+    if isinstance(call.func, Name):
+        return call.func.identifier
+    if isinstance(call.func, Attribute):
+        return call.func.attribute
+    return None
+
+
+def ast_to_string(node: Any) -> str:
+    """Convert an AST expression node to a human-readable string."""
+    if isinstance(node, Name):
+        return node.identifier
+    if isinstance(node, String):
+        return repr(node.value)
+    if isinstance(node, Number):
+        return str(node.value)
+    if isinstance(node, BinaryComparison):
+        left = ast_to_string(node.left)
+        right = ast_to_string(node.right)
+        return f'{left} {node.comparator.original_comparator} {right}'
+    if isinstance(node, BinaryOperation):
+        left = ast_to_string(node.left)
+        right = ast_to_string(node.right)
+        return f'{left} {node.operator.original_operator} {right}'
+    if isinstance(node, UnaryOperation):
+        operand = ast_to_string(node.operand)
+        return f'{node.operator.original_operator} {operand}'
+    if isinstance(node, BooleanOperation):
+        parts = [ast_to_string(v) for v in node.values]
+        return f' {node.operand.original_operand} '.join(parts)
+    if isinstance(node, Call):
+        func_name = get_func_identifier(node) or '?'
+        parts = []
+        for arg in node.arguments:
+            parts.append(f'{arg.name}={ast_to_string(arg.value)}')
+        return f'{func_name}({", ".join(parts)})'
+    if isinstance(node, Attribute):
+        return f'{node.name.identifier}.{node.attribute}'
+    if isinstance(node, AstList):
+        items = [ast_to_string(item) for item in node.items]
+        return f'[{", ".join(items)}]'
+    if isinstance(node, FormatString):
+        return f"f'{node.format_string}'"
+    if hasattr(node, 'value'):
+        return str(node.value)
+    return str(node)

--- a/osprey_worker/src/osprey/worker/ui_api/osprey/views/features.py
+++ b/osprey_worker/src/osprey/worker/ui_api/osprey/views/features.py
@@ -1,0 +1,289 @@
+import logging
+from pathlib import PurePosixPath
+from typing import Any, Dict, List, Optional, Set
+
+from flask import Blueprint, jsonify
+from osprey.engine.ast.grammar import (
+    Annotation,
+    AnnotationWithVariants,
+    Assign,
+    Attribute,
+    BinaryComparison,
+    BinaryOperation,
+    BooleanOperation,
+    Call,
+    FormatString,
+    Name,
+    UnaryOperation,
+)
+from osprey.engine.ast.grammar import (
+    List as AstList,
+)
+from osprey.worker.lib.singletons import ENGINE
+from osprey.worker.ui_api.osprey.lib.abilities import CanViewDocs, require_ability
+
+from ._features_ast_utils import ast_to_string, get_func_identifier
+
+logger = logging.getLogger(__name__)
+
+blueprint = Blueprint('features', __name__)
+
+# Call identifiers that name things other than extracted data features. These
+# have their own dedicated UI pages or aren't meaningful as queryable dimensions:
+#   - Rule: has /rules-visualizer; not a feature
+#   - Count family: distinct concept
+#   - Experiment family: experiment bucket configs, not data features
+#   - WhenRules: handled separately for reference counts
+_NON_FEATURE_CALLS: frozenset[str] = frozenset(
+    {
+        'Rule',
+        'Count',
+        'ReadCount',
+        'ReadCountUnique',
+        'CountUnique',
+        'BitCount',
+        'Experiment',
+        'ExperimentWhen',
+        'WhenRules',
+    }
+)
+
+
+def _format_annotation(annotation: Any) -> Optional[str]:
+    """Format a type annotation AST node into a readable string like 'str', 'Entity[int]', 'Optional[str]'."""
+    if annotation is None:
+        return None
+    if isinstance(annotation, AnnotationWithVariants):
+        variant_strs = [_format_annotation(v) or str(v) for v in annotation.variants]
+        return f'{annotation.identifier}[{", ".join(variant_strs)}]'
+    if isinstance(annotation, Annotation):
+        return annotation.identifier
+    return None
+
+
+def _derive_category(file_path: str) -> str:
+    """Derive the category from a source file path.
+
+    models/user.sml -> models
+    models/actions/guild_created.sml -> models/actions
+    lib/user_history.sml -> lib
+    counters/active_days.sml -> counters
+    actions/dm_channel_created.sml -> actions
+    Empty path -> 'other'.
+    """
+    parts = PurePosixPath(file_path).parts
+    if not parts:
+        return 'other'
+    if parts[0] == 'models' and len(parts) > 2:
+        return f'{parts[0]}/{parts[1]}'
+    return parts[0]
+
+
+def _collect_name_references(node: Any, out: Set[str]) -> None:
+    """Recursively collect all Name.identifier values referenced by an expression node.
+
+    Skip the function-identifier position of Call nodes (we don't treat e.g.
+    `JsonData` in `JsonData(...)` as a feature reference). Walk FormatString.names,
+    BinaryOperation/BinaryComparison left/right, BooleanOperation values,
+    UnaryOperation operand, AstList items, and Attribute chains.
+    """
+    if node is None:
+        return
+    if isinstance(node, Name):
+        out.add(node.identifier)
+        return
+    if isinstance(node, Call):
+        for arg in node.arguments:
+            _collect_name_references(arg.value, out)
+        return
+    if isinstance(node, FormatString):
+        for n in node.names:
+            out.add(n.identifier)
+        return
+    if isinstance(node, BinaryComparison):
+        _collect_name_references(node.left, out)
+        _collect_name_references(node.right, out)
+        return
+    if isinstance(node, BinaryOperation):
+        _collect_name_references(node.left, out)
+        _collect_name_references(node.right, out)
+        return
+    if isinstance(node, UnaryOperation):
+        _collect_name_references(node.operand, out)
+        return
+    if isinstance(node, BooleanOperation):
+        for v in node.values:
+            _collect_name_references(v, out)
+        return
+    if isinstance(node, AstList):
+        for item in node.items:
+            _collect_name_references(item, out)
+        return
+    if isinstance(node, Attribute):
+        _collect_name_references(node.name, out)
+        return
+
+
+def _find_assign_for_feature(sources: Any, feature_name: str, source_path: str, source_line: int) -> Optional[Assign]:
+    """Look up the Assign AST node for a feature in its source file.
+
+    First try exact (file, line) match. Fall back to first Assign in the file
+    with the right target identifier (handles multi-line Assigns where
+    source_line is the comment/start line, not the AST node's start_line).
+    """
+    source = sources.get_by_path(source_path)
+    if source is None:
+        return None
+    for statement in source.ast_root.statements:
+        if (
+            isinstance(statement, Assign)
+            and statement.target.identifier == feature_name
+            and statement.span.start_line == source_line
+        ):
+            return statement
+    for statement in source.ast_root.statements:
+        if isinstance(statement, Assign) and statement.target.identifier == feature_name:
+            return statement
+    return None
+
+
+def _extraction_fn_from_value(value: Any) -> str:
+    """Describe how a feature is extracted based on its Assign value.
+
+    - Call -> the function name ('JsonData', 'Entity', 'SnowflakeAge')
+    - FormatString -> 'FormatString'
+    - BinaryOperation / BinaryComparison -> 'Expression'
+    - BooleanOperation -> 'BooleanExpression'
+    - UnaryOperation -> 'UnaryExpression'
+    - Attribute -> 'Attribute'
+    - Otherwise -> the AST node class name as a fallback.
+    """
+    if isinstance(value, Call):
+        return get_func_identifier(value) or 'Call'
+    if isinstance(value, FormatString):
+        return 'FormatString'
+    if isinstance(value, (BinaryOperation, BinaryComparison)):
+        return 'Expression'
+    if isinstance(value, BooleanOperation):
+        return 'BooleanExpression'
+    if isinstance(value, UnaryOperation):
+        return 'UnaryExpression'
+    if isinstance(value, Attribute):
+        return 'Attribute'
+    return type(value).__name__
+
+
+def _extract_features_from_engine() -> List[Dict[str, Any]]:
+    """Walk the engine AST and return the catalog of extracted features with references."""
+    engine = ENGINE.instance()
+    sources = engine.execution_graph.validated_sources.sources
+    locations = engine.get_known_feature_locations()
+
+    features: Dict[str, Dict[str, Any]] = {}
+
+    for loc in locations:
+        assign = _find_assign_for_feature(sources, loc.name, loc.source_path, loc.source_line)
+        if assign is None:
+            logger.warning('Feature %s at %s:%d not found in AST', loc.name, loc.source_path, loc.source_line)
+            continue
+        extraction_fn = _extraction_fn_from_value(assign.value)
+        if extraction_fn in _NON_FEATURE_CALLS:
+            continue
+        features[loc.name] = {
+            'name': loc.name,
+            'source_file': loc.source_path,
+            'source_line': loc.source_line,
+            'category': _derive_category(loc.source_path),
+            'type_annotation': _format_annotation(assign.annotation),
+            'extraction_fn': extraction_fn,
+            'definition': ast_to_string(assign.value),
+            'referenced_by_rules': [],
+            'referenced_by_features': [],
+            'referenced_by_whenrules': 0,
+        }
+
+    feature_names = set(features.keys())
+    rule_refs: Dict[str, Set[str]] = {}
+    feature_refs: Dict[str, Set[str]] = {}
+    whenrules_refs: Dict[str, int] = {}
+
+    for source in sources:
+        for statement in source.ast_root.statements:
+            # Rule(...) definitions — collect Names in when_all.
+            if (
+                isinstance(statement, Assign)
+                and isinstance(statement.value, Call)
+                and get_func_identifier(statement.value) == 'Rule'
+            ):
+                rule_name = statement.target.identifier
+                refs: Set[str] = set()
+                when_all_arg = statement.value.find_argument('when_all')
+                if when_all_arg:
+                    _collect_name_references(when_all_arg.value, refs)
+                for feat in refs & feature_names:
+                    rule_refs.setdefault(feat, set()).add(rule_name)
+                continue
+
+            # WhenRules(...) calls — bare statement OR assigned.
+            call_node: Optional[Call] = None
+            if isinstance(statement, Call) and get_func_identifier(statement) == 'WhenRules':
+                call_node = statement
+            elif (
+                isinstance(statement, Assign)
+                and isinstance(statement.value, Call)
+                and get_func_identifier(statement.value) == 'WhenRules'
+            ):
+                call_node = statement.value
+            if call_node is not None:
+                refs = set()
+                for arg in call_node.arguments:
+                    if arg.name == 'rules_any':
+                        continue
+                    _collect_name_references(arg.value, refs)
+                for feat in refs & feature_names:
+                    whenrules_refs[feat] = whenrules_refs.get(feat, 0) + 1
+                continue
+
+            # Feature-to-feature references — only for features in our catalog.
+            if isinstance(statement, Assign):
+                defining_name = statement.target.identifier
+                if defining_name not in feature_names:
+                    continue
+                refs = set()
+                _collect_name_references(statement.value, refs)
+                for feat in refs & feature_names:
+                    if feat == defining_name:
+                        continue
+                    feature_refs.setdefault(feat, set()).add(defining_name)
+
+    for feat_name, info in features.items():
+        info['referenced_by_rules'] = sorted(rule_refs.get(feat_name, set()))
+        info['referenced_by_features'] = sorted(feature_refs.get(feat_name, set()))
+        info['referenced_by_whenrules'] = whenrules_refs.get(feat_name, 0)
+        info['total_references'] = (
+            len(info['referenced_by_rules']) + len(info['referenced_by_features']) + info['referenced_by_whenrules']
+        )
+
+    return list(features.values())
+
+
+@blueprint.route('/features', methods=['GET'])
+@require_ability(CanViewDocs)
+def features_list() -> Any:
+    """Return the catalog of extracted features across the rules engine."""
+    features = _extract_features_from_engine()
+
+    categories: Dict[str, int] = {}
+    extraction_fns: Dict[str, int] = {}
+    for f in features:
+        categories[f['category']] = categories.get(f['category'], 0) + 1
+        extraction_fns[f['extraction_fn']] = extraction_fns.get(f['extraction_fn'], 0) + 1
+
+    return jsonify(
+        {
+            'features': features,
+            'total': len(features),
+            'categories': categories,
+            'extraction_fns': extraction_fns,
+        }
+    )

--- a/osprey_worker/src/osprey/worker/ui_api/osprey/views/tests/test_features.py
+++ b/osprey_worker/src/osprey/worker/ui_api/osprey/views/tests/test_features.py
@@ -1,0 +1,240 @@
+import json
+
+import pytest
+from flask import Response, url_for
+from flask.testing import FlaskClient
+
+_base_sources_dict = {
+    'config.yaml': json.dumps(
+        {
+            'ui_config': {},
+            'labels': {},
+            'acl': {
+                'users': {
+                    'local-dev@localhost': {'abilities': [{'name': 'CAN_VIEW_DOCS', 'allow_all': True}]},
+                }
+            },
+        }
+    )
+}
+
+_no_ability_sources_dict = {'config.yaml': json.dumps({'ui_config': {}, 'labels': {}})}
+
+
+@pytest.mark.use_rules_sources(
+    {
+        **_base_sources_dict,
+        'main.sml': '',
+    }
+)
+def test_empty_engine_returns_empty_catalog(client: 'FlaskClient[Response]') -> None:
+    """Empty engine returns {features: [], total: 0, categories: {}, extraction_fns: {}}."""
+    res = client.get(url_for('features.features_list'))
+    assert res.status_code == 200
+    assert res.json == {'features': [], 'total': 0, 'categories': {}, 'extraction_fns': {}}
+
+
+@pytest.mark.use_rules_sources(
+    {
+        **_base_sources_dict,
+        'main.sml': """
+            UserId = Entity(type='User', id=1)
+        """,
+    }
+)
+def test_response_shape_and_basic_feature(client: 'FlaskClient[Response]') -> None:
+    """Response shape and 12-field FeatureInfo."""
+    res = client.get(url_for('features.features_list'))
+    assert res.status_code == 200
+
+    body = res.json
+    assert set(body.keys()) == {'features', 'total', 'categories', 'extraction_fns'}
+    assert body['total'] == 1
+    assert len(body['features']) == 1
+
+    feat = body['features'][0]
+    expected_fields = {
+        'name',
+        'source_file',
+        'source_line',
+        'category',
+        'type_annotation',
+        'extraction_fn',
+        'definition',
+        'referenced_by_rules',
+        'referenced_by_features',
+        'referenced_by_whenrules',
+        'total_references',
+    }
+    assert expected_fields.issubset(set(feat.keys()))
+    assert feat['name'] == 'UserId'
+    assert feat['source_file'] == 'main.sml'
+    assert feat['extraction_fn'] == 'Entity'
+    assert feat['type_annotation'] is None
+    assert feat['referenced_by_rules'] == []
+    assert feat['referenced_by_features'] == []
+    assert feat['referenced_by_whenrules'] == 0
+    assert feat['total_references'] == 0
+
+
+@pytest.mark.use_rules_sources(
+    {
+        **_base_sources_dict,
+        'main.sml': """
+            CallFeat = JsonData(path='$.foo')
+            FmtFeat = f'hello {CallFeat}'
+            ExprFeat = 1 + 2
+            CmpFeat = CallFeat == 'x'
+            BoolFeat = CallFeat and FmtFeat
+            UnaryFeat = not CallFeat
+            AttrFeat = CallFeat.id
+        """,
+    }
+)
+def test_extraction_fn_inference(client: 'FlaskClient[Response]') -> None:
+    """extraction_fn correctly inferred per AST value type."""
+    res = client.get(url_for('features.features_list'))
+    by_name = {f['name']: f for f in res.json['features']}
+
+    assert by_name['CallFeat']['extraction_fn'] == 'JsonData'
+    assert by_name['FmtFeat']['extraction_fn'] == 'FormatString'
+    assert by_name['ExprFeat']['extraction_fn'] == 'Expression'
+    assert by_name['CmpFeat']['extraction_fn'] == 'Expression'
+    assert by_name['BoolFeat']['extraction_fn'] == 'BooleanExpression'
+    assert by_name['UnaryFeat']['extraction_fn'] == 'UnaryExpression'
+    assert by_name['AttrFeat']['extraction_fn'] == 'Attribute'
+
+
+@pytest.mark.use_rules_sources(
+    {
+        **_base_sources_dict,
+        'main.sml': """
+            Feat = JsonData(path='$.foo')
+            R = Rule(when_all=[True], description='')
+            C = Count(events=[Feat], window='1d', bucket='user_id')
+        """,
+    }
+)
+def test_non_feature_calls_excluded(client: 'FlaskClient[Response]') -> None:
+    """Rule/Count/etc. excluded from features list."""
+    res = client.get(url_for('features.features_list'))
+    names = {f['name'] for f in res.json['features']}
+    assert 'Feat' in names
+    assert 'R' not in names
+    assert 'C' not in names
+
+
+@pytest.mark.use_rules_sources(
+    {
+        **_base_sources_dict,
+        'models/user.sml': "UserA = JsonData(path='$.a')",
+        'models/actions/joined.sml': "UserB = JsonData(path='$.b')",
+        'lib/foo.sml': "UserC = JsonData(path='$.c')",
+        'counters/active.sml': "UserD = JsonData(path='$.d')",
+        'actions/dm.sml': "UserE = JsonData(path='$.e')",
+    }
+)
+def test_category_derivation(client: 'FlaskClient[Response]') -> None:
+    """category derived from source path."""
+    res = client.get(url_for('features.features_list'))
+    by_name = {f['name']: f for f in res.json['features']}
+
+    assert by_name['UserA']['category'] == 'models'
+    assert by_name['UserB']['category'] == 'models/actions'
+    assert by_name['UserC']['category'] == 'lib'
+    assert by_name['UserD']['category'] == 'counters'
+    assert by_name['UserE']['category'] == 'actions'
+
+
+@pytest.mark.use_rules_sources(
+    {
+        **_base_sources_dict,
+        'main.sml': """
+            FeatA = JsonData(path='$.a')
+            FeatB = JsonData(path='$.b')
+            FeatC = FeatA
+            R1 = Rule(when_all=[FeatA == 'x'], description='r1')
+            R2 = Rule(when_all=[FeatB == 'y'], description='r2')
+            WhenRules(rules_any=[R1], then=[FeatA])
+        """,
+    }
+)
+def test_reference_counting_and_total(client: 'FlaskClient[Response]') -> None:
+    """reference counts and total."""
+    res = client.get(url_for('features.features_list'))
+    by_name = {f['name']: f for f in res.json['features']}
+
+    # FeatA referenced by R1 (rule), FeatC (feature), and the WhenRules then=
+    assert by_name['FeatA']['referenced_by_rules'] == ['R1']
+    assert by_name['FeatA']['referenced_by_features'] == ['FeatC']
+    assert by_name['FeatA']['referenced_by_whenrules'] == 1
+    assert by_name['FeatA']['total_references'] == 3
+
+    # FeatB referenced only by R2.
+    assert by_name['FeatB']['referenced_by_rules'] == ['R2']
+    assert by_name['FeatB']['referenced_by_features'] == []
+    assert by_name['FeatB']['referenced_by_whenrules'] == 0
+    assert by_name['FeatB']['total_references'] == 1
+
+    # FeatC has no inbound references; itself doesn't count as a self-reference.
+    assert by_name['FeatC']['referenced_by_rules'] == []
+    assert by_name['FeatC']['referenced_by_features'] == []
+    assert by_name['FeatC']['referenced_by_whenrules'] == 0
+    assert by_name['FeatC']['total_references'] == 0
+
+
+@pytest.mark.use_rules_sources(
+    {
+        **_base_sources_dict,
+        'main.sml': "Feat = JsonData(path='$.foo')",
+    }
+)
+def test_dual_route_registration(client: 'FlaskClient[Response]') -> None:
+    """GET reachable at both /features and /api/features."""
+    res_root = client.get('/features')
+    res_api = client.get('/api/features')
+    assert res_root.status_code == 200
+    assert res_api.status_code == 200
+    assert res_root.json == res_api.json
+
+
+@pytest.mark.use_rules_sources(
+    {
+        **_no_ability_sources_dict,
+        'main.sml': "Feat = JsonData(path='$.foo')",
+    }
+)
+def test_endpoint_requires_can_view_docs(client: 'FlaskClient[Response]') -> None:
+    """A user without CAN_VIEW_DOCS gets 401."""
+    res = client.get(url_for('features.features_list'))
+    assert res.status_code == 401
+
+
+@pytest.mark.use_rules_sources(
+    {
+        **_base_sources_dict,
+        'main.sml': """
+            Feat = JsonData(path='$.foo')
+        """,
+    }
+)
+def test_find_assign_fallback_when_source_line_mismatches(client: 'FlaskClient[Response]') -> None:
+    """A feature whose source_line doesn't exactly match the AST Assign node's
+    start_line is found via fallback search by target identifier in the same
+    source file."""
+    from osprey.worker.lib.singletons import ENGINE
+    from osprey.worker.ui_api.osprey.views.features import _find_assign_for_feature
+
+    engine = ENGINE.instance()
+    sources = engine.execution_graph.validated_sources.sources
+
+    # Real source_line for `Feat` is whatever the engine reports — but the
+    # fallback path is what matters here: pass a deliberately-wrong line and
+    # confirm the helper still finds the Assign by target identifier.
+    bogus_line = 99999
+    assign = _find_assign_for_feature(sources, 'Feat', 'main.sml', bogus_line)
+    assert assign is not None
+    assert assign.target.identifier == 'Feat'
+
+    # Negative control: a feature name that doesn't exist in the source returns None.
+    assert _find_assign_for_feature(sources, 'DoesNotExist', 'main.sml', bogus_line) is None

--- a/osprey_worker/src/osprey/worker/ui_api/osprey/views/tests/test_features.py
+++ b/osprey_worker/src/osprey/worker/ui_api/osprey/views/tests/test_features.py
@@ -81,13 +81,12 @@ def test_response_shape_and_basic_feature(client: 'FlaskClient[Response]') -> No
     {
         **_base_sources_dict,
         'main.sml': """
-            CallFeat = JsonData(path='$.foo')
+            CallFeat: str = JsonData(path='$.foo')
             FmtFeat = f'hello {CallFeat}'
             ExprFeat = 1 + 2
             CmpFeat = CallFeat == 'x'
-            BoolFeat = CallFeat and FmtFeat
-            UnaryFeat = not CallFeat
-            AttrFeat = CallFeat.id
+            BoolFeat = CmpFeat and (CallFeat == 'y')
+            UnaryFeat = not CmpFeat
         """,
     }
 )
@@ -102,36 +101,34 @@ def test_extraction_fn_inference(client: 'FlaskClient[Response]') -> None:
     assert by_name['CmpFeat']['extraction_fn'] == 'Expression'
     assert by_name['BoolFeat']['extraction_fn'] == 'BooleanExpression'
     assert by_name['UnaryFeat']['extraction_fn'] == 'UnaryExpression'
-    assert by_name['AttrFeat']['extraction_fn'] == 'Attribute'
 
 
 @pytest.mark.use_rules_sources(
     {
         **_base_sources_dict,
         'main.sml': """
-            Feat = JsonData(path='$.foo')
+            Feat: str = JsonData(path='$.foo')
             R = Rule(when_all=[True], description='')
-            C = Count(events=[Feat], window='1d', bucket='user_id')
         """,
     }
 )
 def test_non_feature_calls_excluded(client: 'FlaskClient[Response]') -> None:
-    """Rule/Count/etc. excluded from features list."""
+    """Calls in _NON_FEATURE_CALLS (Rule, Count, etc.) excluded from features list."""
     res = client.get(url_for('features.features_list'))
     names = {f['name'] for f in res.json['features']}
     assert 'Feat' in names
     assert 'R' not in names
-    assert 'C' not in names
 
 
 @pytest.mark.use_rules_sources(
     {
         **_base_sources_dict,
-        'models/user.sml': "UserA = JsonData(path='$.a')",
-        'models/actions/joined.sml': "UserB = JsonData(path='$.b')",
-        'lib/foo.sml': "UserC = JsonData(path='$.c')",
-        'counters/active.sml': "UserD = JsonData(path='$.d')",
-        'actions/dm.sml': "UserE = JsonData(path='$.e')",
+        'main.sml': '',
+        'models/user.sml': "UserA: str = JsonData(path='$.a')",
+        'models/actions/joined.sml': "UserB: str = JsonData(path='$.b')",
+        'lib/foo.sml': "UserC: str = JsonData(path='$.c')",
+        'counters/active.sml': "UserD: str = JsonData(path='$.d')",
+        'actions/dm.sml': "UserE: str = JsonData(path='$.e')",
     }
 )
 def test_category_derivation(client: 'FlaskClient[Response]') -> None:
@@ -150,12 +147,12 @@ def test_category_derivation(client: 'FlaskClient[Response]') -> None:
     {
         **_base_sources_dict,
         'main.sml': """
-            FeatA = JsonData(path='$.a')
-            FeatB = JsonData(path='$.b')
+            FeatA: str = JsonData(path='$.a')
+            FeatB: str = JsonData(path='$.b')
             FeatC = FeatA
             R1 = Rule(when_all=[FeatA == 'x'], description='r1')
             R2 = Rule(when_all=[FeatB == 'y'], description='r2')
-            WhenRules(rules_any=[R1], then=[FeatA])
+            WhenRules(rules_any=[R1], then=[DeclareVerdict(verdict=FeatA)])
         """,
     }
 )
@@ -186,7 +183,7 @@ def test_reference_counting_and_total(client: 'FlaskClient[Response]') -> None:
 @pytest.mark.use_rules_sources(
     {
         **_base_sources_dict,
-        'main.sml': "Feat = JsonData(path='$.foo')",
+        'main.sml': "Feat: str = JsonData(path='$.foo')",
     }
 )
 def test_dual_route_registration(client: 'FlaskClient[Response]') -> None:
@@ -201,7 +198,7 @@ def test_dual_route_registration(client: 'FlaskClient[Response]') -> None:
 @pytest.mark.use_rules_sources(
     {
         **_no_ability_sources_dict,
-        'main.sml': "Feat = JsonData(path='$.foo')",
+        'main.sml': "Feat: str = JsonData(path='$.foo')",
     }
 )
 def test_endpoint_requires_can_view_docs(client: 'FlaskClient[Response]') -> None:
@@ -214,7 +211,7 @@ def test_endpoint_requires_can_view_docs(client: 'FlaskClient[Response]') -> Non
     {
         **_base_sources_dict,
         'main.sml': """
-            Feat = JsonData(path='$.foo')
+            Feat: str = JsonData(path='$.foo')
         """,
     }
 )


### PR DESCRIPTION
## Summary

Resubmitting — I accidentally merged #245 into the old `hailey/osprey-ui-2-0/phase-3-rebased` base instead of `main`. Same code as #245.

## What this PR does

- Cherry-picks `1a4b7a4` (the squash from #245, carrying all reviewed Phase 4 work) onto a fresh branch off current `main`.
- One commit, identical content to what was approved on #245.

## Testing

Identical content to #245's verified state — see that PR for the original test notes.