### PR TITLE
docs(setup): note ARM64 emulation expectations for demo stack

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -10,6 +10,16 @@ This guide provides comprehensive instructions for setting up a development envi
 - **[uv](https://docs.astral.sh/uv/)** for Python package management
 - **[npm](https://nodejs.org/en/download)**
 
+### Apple Silicon (ARM64) note
+
+Several images in the demo compose stack are published only for `linux/amd64` — notably `apache/druid` and `ghcr.io/ayubun/snowflake-id-worker` (and the `gcr.io/.../cloud-sdk` image if running with the optional bigtable emulator). On M1/M2/M3 Macs, Docker runs these under Rosetta 2 emulation; expect a one-time warning per service on first boot and slower startup. Functionality is unchanged.
+
+The warning looks like:
+
+```
+The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8)
+```
+
 ## Project Setup
 
 ### 1. Clone the Repository


### PR DESCRIPTION
## Summary
- Add a short Apple Silicon subsection under Prerequisites in `docs/DEVELOPMENT.md` documenting that several demo-compose images (`apache/druid`, `ghcr.io/ayubun/snowflake-id-worker`, and the optional bigtable cloud-sdk emulator) are `linux/amd64`-only and run under Rosetta 2 on M-series Macs.
- Include the verbatim platform-mismatch warning text so users searching for the error land on this section.

No `docker-compose.yaml` changes — this is docs-only.

## Test plan
- [ ] Spot-check that `docs/DEVELOPMENT.md` renders cleanly on the PR (markdown view).
- [ ] No SUMMARY.md update needed — the mdBook TOC only lists top-level pages, and the new subsection is in-page under the already-linked DEVELOPMENT.md.

Closes roostorg/osprey#96 (sub-item 5 of the friction log — platform mismatch warnings).