### PR TITLE
fix(compose): wait for healthchecks before starting osprey-ui-api

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -138,10 +138,14 @@ services:
       context: .
       dockerfile: osprey_worker/Dockerfile
     depends_on:
-      - osprey-worker
-      - druid-broker
-      - postgres
-      - snowflake-id-worker
+      osprey-worker:
+        condition: service_started
+      druid-broker:
+        condition: service_started
+      postgres:
+        condition: service_healthy
+      snowflake-id-worker:
+        condition: service_started
     ports:
       - "127.0.0.1:5004:5004"
     command: ["osprey-ui-api"]


### PR DESCRIPTION
## Description

Converts `osprey-ui-api.depends_on` in `docker-compose.yaml` from the bare list form to the long form with `condition:` keys, so the container waits for postgres to be `service_healthy` before starting.

On a clean boot the `osprey-ui-api` container was crashing with:

```
psycopg2.OperationalError: could not translate host name "postgres" to address: Name or service not known
```

The bare list form of `depends_on` only waits for the dependency container to be **started**, not **ready**. Postgres already defines a `pg_isready` healthcheck (line 260), so we can wait on it properly.

For the three other dependencies (`osprey-worker`, `druid-broker`, `snowflake-id-worker`), no `healthcheck:` is defined, so they stay on `service_started`. Adding healthchecks for those is plausible follow-up work but out of scope here.

Closes #96 (sub-item 2 of the friction log).

## Changes

- `osprey-ui-api.depends_on`: bare list -> long form with explicit `condition:` per dep
  - `postgres: service_healthy` (has pg_isready healthcheck)
  - `osprey-worker`, `druid-broker`, `snowflake-id-worker`: `service_started` (no healthcheck defined)

## Testing

Live boot verification deferred to the operator (a live osprey stack is running on this machine and shouldn't be disturbed).

Static verification:

- `docker compose -f docker-compose.yaml config --quiet` -> exit 0
- `python3 -c "import yaml; yaml.safe_load(open('docker-compose.yaml'))"` -> OK
- Rendered config shows all four entries resolve with the expected `condition` and `required: true`.

## Checklist

- [x] Static `docker compose config` validates
- [x] No scope creep (only the `osprey-ui-api.depends_on` block changed)
- [ ] Live `docker compose up` boot verified by operator