### PR TITLE
[engine] fix UDF→Druid KeyError via stable mapping key

### DIFF
--- a/osprey_worker/src/osprey/engine/ast_validator/validators/feature_name_to_entity_type_mapping.py
+++ b/osprey_worker/src/osprey/engine/ast_validator/validators/feature_name_to_entity_type_mapping.py
@@ -21,7 +21,8 @@ class FeatureNameToEntityTypeMapping(SourceValidator, HasResult[Dict[str, str]])
                 and not statement.target.is_local
                 and isinstance(statement.value, grammar.Call)
             ):
-                _, args = self._udf_node_mapping[id(statement.value)]
+                span_key = (statement.value.span.source.path, statement.value.span.start_line, statement.value.span.start_pos)
+                _, args = self._udf_node_mapping[span_key]
                 if isinstance(args, EntityArgumentsBase):
                     self._feature_name_to_entity_type[statement.target.identifier] = args.type.value
 

--- a/osprey_worker/src/osprey/engine/ast_validator/validators/feature_name_to_entity_type_mapping.py
+++ b/osprey_worker/src/osprey/engine/ast_validator/validators/feature_name_to_entity_type_mapping.py
@@ -5,7 +5,7 @@ from osprey.engine.stdlib.udfs.entity import EntityArgumentsBase
 
 from ..base_validator import HasResult, SourceValidator
 from ..validation_context import ValidationContext
-from .validate_call_kwargs import UDFNodeMapping, ValidateCallKwargs
+from .validate_call_kwargs import UDFNodeMapping, ValidateCallKwargs, udf_mapping_key
 
 
 class FeatureNameToEntityTypeMapping(SourceValidator, HasResult[Dict[str, str]]):
@@ -21,8 +21,7 @@ class FeatureNameToEntityTypeMapping(SourceValidator, HasResult[Dict[str, str]])
                 and not statement.target.is_local
                 and isinstance(statement.value, grammar.Call)
             ):
-                span_key = (statement.value.span.source.path, statement.value.span.start_line, statement.value.span.start_pos)
-                _, args = self._udf_node_mapping[span_key]
+                _, args = self._udf_node_mapping[udf_mapping_key(statement.value)]
                 if isinstance(args, EntityArgumentsBase):
                     self._feature_name_to_entity_type[statement.target.identifier] = args.type.value
 

--- a/osprey_worker/src/osprey/engine/ast_validator/validators/imports_must_not_have_cycles.py
+++ b/osprey_worker/src/osprey/engine/ast_validator/validators/imports_must_not_have_cycles.py
@@ -96,7 +96,8 @@ class ImportsMustNotHaveCycles(BaseValidator, HasResult[ImportGraphResult]):
         from osprey.engine.stdlib.udfs.import_ import Import
 
         for call_node in filter_nodes(source.ast_root, Call):
-            udf, _ = self._udf_node_mapping[id(call_node)]
+            span_key = (call_node.span.source.path, call_node.span.start_line, call_node.span.start_pos)
+            udf, _ = self._udf_node_mapping[span_key]
             if not isinstance(udf, Import):
                 continue
 

--- a/osprey_worker/src/osprey/engine/ast_validator/validators/imports_must_not_have_cycles.py
+++ b/osprey_worker/src/osprey/engine/ast_validator/validators/imports_must_not_have_cycles.py
@@ -6,7 +6,7 @@ from osprey.engine.ast.grammar import Call, Source, Span
 from osprey.engine.utils.graph import CyclicDependencyError, Graph
 
 from ..base_validator import BaseValidator, HasResult
-from .validate_call_kwargs import UDFNodeMapping, ValidateCallKwargs
+from .validate_call_kwargs import UDFNodeMapping, ValidateCallKwargs, udf_mapping_key
 
 if TYPE_CHECKING:
     from ..validation_context import ValidationContext
@@ -96,8 +96,7 @@ class ImportsMustNotHaveCycles(BaseValidator, HasResult[ImportGraphResult]):
         from osprey.engine.stdlib.udfs.import_ import Import
 
         for call_node in filter_nodes(source.ast_root, Call):
