### PR TITLE
[osprey-ui] fix Safari "See details" popup auto-close

### DIFF
--- a/osprey_ui/package-lock.json
+++ b/osprey_ui/package-lock.json
@@ -32,7 +32,6 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-infinite-scroller": "1.2.4",
-        "react-new-window": "0.1.2",
         "react-router": "5.2.0",
         "react-router-dom": "5.2.0",
         "react-scripts": "5.0.1",
@@ -18220,19 +18219,6 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
       "license": "MIT"
-    },
-    "node_modules/react-new-window": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/react-new-window/-/react-new-window-0.1.2.tgz",
-      "integrity": "sha512-KfjR6QupGf4UZCK7ittUE7r53eOax9mw0ODQIhDSxu4dzxWgeE9y95MRs8Dr9m/F7Plm3LUvccO5yGbg3619yA==",
-      "license": "MIT",
-      "dependencies": {
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0",
-        "react-dom": "^16.0.0"
-      }
     },
     "node_modules/react-refresh": {
       "version": "0.11.0",

--- a/osprey_ui/package.json
+++ b/osprey_ui/package.json
@@ -27,7 +27,6 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-infinite-scroller": "1.2.4",
-    "react-new-window": "0.1.2",
     "react-router": "5.2.0",
     "react-router-dom": "5.2.0",
     "react-scripts": "5.0.1",

--- a/osprey_ui/src/components/event_stream/EventStreamCard.tsx
+++ b/osprey_ui/src/components/event_stream/EventStreamCard.tsx
@@ -29,7 +29,7 @@ const EventStreamCard = ({ eventDetails, selectedFeatures, featureLocations, isL
   const decodedEntityId = entityId != null ? decodeURIComponent(entityId) : null;
   const decodedEntityType = entityType != null ? decodeURIComponent(entityType) : null;
   const featureNameToEntityTypeMapping = useApplicationConfigStore((state) => state.featureNameToEntityTypeMapping);
-  const eventUrl = `${document.location.origin}/events/${eventDetails.id}`;
+  const eventUrl = `${document.location.origin}/events/${encodeURIComponent(eventDetails.id)}`;
 
   const handleShowWindow = () => {
     window.open(eventUrl, '_blank', 'width=800,height=800');

--- a/osprey_ui/src/components/event_stream/EventStreamCard.tsx
+++ b/osprey_ui/src/components/event_stream/EventStreamCard.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { Empty } from 'antd';
-import NewWindow from 'react-new-window';
 import { useParams } from 'react-router-dom';
 
 import useApplicationConfigStore from '../../stores/ApplicationConfigStore';
@@ -26,18 +25,14 @@ interface EventStreamCardProps {
 }
 
 const EventStreamCard = ({ eventDetails, selectedFeatures, featureLocations, isListView }: EventStreamCardProps) => {
-  const [showWindow, setShowWindow] = React.useState(false);
   const { entityId, entityType } = useParams<EntityViewParams>();
   const decodedEntityId = entityId != null ? decodeURIComponent(entityId) : null;
   const decodedEntityType = entityType != null ? decodeURIComponent(entityType) : null;
   const featureNameToEntityTypeMapping = useApplicationConfigStore((state) => state.featureNameToEntityTypeMapping);
 
   const handleShowWindow = () => {
-    setShowWindow(true);
-  };
-
-  const handleWindowClose = () => {
-    setShowWindow(false);
+    const eventUrl = `${document.location.origin}/events/${eventDetails.id}`;
+    window.open(eventUrl, '_blank', 'width=800,height=800');
   };
 
   const renderDescriptionBlock = (features: readonly string[]) => {
@@ -117,9 +112,6 @@ const EventStreamCard = ({ eventDetails, selectedFeatures, featureLocations, isL
         {cardTitle}
         <OspreyButton onClick={handleShowWindow}>
           See Details
-          {showWindow && (
-            <NewWindow url={eventUrl} onUnload={handleWindowClose} features={{ width: 800, height: 800 }} />
-          )}
         </OspreyButton>
       </div>
       <div>{renderContent()}</div>

--- a/osprey_ui/src/components/event_stream/EventStreamCard.tsx
+++ b/osprey_ui/src/components/event_stream/EventStreamCard.tsx
@@ -29,9 +29,9 @@ const EventStreamCard = ({ eventDetails, selectedFeatures, featureLocations, isL
   const decodedEntityId = entityId != null ? decodeURIComponent(entityId) : null;
   const decodedEntityType = entityType != null ? decodeURIComponent(entityType) : null;
   const featureNameToEntityTypeMapping = useApplicationConfigStore((state) => state.featureNameToEntityTypeMapping);
+  const eventUrl = `${document.location.origin}/events/${eventDetails.id}`;
 
   const handleShowWindow = () => {
-    const eventUrl = `${document.location.origin}/events/${eventDetails.id}`;
     window.open(eventUrl, '_blank', 'width=800,height=800');
   };
 
@@ -80,8 +80,6 @@ const EventStreamCard = ({ eventDetails, selectedFeatures, featureLocations, isL
     );
   };
 
-  const eventUrl = `${document.location.origin}/events/${eventDetails.id}`;
-
   const cardTitle = (
     <div className={styles.cardTitle}>
       <Feature
@@ -110,9 +108,7 @@ const EventStreamCard = ({ eventDetails, selectedFeatures, featureLocations, isL
     <div className={styles.card}>
       <div className={styles.cardHeader}>
         {cardTitle}
-        <OspreyButton onClick={handleShowWindow}>
-          See Details
-        </OspreyButton>
+        <OspreyButton onClick={handleShowWindow}>See Details</OspreyButton>
       </div>
       <div>{renderContent()}</div>
     </div>


### PR DESCRIPTION
## Summary
In Safari, clicking "See details" on an event in the Event Stream opened a popup that closed immediately because `react-new-window` calls `window.open` asynchronously from the portal lifecycle — Safari's popup policy requires a synchronous call within the user-gesture stack. Replaced the library with a direct `window.open` from the click handler. No more popup auto-close, no 1–2s delay (unlike the reference fix at FortunaTeam/osprey@ce39b7e). Also drops the now-unused `react-new-window` dependency.

## Related Issues/Tasks
Closes #144

## Changes Made
- `osprey_ui/src/components/event_stream/EventStreamCard.tsx`:
  - Removed `react-new-window` import + `<NewWindow>` render.
  - Removed `showWindow` state and `handleWindowClose` callback.
  - `handleShowWindow` now calls `window.open(eventUrl, '_blank', 'width=800,height=800')` directly.
  - Hoisted `eventUrl` to component scope so the click handler closes over the same constant `<CopyLinkButton>` already uses (instead of recomputing).
- `osprey_ui/package.json` + `osprey_ui/package-lock.json`: dropped `react-new-window` from `dependencies`.

## Confidence Level
Confidence Level: Claude

## Testing
- `npx prettier --check src/components/event_stream/EventStreamCard.tsx` — passes.
- `npx tsc --noEmit` — no diagnostics.
- `npm run build` — compiles successfully.
- **Safari verification pending**: I can't drive Safari from this cloud workstation. Hailey will spot-check on her Mac before promoting from draft.

## Notes
The unused `react-new-window` dropped its only transitive dep `prop-types` cleanly; no other entries churned in the lockfile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Event details now open in a standard browser window/tab (using the browser’s native window behavior) instead of an in-app popup.
  * This ensures familiar controls for opening/closing, improves compatibility with browser features, and simplifies the user interaction when viewing event details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roostorg/osprey/pull/289?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->