### PR TITLE
chore(compose): remove bigtable emulator from demo stack

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ uv sync --dev
 # Install git hooks
 uv run pre-commit install --install-hooks
 
-# Start full stack (Kafka, Postgres, Druid, MinIO, Bigtable emulator, worker, UI, UI API)
+# Start full stack (Kafka, Postgres, Druid, MinIO, worker, UI, UI API)
 docker compose up -d
 # or
 ./start.sh

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -47,10 +47,6 @@ services:
         condition: service_healthy
       osprey-kafka-topic-creator:
         condition: service_completed_successfully
-      bigtable:
-        condition: service_healthy
-      bigtable-initializer:
-        condition: service_completed_successfully
       minio:
         condition: service_healthy
       minio-bucket-init:
@@ -76,7 +72,6 @@ services:
       - DD_TRACE_ENABLED=False
       - DD_DOGSTATSD_DISABLE=True
       - OSPREY_RULES_SINK_NUM_WORKERS=1
-      - BIGTABLE_EMULATOR_HOST=bigtable:8361
       - OSPREY_EXECUTION_RESULT_STORAGE_BACKEND=minio
       - OSPREY_MINIO_ENDPOINT=minio:9000
       - OSPREY_MINIO_ACCESS_KEY=minioadmin

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -117,7 +117,6 @@ services:
       - DD_TRACE_ENABLED=False
       - DD_DOGSTATSD_DISABLE=True
       - OSPREY_RULES_SINK_NUM_WORKERS=1
-      - BIGTABLE_EMULATOR_HOST=bigtable:8361
       - OSPREY_EXECUTION_RESULT_STORAGE_BACKEND=minio
       - OSPREY_MINIO_ENDPOINT=minio:9000
       - OSPREY_MINIO_ACCESS_KEY=minioadmin
@@ -158,7 +157,6 @@ services:
       - DD_DOGSTATSD_DISABLE=True
       - OSPREY_RULES_PATH=/osprey/example_rules
       - OSPREY_DISABLE_VALIDATION_EXPORTER=true
-      - BIGTABLE_EMULATOR_HOST=bigtable:8361
       - SNOWFLAKE_API_ENDPOINT=http://snowflake-id-worker:8088
       - SNOWFLAKE_EPOCH=1420070400000
       - OSPREY_EXECUTION_RESULT_STORAGE_BACKEND=minio
@@ -201,34 +199,6 @@ services:
       - EPOCH=1420070400000
       - PORT=8088
     restart: unless-stopped
-
-  bigtable:
-    hostname: bigtable
-    container_name: bigtable
-    image: gcr.io/google.com/cloudsdktool/cloud-sdk:572.0.0@sha256:f67318c2d4719e3d9579ee724dd16b9d028ae916c4919586ae01e9e26d6c1beb
-    ports:
-      - "127.0.0.1:8361:8361"
-    command: >
-      bash -c "
-        gcloud beta emulators bigtable start --host-port=0.0.0.0:8361 --project=osprey-dev
-      "
-    healthcheck:
-      test: ["CMD", "bash", "-c", "pgrep -f cbtemulator > /dev/null || exit 1"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 60s
-    restart: unless-stopped
-
-  bigtable-initializer:
-    container_name: bigtable-initializer
-    image: gcr.io/google.com/cloudsdktool/cloud-sdk:572.0.0@sha256:f67318c2d4719e3d9579ee724dd16b9d028ae916c4919586ae01e9e26d6c1beb
-    depends_on:
-      bigtable:
-        condition: service_healthy
-    volumes:
-      - ./init-bigtable.sh:/init-bigtable.sh
-    command: ["/bin/bash", "/init-bigtable.sh"]
 
   # Optional test data generator - run with:
   # docker compose --profile test_data up osprey-kafka-test-data-producer -d


### PR DESCRIPTION
## Description

Removes the `bigtable` and `bigtable-initializer` services from `docker-compose.yaml` and `docker-compose.test.yaml`, along with the `BIGTABLE_EMULATOR_HOST` env var on `osprey-worker` and `osprey-ui-api`. The demo stack uses MinIO for execution-result storage (`OSPREY_EXECUTION_RESULT_STORAGE_BACKEND=minio`), so the bigtable emulator was unused dead weight slowing down boot for demo users.

Closes #96 — per @vinaysrao1:

> Remove bigtable from docker-compose.yaml. Saves a bunch of start up time for demo users.

### Why this is safe (investigation findings)

Bigtable is optional in osprey — not load-bearing at boot:

- `_stdlibplugin/sink_register.py` selects an execution-result store via `OSPREY_EXECUTION_RESULT_STORAGE_BACKEND`. Demo is set to `minio`, which returns `StoredExecutionResultMinIO`. `StoredExecutionResultBigTable` is only constructed when the backend is `BIGTABLE`.
- `osprey_bigtable` in `lib/storage/bigtable.py` is a lazy singleton. Its `_setup_client_instance()` (which calls `Client(...)`) only runs when `.table()` or `.bootstrap()` is invoked. Importing the module is side-effect-free beyond registering a config callback.
- `_bootstrap_bigtable()` in `cli/sinks.py` only runs when `run-rules-sink --bootstrap-bigtable` is passed. The worker entrypoint (`entrypoint.sh` → `cli-osprey-worker`) does not pass that flag.
- `access_audit_log.py` references bigtable, but all of those lines are commented out.
- No service had `bigtable` or `bigtable-initializer` in `depends_on`, so nothing else needed editing.

`docker compose -f docker-compose.yaml config --quiet` passes after the change.

### Scope

- `docker-compose.yaml`: remove two services + two env vars.
- `AGENTS.md`: update the demo-stack listing comment to drop "Bigtable emulator".

### Out-of-scope follow-ups (intentionally not addressed here)

- `init-bigtable.sh` is now orphaned (only referenced by the removed `bigtable-initializer` service). Left in place to keep the diff scoped; safe to delete in a follow-up.
- `google-cloud-bigtable==2.10.0` is still in `pyproject.toml` because `StoredExecutionResultBigTable` remains a valid backend choice for non-demo deployments.

## Checklist

- [x] Tests pass locally (no Python touched; pre-commit hooks ran clean on changed files)
- [x] `uv run ruff check .` — n/a (no Python changes)
- [x] `uv tool run fawltydeps --check-unused --pyenv .venv` — n/a (no dep changes)
- [ ] Updated `CHANGELOG.md` with my changes, if applicable — n/a (compose-only demo cleanup)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified local environment setup by removing Bigtable emulator startup and related configuration references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->