-            span_key = (call_node.span.source.path, call_node.span.start_line, call_node.span.start_pos)
-            udf, _ = self._udf_node_mapping[span_key]
+            udf, _ = self._udf_node_mapping[udf_mapping_key(call_node)]
             if not isinstance(udf, Import):
                 continue
 

--- a/osprey_worker/src/osprey/engine/ast_validator/validators/validate_call_kwargs.py
+++ b/osprey_worker/src/osprey/engine/ast_validator/validators/validate_call_kwargs.py
@@ -22,9 +22,13 @@ if TYPE_CHECKING:
     from ..validation_context import ValidationContext
 
 
-# Map from (source_path, start_line, start_pos) to (UDF, Arguments)
-# This provides a stable key that doesn't depend on Python object identity
+# Keyed by (source_path, start_line, start_pos) — stable across Python object reuse
 UDFNodeMapping = Dict[Tuple[str, int, int], Tuple[UDFBase[Any, Any], ArgumentsBase]]
+
+
+def udf_mapping_key(node: Call) -> Tuple[str, int, int]:
+    """Get stable (source_path, line, pos) key for a Call node."""
+    return (node.span.source.path, node.span.start_line, node.span.start_pos)
 
 
 class ValidateCallKwargs(SourceValidator, HasResult[UDFNodeMapping]):
@@ -182,9 +186,7 @@ class ValidateCallKwargs(SourceValidator, HasResult[UDFNodeMapping]):
             # If it's a dynamic UDF, we'll add the RValueTypeChecker in ValidateDynamicCallsHaveAnnotatedRValue
             # Store the udf in the node mapping - this will be read in `CallExecutor` within the executor,
             # to then pluck the udf + arguments that we parsed here to be executed upon.
-            # Use (source_path, line, pos) as key for stable identity independent of object reuse
-            span_key = (call_node.span.source.path, call_node.span.start_line, call_node.span.start_pos)
-            self._udf_node_mapping[span_key] = (udf, arguments)
+            self._udf_node_mapping[udf_mapping_key(call_node)] = (udf, arguments)
 
         # Catch the ConstExprArgumentException - if any other exception is thrown, it's considered a
         # compilation error!

--- a/osprey_worker/src/osprey/engine/ast_validator/validators/validate_call_kwargs.py
+++ b/osprey_worker/src/osprey/engine/ast_validator/validators/validate_call_kwargs.py
@@ -22,7 +22,9 @@ if TYPE_CHECKING:
     from ..validation_context import ValidationContext
 
 
-UDFNodeMapping = Dict[int, Tuple[UDFBase[Any, Any], ArgumentsBase]]
+# Map from (source_path, start_line, start_pos) to (UDF, Arguments)
+# This provides a stable key that doesn't depend on Python object identity
+UDFNodeMapping = Dict[Tuple[str, int, int], Tuple[UDFBase[Any, Any], ArgumentsBase]]
 
 
 class ValidateCallKwargs(SourceValidator, HasResult[UDFNodeMapping]):
@@ -180,7 +182,9 @@ class ValidateCallKwargs(SourceValidator, HasResult[UDFNodeMapping]):
             # If it's a dynamic UDF, we'll add the RValueTypeChecker in ValidateDynamicCallsHaveAnnotatedRValue
             # Store the udf in the node mapping - this will be read in `CallExecutor` within the executor,
             # to then pluck the udf + arguments that we parsed here to be executed upon.
-            self._udf_node_mapping[id(call_node)] = (udf, arguments)
+            # Use (source_path, line, pos) as key for stable identity independent of object reuse
+            span_key = (call_node.span.source.path, call_node.span.start_line, call_node.span.start_pos)
+            self._udf_node_mapping[span_key] = (udf, arguments)
 
         # Catch the ConstExprArgumentException - if any other exception is thrown, it's considered a
         # compilation error!

--- a/osprey_worker/src/osprey/engine/ast_validator/validators/validate_dynamic_calls_have_annotated_rvalue.py
+++ b/osprey_worker/src/osprey/engine/ast_validator/validators/validate_dynamic_calls_have_annotated_rvalue.py
@@ -106,5 +106,6 @@ class ValidateDynamicCallsHaveAnnotatedRValue(SourceValidator):
                     ),
                 )
 
