### PR TITLE
build(deps): bump @sentry/browser from 5.12.1 to 7.119.1

### DIFF
--- a/osprey_ui/package-lock.json
+++ b/osprey_ui/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@ant-design/icons": "^5.0.0",
         "@juggle/resize-observer": "3.2.0",
-        "@sentry/browser": "5.12.1",
+        "@sentry/browser": "^7.119.1",
         "ajv": "^8.20.0",
         "antd": "^5.0.0",
         "axios": "^1.16.1",
@@ -4242,85 +4242,130 @@
       "integrity": "sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==",
       "license": "MIT"
     },
-    "node_modules/@sentry/browser": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.12.1.tgz",
-      "integrity": "sha512-Zl7VdppUxctyaoqMSEhnDJp2rrupx8n8N2n3PSooH74yhB2Z91nt84mouczprBsw3JU1iggGyUw9seRFzDI1hw==",
-      "license": "BSD-3-Clause",
+    "node_modules/@sentry-internal/feedback": {
+      "version": "7.119.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.119.1.tgz",
+      "integrity": "sha512-EPyW6EKZmhKpw/OQUPRkTynXecZdYl4uhZwdZuGqnGMAzswPOgQvFrkwsOuPYvoMfXqCH7YuRqyJrox3uBOrTA==",
+      "license": "MIT",
       "dependencies": {
-        "@sentry/core": "5.12.0",
-        "@sentry/types": "5.12.0",
-        "@sentry/utils": "5.12.0",
-        "tslib": "^1.9.3"
+        "@sentry/core": "7.119.1",
+        "@sentry/types": "7.119.1",
+        "@sentry/utils": "7.119.1"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "7.119.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.119.1.tgz",
+      "integrity": "sha512-O/lrzENbMhP/UDr7LwmfOWTjD9PLNmdaCF408Wx8SDuj7Iwc+VasGfHg7fPH4Pdr4nJON6oh+UqoV4IoG05u+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "7.119.1",
+        "@sentry/replay": "7.119.1",
+        "@sentry/types": "7.119.1",
+        "@sentry/utils": "7.119.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sentry-internal/tracing": {
+      "version": "7.119.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.119.1.tgz",
+      "integrity": "sha512-cI0YraPd6qBwvUA3wQdPGTy8PzAoK0NZiaTN1LM3IczdPegehWOaEG5GVTnpGnTsmBAzn1xnBXNBhgiU4dgcrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "7.119.1",
+        "@sentry/types": "7.119.1",
+        "@sentry/utils": "7.119.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "7.119.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.119.1.tgz",
+      "integrity": "sha512-aMwAnFU4iAPeLyZvqmOQaEDHt/Dkf8rpgYeJ0OEi50dmP6AjG+KIAMCXU7CYCCQDn70ITJo8QD5+KzCoZPYz0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/feedback": "7.119.1",
+        "@sentry-internal/replay-canvas": "7.119.1",
+        "@sentry-internal/tracing": "7.119.1",
+        "@sentry/core": "7.119.1",
+        "@sentry/integrations": "7.119.1",
+        "@sentry/replay": "7.119.1",
+        "@sentry/types": "7.119.1",
+        "@sentry/utils": "7.119.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.12.0.tgz",
-      "integrity": "sha512-wY4rsoX71QsGpcs9tF+OxKgDPKzIFMRvFiSRcJoPMfhFsTilQ/CBMn/c3bDtWQd9Bnr/ReQIL6NbnIjUsPHA4Q==",
-      "license": "BSD-3-Clause",
+      "version": "7.119.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.119.1.tgz",
+      "integrity": "sha512-YUNnH7O7paVd+UmpArWCPH4Phlb5LwrkWVqzFWqL3xPyCcTSof2RL8UmvpkTjgYJjJ+NDfq5mPFkqv3aOEn5Sw==",
+      "license": "MIT",
       "dependencies": {
-        "@sentry/hub": "5.12.0",
-        "@sentry/minimal": "5.12.0",
-        "@sentry/types": "5.12.0",
-        "@sentry/utils": "5.12.0",
-        "tslib": "^1.9.3"
+        "@sentry/types": "7.119.1",
+        "@sentry/utils": "7.119.1"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
-    "node_modules/@sentry/hub": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.12.0.tgz",
-      "integrity": "sha512-3k7yE8BEVJsKx8mR4LcI4IN0O8pngmq44OcJ/fRUUBAPqsT38jsJdP2CaWhdlM1jiNUzUDB1ktBv6/lY+VgcoQ==",
-      "license": "BSD-3-Clause",
+    "node_modules/@sentry/integrations": {
+      "version": "7.119.1",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.119.1.tgz",
+      "integrity": "sha512-CGmLEPnaBqbUleVqrmGYjRjf5/OwjUXo57I9t0KKWViq81mWnYhaUhRZWFNoCNQHns+3+GPCOMvl0zlawt+evw==",
+      "license": "MIT",
       "dependencies": {
-        "@sentry/types": "5.12.0",
-        "@sentry/utils": "5.12.0",
-        "tslib": "^1.9.3"
+        "@sentry/core": "7.119.1",
+        "@sentry/types": "7.119.1",
+        "@sentry/utils": "7.119.1",
+        "localforage": "^1.8.1"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
-    "node_modules/@sentry/minimal": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.12.0.tgz",
-      "integrity": "sha512-fk73meyz4k4jCg9yzbma+WkggsfEIQWI2e2TWfYsRGcrV3RnlSrXyM4D91/A8Bjx10SNezHPUFHjasjlHXOkyA==",
-      "license": "BSD-3-Clause",
+    "node_modules/@sentry/replay": {
+      "version": "7.119.1",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.119.1.tgz",
+      "integrity": "sha512-4da+ruMEipuAZf35Ybt2StBdV1S+oJbSVccGpnl9w6RoeQoloT4ztR6ML3UcFDTXeTPT1FnHWDCyOfST0O7XMw==",
+      "license": "MIT",
       "dependencies": {
-        "@sentry/hub": "5.12.0",
-        "@sentry/types": "5.12.0",
-        "tslib": "^1.9.3"
+        "@sentry-internal/tracing": "7.119.1",
+        "@sentry/core": "7.119.1",
+        "@sentry/types": "7.119.1",
+        "@sentry/utils": "7.119.1"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=12"
       }
     },
     "node_modules/@sentry/types": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.12.0.tgz",
-      "integrity": "sha512-aZbBouBLrKB8wXlztriIagZNmsB+wegk1Jkl6eprqRW/w24Sl/47tiwH8c5S4jYTxdAiJk+SAR10AAuYmIN3zg==",
-      "license": "BSD-3-Clause",
+      "version": "7.119.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.119.1.tgz",
+      "integrity": "sha512-4G2mcZNnYzK3pa2PuTq+M2GcwBRY/yy1rF+HfZU+LAPZr98nzq2X3+mJHNJoobeHRkvVh7YZMPi4ogXiIS5VNQ==",
+      "license": "MIT",
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.12.0.tgz",
-      "integrity": "sha512-fYUadGLbfTCbs4OG5hKCOtv2jrNE4/8LHNABy9DwNJ/t5DVtGqWAZBnxsC+FG6a3nVqCpxjFI9AHlYsJ2wsf7Q==",
-      "license": "BSD-3-Clause",
+      "version": "7.119.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.119.1.tgz",
+      "integrity": "sha512-ju/Cvyeu/vkfC5/XBV30UNet5kLEicZmXSyuLwZu95hEbL+foPdxN+re7pCI/eNqfe3B2vz7lvz5afLVOlQ2Hg==",
+      "license": "MIT",
       "dependencies": {
-        "@sentry/types": "5.12.0",
-        "tslib": "^1.9.3"
+        "@sentry/types": "7.119.1"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -11385,6 +11430,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/immer": {
       "version": "9.0.21",
       "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
@@ -14577,6 +14628,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
@@ -14617,6 +14677,15 @@
       },
       "engines": {
         "node": ">=8.9.0"
+      }
+    },
+    "node_modules/localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lie": "3.1.1"
       }
     },
     "node_modules/locate-path": {

--- a/osprey_ui/package.json
+++ b/osprey_ui/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@ant-design/icons": "^5.0.0",
     "@juggle/resize-observer": "3.2.0",
-    "@sentry/browser": "5.12.1",
+    "@sentry/browser": "7.119.1",
     "ajv": "^8.20.0",
     "antd": "^5.0.0",
     "axios": "^1.16.1",


### PR DESCRIPTION
## Description

Bumps [@sentry/browser](https://github.com/getsentry/sentry-javascript) from 5.12.1 to 7.119.1.

Split out of grouped Dependabot PR #285 so each version bump can be reviewed independently. This is a **two-major-version** bump (5.x → 7.x) so it warrants its own PR.

Notable transitive additions pulled in by Sentry 7.x: `@sentry-internal/feedback`, `@sentry-internal/replay-canvas`, `@sentry-internal/tracing`, `@sentry/integrations`, `@sentry/replay`, plus `immediate` / `lie` / `localforage`. Removed: `@sentry/hub`, `@sentry/minimal` (folded into `@sentry/core` in 6.x).

## Checklist

- [ ] Tests pass locally
- [ ] `uv run ruff check .` passes (no unused imports or other lint errors)
- [ ] `uv tool run fawltydeps --check-unused --pyenv .venv` passes (no unused dependencies)
- [ ] Updated `CHANGELOG.md` with my changes, if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the app's error tracking library to a newer release, improving stability and error monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->