### PR TITLE
[compose] register minio storage backend on osprey-ui-api

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -160,6 +160,12 @@ services:
       - BIGTABLE_EMULATOR_HOST=bigtable:8361
       - SNOWFLAKE_API_ENDPOINT=http://snowflake-id-worker:8088
       - SNOWFLAKE_EPOCH=1420070400000
+      - OSPREY_EXECUTION_RESULT_STORAGE_BACKEND=minio
+      - OSPREY_MINIO_ENDPOINT=minio:9000
+      - OSPREY_MINIO_ACCESS_KEY=minioadmin
+      - OSPREY_MINIO_SECRET_KEY=minioadmin123
+      - OSPREY_MINIO_SECURE=false
+      - OSPREY_MINIO_EXECUTION_RESULTS_BUCKET=execution-output
     volumes:
       - ./osprey_worker:/osprey/osprey_worker
       - ./osprey_rpc:/osprey/osprey_rpc


### PR DESCRIPTION
## Summary
The example `docker-compose.yaml` set `OSPREY_EXECUTION_RESULT_STORAGE_BACKEND` (and the MinIO config it needs) on `osprey-worker`, but not on `osprey-ui-api`. The UI API process bootstraps its own storage backend, so its `/scan` endpoint was failing with `AssertionError: No storage backend registered` on a fresh setup. Add the same six env vars to the `osprey-ui-api` service so the example compose is usable out of the box.

## Related Issues/Tasks
Closes #181

## Changes Made
- Added to the `osprey-ui-api` service in `docker-compose.yaml`:
  - `OSPREY_EXECUTION_RESULT_STORAGE_BACKEND=minio`
  - `OSPREY_MINIO_ENDPOINT=minio:9000`
  - `OSPREY_MINIO_ACCESS_KEY=minioadmin`
  - `OSPREY_MINIO_SECRET_KEY=minioadmin123`
  - `OSPREY_MINIO_SECURE=false`
  - `OSPREY_MINIO_EXECUTION_RESULTS_BUCKET=execution-output`
- Values are byte-identical to the existing block on `osprey-worker`.

## Confidence Level
Confidence Level: Claude

## Testing
- `docker compose config --quiet` — passes (compose syntax valid).
- Env var names verified against `bootstrap_execution_result_storage_service()` in `osprey_worker/src/osprey/worker/lib/storage/stored_execution_result.py` and `get_rules_execution_result_storage_backend()` in `osprey_worker/src/osprey/worker/_stdlibplugin/execution_result_store_chooser.py`.
- Not booted end-to-end in this session because of a parallel-worktree compose conflict; the failure mode (#181's traceback) is deterministic on the missing env var, so the fix is straightforward to verify on the next clean `./start.sh`.

## Follow-up note (out of scope here)
`osprey-ui-api.depends_on` does not gate on `minio: service_healthy` like `osprey-worker.depends_on` does — the transitive chain via `osprey-worker` covers the typical boot order but leaves a narrow race. Worth a separate compose-hardening pass; deliberately not included here per the "minimal and scoped" rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated execution result storage configuration in the deployment setup to use MinIO-backed storage with the associated endpoint and authentication credentials.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roostorg/osprey/pull/288?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->