-        udf, _ = self._udf_node_mapping[id(call_node)]
+        span_key = (call_node.span.source.path, call_node.span.start_line, call_node.span.start_pos)
+        udf, _ = self._udf_node_mapping[span_key]
         udf.set_rvalue_type_checker(rvalue_type_checker)

--- a/osprey_worker/src/osprey/engine/ast_validator/validators/validate_dynamic_calls_have_annotated_rvalue.py
+++ b/osprey_worker/src/osprey/engine/ast_validator/validators/validate_dynamic_calls_have_annotated_rvalue.py
@@ -4,7 +4,7 @@ from osprey.engine.ast.ast_utils import filter_nodes
 from osprey.engine.ast.grammar import Assign, Call, Name, Source
 from osprey.engine.ast_validator.base_validator import SourceValidator
 from osprey.engine.ast_validator.validation_utils import add_must_assign_to_variable_error
-from osprey.engine.ast_validator.validators.validate_call_kwargs import ValidateCallKwargs
+from osprey.engine.ast_validator.validators.validate_call_kwargs import ValidateCallKwargs, udf_mapping_key
 from osprey.engine.udf.rvalue_type_checker import (
     AnnotationConversionError,
     convert_ast_annotation_to_type_checker,
@@ -106,6 +106,5 @@ class ValidateDynamicCallsHaveAnnotatedRValue(SourceValidator):
                     ),
                 )
 
-        span_key = (call_node.span.source.path, call_node.span.start_line, call_node.span.start_pos)
-        udf, _ = self._udf_node_mapping[span_key]
+        udf, _ = self._udf_node_mapping[udf_mapping_key(call_node)]
         udf.set_rvalue_type_checker(rvalue_type_checker)

--- a/osprey_worker/src/osprey/engine/ast_validator/validators/validate_labels.py
+++ b/osprey_worker/src/osprey/engine/ast_validator/validators/validate_labels.py
@@ -28,7 +28,8 @@ class ValidateLabels(SourceValidator):
 
     def validate_source(self, source: 'grammar.Source') -> None:
         for call_node in filter_nodes(source.ast_root, grammar.Call):
-            _, arguments = self._udf_node_mapping[id(call_node)]
+            span_key = (call_node.span.source.path, call_node.span.start_line, call_node.span.start_pos)
+            _, arguments = self._udf_node_mapping[span_key]
             if isinstance(arguments, LabelArguments):
                 self._validate_label(call_node, arguments)
 

--- a/osprey_worker/src/osprey/engine/ast_validator/validators/validate_labels.py
+++ b/osprey_worker/src/osprey/engine/ast_validator/validators/validate_labels.py
@@ -8,7 +8,7 @@ from osprey.engine.utils.get_closest_string_within_threshold import get_closest_
 
 from ..validation_context import ValidationContext
 from .feature_name_to_entity_type_mapping import FeatureNameToEntityTypeMapping
-from .validate_call_kwargs import UDFNodeMapping, ValidateCallKwargs
+from .validate_call_kwargs import UDFNodeMapping, ValidateCallKwargs, udf_mapping_key
 
 ### meow
 
@@ -28,8 +28,7 @@ class ValidateLabels(SourceValidator):
 
     def validate_source(self, source: 'grammar.Source') -> None:
         for call_node in filter_nodes(source.ast_root, grammar.Call):
-            span_key = (call_node.span.source.path, call_node.span.start_line, call_node.span.start_pos)
-            _, arguments = self._udf_node_mapping[span_key]
+            _, arguments = self._udf_node_mapping[udf_mapping_key(call_node)]
             if isinstance(arguments, LabelArguments):
                 self._validate_label(call_node, arguments)
 

--- a/osprey_worker/src/osprey/engine/ast_validator/validators/validate_static_types.py
+++ b/osprey_worker/src/osprey/engine/ast_validator/validators/validate_static_types.py
@@ -22,7 +22,7 @@ from typing_extensions import get_origin
 from ..base_validator import HasInput, HasResult, SourceValidator
 from .imports_must_not_have_cycles import ImportsMustNotHaveCycles
 from .unique_stored_names import UniqueStoredNames
-from .validate_call_kwargs import UDFNodeMapping, ValidateCallKwargs
+from .validate_call_kwargs import UDFNodeMapping, ValidateCallKwargs, udf_mapping_key
 from .validate_dynamic_calls_have_annotated_rvalue import ValidateDynamicCallsHaveAnnotatedRValue
 from .variables_must_be_defined import VariablesMustBeDefined
 
@@ -301,8 +301,7 @@ class ValidateStaticTypes(SourceValidator, HasInput[Dict[str, _TypeAndSpan]], Ha
         return List[child_type]  # type: ignore # Doesn't like runtime types like this
 
     def _validate_call(self, call: grammar.Call) -> type:
-        span_key = (call.span.source.path, call.span.start_line, call.span.start_pos)
-        udf, arguments = self._udf_node_mapping[span_key]
+        udf, arguments = self._udf_node_mapping[udf_mapping_key(call)]
 
         # Special case to handle import. Need to do this so we populate name types.
         if isinstance(udf, Import):

--- a/osprey_worker/src/osprey/engine/ast_validator/validators/validate_static_types.py
+++ b/osprey_worker/src/osprey/engine/ast_validator/validators/validate_static_types.py
@@ -301,7 +301,8 @@ class ValidateStaticTypes(SourceValidator, HasInput[Dict[str, _TypeAndSpan]], Ha
         return List[child_type]  # type: ignore # Doesn't like runtime types like this
 
     def _validate_call(self, call: grammar.Call) -> type:
-        udf, arguments = self._udf_node_mapping[id(call)]
+        span_key = (call.span.source.path, call.span.start_line, call.span.start_pos)
+        udf, arguments = self._udf_node_mapping[span_key]
 
         # Special case to handle import. Need to do this so we populate name types.
         if isinstance(udf, Import):

--- a/osprey_worker/src/osprey/engine/ast_validator/validators/variables_must_be_defined.py
+++ b/osprey_worker/src/osprey/engine/ast_validator/validators/variables_must_be_defined.py
@@ -9,7 +9,7 @@ from osprey.engine.utils.get_closest_string_within_threshold import get_closest_
 from ..base_validator import BaseValidator, HasInput, HasResult
 from .imports_must_not_have_cycles import ImportsMustNotHaveCycles
 from .unique_stored_names import UniqueStoredNames
-from .validate_call_kwargs import ValidateCallKwargs
+from .validate_call_kwargs import ValidateCallKwargs, udf_mapping_key
 
 
 class VariablesMustBeDefined(BaseValidator, HasInput[Set[str]], HasResult[Mapping[Source, Set[str]]]):
@@ -131,7 +131,7 @@ class VariablesMustBeDefined(BaseValidator, HasInput[Set[str]], HasResult[Mappin
 
     def get_imported_sources(self, node: Call) -> Sequence[Source]:
         udf_mapping = self.context.get_validator_result(ValidateCallKwargs)
-        call_udf, _ = udf_mapping[id(node)]
+        call_udf, _ = udf_mapping[udf_mapping_key(node)]
         assert isinstance(call_udf, Import)
         return [s for s, _ in call_udf.sources_and_spans]
 

--- a/osprey_worker/src/osprey/engine/executor/node_executor/call_executor.py
+++ b/osprey_worker/src/osprey/engine/executor/node_executor/call_executor.py
@@ -22,11 +22,14 @@ class CallExecutor(BaseNodeExecutor[Call, Any]):
     _udf: 'UDFBase[Any, Any]'
 
     def __init__(self, node: Call, sources: 'ValidatedSources'):
-        from osprey.engine.ast_validator.validators.validate_call_kwargs import ValidateCallKwargs
+        from osprey.engine.ast_validator.validators.validate_call_kwargs import (
+            ValidateCallKwargs,
+            udf_mapping_key,
+        )
 
         super().__init__(node=node, sources=sources)
         udf_map = sources.get_validator_result(ValidateCallKwargs)
-        self._udf, self.unresolved_arguments = udf_map[id(node)]
+        self._udf, self.unresolved_arguments = udf_map[udf_mapping_key(node)]
         self.dependent_node_dict = self.unresolved_arguments.get_dependent_node_dict()
 
     def set_tracing_tags(self, span: 'Span') -> None:

--- a/osprey_worker/src/osprey/engine/query_language/ast_druid_translator.py
+++ b/osprey_worker/src/osprey/engine/query_language/ast_druid_translator.py
@@ -99,7 +99,8 @@ class DruidQueryTransformer:
             raise DruidQueryTransformException(node, 'Unknown Unary Operator')
 
     def transform_Call(self, node: grammar.Call) -> Dict[str, Any]:
-        udf, _ = self._udf_node_mapping[id(node)]
+        span_key = (node.span.source.path, node.span.start_line, node.span.start_pos)
+        udf, _ = self._udf_node_mapping[span_key]
 
         if not isinstance(udf, QueryUdfBase):
             raise DruidQueryTransformException(node, 'Unknown function call type')

--- a/osprey_worker/src/osprey/engine/query_language/ast_druid_translator.py
+++ b/osprey_worker/src/osprey/engine/query_language/ast_druid_translator.py
@@ -2,7 +2,7 @@ from typing import Any, Dict
 
 from osprey.engine.ast import grammar
 from osprey.engine.ast_validator.validation_context import ValidatedSources
-from osprey.engine.ast_validator.validators.validate_call_kwargs import ValidateCallKwargs
+from osprey.engine.ast_validator.validators.validate_call_kwargs import ValidateCallKwargs, udf_mapping_key
 from osprey.engine.udf.base import QueryUdfBase
 from osprey.engine.utils.osprey_unary_executor import OspreyUnaryExecutor
 
@@ -99,8 +99,7 @@ class DruidQueryTransformer:
             raise DruidQueryTransformException(node, 'Unknown Unary Operator')
 
     def transform_Call(self, node: grammar.Call) -> Dict[str, Any]:
-        span_key = (node.span.source.path, node.span.start_line, node.span.start_pos)
-        udf, _ = self._udf_node_mapping[span_key]
+        udf, _ = self._udf_node_mapping[udf_mapping_key(node)]
 
         if not isinstance(udf, QueryUdfBase):
             raise DruidQueryTransformException(node, 'Unknown function call type')

--- a/osprey_worker/src/osprey/engine/query_language/tests/test_ast_druid_translator.py
+++ b/osprey_worker/src/osprey/engine/query_language/tests/test_ast_druid_translator.py
@@ -149,19 +149,18 @@ def test_udf_node_mapping_uses_stable_keys(
 
     # Get the UDF mapping
     udf_mapping = validated_sources.get_validator_result(ValidateCallKwargs)
-    assert len(udf_mapping) > 0, "Should have at least one UDF in mapping"
+    assert len(udf_mapping) > 0, 'Should have at least one UDF in mapping'
 
     # Verify that the mapping uses stable (source_path, line, pos) keys (tuples)
     # not id()-based keys (integers)
     for key in udf_mapping.keys():
         assert isinstance(key, tuple), (
-            f"Mapping should use stable (source_path, line, pos) tuple keys, "
-            f"not id() keys. Got {type(key)}: {key}"
+            f'Mapping should use stable (source_path, line, pos) tuple keys, not id() keys. Got {type(key)}: {key}'
         )
-        assert len(key) == 3, f"Key should be (path, line, pos) tuple with 3 elements, got {len(key)}: {key}"
-        assert isinstance(key[0], str), f"First key element should be path (str), got {type(key[0])}"
-        assert isinstance(key[1], int), f"Second key element should be line (int), got {type(key[1])}"
-        assert isinstance(key[2], int), f"Third key element should be pos (int), got {type(key[2])}"
+        assert len(key) == 3, f'Key should be (path, line, pos) tuple with 3 elements, got {len(key)}: {key}'
+        assert isinstance(key[0], str), f'First key element should be path (str), got {type(key[0])}'
+        assert isinstance(key[1], int), f'Second key element should be line (int), got {type(key[1])}'
+        assert isinstance(key[2], int), f'Third key element should be pos (int), got {type(key[2])}'
 
     # Verify transformation works (consumes the stable keys)
     transformer = DruidQueryTransformer(validated_sources=validated_sources)

--- a/osprey_worker/src/osprey/engine/query_language/tests/test_ast_druid_translator.py
+++ b/osprey_worker/src/osprey/engine/query_language/tests/test_ast_druid_translator.py
@@ -128,36 +128,44 @@ def test_parses_query_with_regex_match_on_username(
     assert transformed_query['filter'].get('pattern') == '^jake'
 
 
-def test_udf_node_mapping_with_missing_entry(
+def test_udf_node_mapping_uses_stable_keys(
     make_rules_sources: MakeRulesSourcesFunction,
 ) -> None:
     """
-    Regression test for issue #158: KeyError in transform_Call when UDF node mapping is keyed by id(node).
+    Regression test for issue #158: UDF node mapping must use stable keys, not object identity.
 
-    This test verifies that transform_Call can handle Call nodes that aren't in the UDF mapping,
-    which can occur if:
-    1. A Call node passes syntax validation but fails argument validation
-    2. The node is included in the AST but not added to _udf_node_mapping
-    3. transform_Call tries to look it up and gets KeyError
+    The bug was that ValidateCallKwargs keyed the mapping by id(call_node), which is unstable
+    if the AST is reparsed or nodes are reconstructed. This caused KeyError in consumers like
+    DruidQueryTransformer, ValidateStaticTypes, etc. when they tried to look up the UDF.
 
-    The fix should either:
-    - Use a stable key instead of id(node), or
-    - Handle missing keys gracefully in transform_Call
+    The fix changes the key to be (source.path, start_line, start_pos), which is stable across
+    reparsing and object reconstruction.
     """
-    # This test would ideally simulate the case where a Call node exists in the AST
-    # but wasn't added to the mapping. Since our valid queries always have valid UDFs,
-    # we'll just verify the current behavior works.
     rules_sources = make_rules_sources([('UserName', '"some_user"')])
 
-    # Parse the query with a valid UDF
+    # Parse and validate the query
     query = "RegexMatch(item=UserName, regex='^jake')"
     validated_sources = parse_query_to_validated_ast(query, rules_sources)
 
-    # Create transformer and attempt to transform
+    # Get the UDF mapping
+    udf_mapping = validated_sources.get_validator_result(ValidateCallKwargs)
+    assert len(udf_mapping) > 0, "Should have at least one UDF in mapping"
+
+    # Verify that the mapping uses stable (source_path, line, pos) keys (tuples)
+    # not id()-based keys (integers)
+    for key in udf_mapping.keys():
+        assert isinstance(key, tuple), (
+            f"Mapping should use stable (source_path, line, pos) tuple keys, "
+            f"not id() keys. Got {type(key)}: {key}"
+        )
+        assert len(key) == 3, f"Key should be (path, line, pos) tuple with 3 elements, got {len(key)}: {key}"
+        assert isinstance(key[0], str), f"First key element should be path (str), got {type(key[0])}"
+        assert isinstance(key[1], int), f"Second key element should be line (int), got {type(key[1])}"
+        assert isinstance(key[2], int), f"Third key element should be pos (int), got {type(key[2])}"
+
+    # Verify transformation works (consumes the stable keys)
     transformer = DruidQueryTransformer(validated_sources=validated_sources)
     transformed_query = transformer.transform()
-
-    # Verify the transformation succeeded
     assert transformed_query is not None
     assert isinstance(transformed_query, dict)
     assert 'filter' in transformed_query

--- a/osprey_worker/src/osprey/engine/query_language/tests/test_ast_druid_translator.py
+++ b/osprey_worker/src/osprey/engine/query_language/tests/test_ast_druid_translator.py
@@ -110,6 +110,59 @@ def test_parses_did_mutate_label(
     assert check_json_output(transformed_query)
 
 
+def test_parses_query_with_regex_match_on_username(
+    make_rules_sources: MakeRulesSourcesFunction,
+) -> None:
+    validated_sources = parse_query_to_validated_ast(
+        "RegexMatch(item=UserName, regex='^jake')",
+        make_rules_sources([('UserName', '"some_user"')]),
+    )
+    transformed_query = DruidQueryTransformer(validated_sources=validated_sources).transform()
+
+    # Assert it returns a valid Druid query with the regex filter
+    assert isinstance(transformed_query, dict)
+    assert 'filter' in transformed_query
+    assert isinstance(transformed_query['filter'], dict)
+    assert transformed_query['filter'].get('type') == 'regex'
+    assert transformed_query['filter'].get('dimension') == 'UserName'
+    assert transformed_query['filter'].get('pattern') == '^jake'
+
+
+def test_udf_node_mapping_with_missing_entry(
+    make_rules_sources: MakeRulesSourcesFunction,
+) -> None:
+    """
+    Regression test for issue #158: KeyError in transform_Call when UDF node mapping is keyed by id(node).
+
+    This test verifies that transform_Call can handle Call nodes that aren't in the UDF mapping,
+    which can occur if:
+    1. A Call node passes syntax validation but fails argument validation
+    2. The node is included in the AST but not added to _udf_node_mapping
+    3. transform_Call tries to look it up and gets KeyError
+
+    The fix should either:
+    - Use a stable key instead of id(node), or
+    - Handle missing keys gracefully in transform_Call
+    """
+    # This test would ideally simulate the case where a Call node exists in the AST
+    # but wasn't added to the mapping. Since our valid queries always have valid UDFs,
+    # we'll just verify the current behavior works.
+    rules_sources = make_rules_sources([('UserName', '"some_user"')])
+
+    # Parse the query with a valid UDF
+    query = "RegexMatch(item=UserName, regex='^jake')"
+    validated_sources = parse_query_to_validated_ast(query, rules_sources)
+
+    # Create transformer and attempt to transform
+    transformer = DruidQueryTransformer(validated_sources=validated_sources)
+    transformed_query = transformer.transform()
+
+    # Verify the transformation succeeded
+    assert transformed_query is not None
+    assert isinstance(transformed_query, dict)
+    assert 'filter' in transformed_query
+
+
 @pytest.mark.parametrize(
     'query',
     [


### PR DESCRIPTION
## Summary
`DruidQueryTransformer.transform_Call` (and several validators / the executor) looked up entries in `_udf_node_mapping` by `id(node)` — Python's object-identity int. That key was unstable across the validator-pipeline → consumer boundary, so any UDF with a Druid translation (e.g. `RegexMatch(item=UserName, regex='^jake')`) blew up with `KeyError` and returned a 500 from `/queries/validate`.

Replace the unstable `id(node)` key with a stable source-position tuple `(source.path, start_line, start_pos)` and route every reader through a new `udf_mapping_key(node)` helper.

## Related Issues/Tasks
Closes #158

## Changes Made
- `validate_call_kwargs.py`: changed `UDFNodeMapping` from `Dict[int, ...]` to `Dict[Tuple[str, int, int], ...]`. Added `udf_mapping_key(node) -> Tuple[str, int, int]` helper next to the alias. Producer uses the helper.
- Updated all eight consumers to look up via `udf_mapping_key(node)`:
  - `query_language/ast_druid_translator.py` (the reported failure site)
  - `executor/node_executor/call_executor.py`
  - `ast_validator/validators/feature_name_to_entity_type_mapping.py`
  - `ast_validator/validators/imports_must_not_have_cycles.py`
  - `ast_validator/validators/validate_dynamic_calls_have_annotated_rvalue.py`
  - `ast_validator/validators/validate_labels.py`
  - `ast_validator/validators/validate_static_types.py`
  - `ast_validator/validators/variables_must_be_defined.py`
- Added regression test `test_udf_node_mapping_uses_stable_keys` in `test_ast_druid_translator.py`. The test exercises the producer/consumer contract via `parse_query_to_validated_ast` and asserts the keys are `(str, int, int)` tuples. With the producer reverted to `id(node)`, the test fails inside the validator pipeline with the original-shape `KeyError`.

## Confidence Level
Confidence Level: Claude

## Testing
- Full engine sweep (this branch): 806 passed, 1 skipped, 4 xfailed (63 errors are pre-existing `KeyError: 'POSTGRES_HOSTS'` collection errors unrelated to this change).
- Same on `main`: 804 passed (the +2 are the new regression tests).
- `test_ast_druid_translator.py`: 16 passed.
- `mypy` on all touched files: clean.

## Cycle notes
This took three review cycles. Cycle 1 shipped a fix without a real red→green test. Cycle 2 added the helper + cleaned PR-context comments but missed two orphan consumers (`CallExecutor` and `VariablesMustBeDefined`) — 360 engine tests were broken until cycle 3 caught them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of internal node mapping lookup mechanism across validation and execution layers to use consistent, position-based keys instead of unreliable object identity references.

* **Tests**
  * Added regression test validating stable node mapping behavior in query translation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roostorg/osprey/pull/291?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->