### PR TITLE
fix(query-view): default time range to a relative window anchored at now

### DIFF
--- a/osprey_ui/src/utils/QueryStoreUtils.test.tsx
+++ b/osprey_ui/src/utils/QueryStoreUtils.test.tsx
@@ -109,6 +109,20 @@ describe('extractQueryStateFromSearchParams', () => {
     });
   });
 
+  describe('home route with an unknown interval value', () => {
+    it('falls back to the URL timestamps (or empty) and does not throw on an unrecognized interval', () => {
+      const state = extractQueryStateFromSearchParams(
+        makeLocation('?interval=garbage&start=2025-01-01T00:00:00Z&end=2025-01-02T00:00:00Z')
+      );
+
+      // Unknown interval is preserved as-is from the URL (existing cast
+      // behavior); the start/end fall through to the URL values without
+      // attempting to recompute against a missing IntervalOptions entry.
+      expect(state.executedQuery.start).toBe('2025-01-01T00:00:00Z');
+      expect(state.executedQuery.end).toBe('2025-01-02T00:00:00Z');
+    });
+  });
+
   describe('saveQueryToHistory side effect', () => {
     beforeEach(() => {
       mockedSaveQueryToHistory.mockClear();

--- a/osprey_ui/src/utils/QueryStoreUtils.test.tsx
+++ b/osprey_ui/src/utils/QueryStoreUtils.test.tsx
@@ -1,0 +1,131 @@
+import { Location } from 'history';
+import dayjs from 'dayjs';
+
+import '../utils/DayjsSetup';
+
+import { saveQueryToHistory } from '../actions/QueryActions';
+import { extractQueryStateFromSearchParams } from './QueryStoreUtils';
+
+jest.mock('../actions/QueryActions', () => {
+  return {
+    saveQueryToHistory: jest.fn(),
+  };
+});
+
+const mockedSaveQueryToHistory = saveQueryToHistory as jest.Mock;
+
+const makeLocation = (search: string): Location => {
+  return {
+    pathname: '/',
+    search,
+    hash: '',
+    state: undefined,
+    key: 'test',
+  } as Location;
+};
+
+const ONE_MINUTE_MS = 60 * 1000;
+
+const expectIsApproximatelyNow = (timestamp: string, toleranceMs: number = ONE_MINUTE_MS): void => {
+  const diff = Math.abs(dayjs.utc(timestamp).diff(dayjs.utc()));
+  expect(diff).toBeLessThanOrEqual(toleranceMs);
+};
+
+const expectIsApproximatelyNowMinus = (
+  timestamp: string,
+  amount: number,
+  unit: dayjs.ManipulateType,
+  toleranceMs: number = ONE_MINUTE_MS
+): void => {
+  const expected = dayjs.utc().subtract(amount, unit);
+  const diff = Math.abs(dayjs.utc(timestamp).diff(expected));
+  expect(diff).toBeLessThanOrEqual(toleranceMs);
+};
+
+describe('extractQueryStateFromSearchParams', () => {
+  describe('home route with no URL params (fresh page load)', () => {
+    it('populates start and end from the default 1-day interval relative to now', () => {
+      const state = extractQueryStateFromSearchParams(makeLocation(''));
+
+      expect(state.executedQuery.interval).toBe('day');
+      expect(state.executedQuery.start).not.toBe('');
+      expect(state.executedQuery.end).not.toBe('');
+      expectIsApproximatelyNowMinus(state.executedQuery.start, 1, 'day');
+      expectIsApproximatelyNow(state.executedQuery.end);
+    });
+  });
+
+  describe('home route with relative interval and stale timestamps', () => {
+    it('recomputes start and end from the interval relative to now (ignores stale URL timestamps)', () => {
+      const staleStart = '2025-01-01T00:00:00Z';
+      const staleEnd = '2025-01-02T00:00:00Z';
+      const state = extractQueryStateFromSearchParams(
+        makeLocation(`?interval=day&start=${encodeURIComponent(staleStart)}&end=${encodeURIComponent(staleEnd)}`)
+      );
+
+      expect(state.executedQuery.interval).toBe('day');
+      // The URL timestamps were from 2025-01-01, but interval=day means "last
+      // 24h relative to now" — the returned range must be fresh.
+      expect(state.executedQuery.start).not.toBe(staleStart);
+      expect(state.executedQuery.end).not.toBe(staleEnd);
+      expectIsApproximatelyNowMinus(state.executedQuery.start, 1, 'day');
+      expectIsApproximatelyNow(state.executedQuery.end);
+    });
+
+    it('recomputes start and end for a different relative interval (twoHours)', () => {
+      const state = extractQueryStateFromSearchParams(
+        makeLocation(`?interval=twoHours&start=2025-01-01T00:00:00Z&end=2025-01-01T02:00:00Z`)
+      );
+
+      expect(state.executedQuery.interval).toBe('twoHours');
+      expectIsApproximatelyNowMinus(state.executedQuery.start, 2, 'hour');
+      expectIsApproximatelyNow(state.executedQuery.end);
+    });
+  });
+
+  describe('home route with custom interval and explicit timestamps', () => {
+    it('preserves the explicit start and end timestamps from the URL', () => {
+      const explicitStart = '2025-01-01T00:00:00Z';
+      const explicitEnd = '2025-01-02T00:00:00Z';
+      const state = extractQueryStateFromSearchParams(
+        makeLocation(
+          `?interval=custom&start=${encodeURIComponent(explicitStart)}&end=${encodeURIComponent(explicitEnd)}`
+        )
+      );
+
+      expect(state.executedQuery.interval).toBe('custom');
+      expect(state.executedQuery.start).toBe(explicitStart);
+      expect(state.executedQuery.end).toBe(explicitEnd);
+    });
+  });
+
+  describe('home route with relative interval but no timestamps', () => {
+    it('derives fresh timestamps from the interval', () => {
+      const state = extractQueryStateFromSearchParams(makeLocation('?interval=hour'));
+
+      expect(state.executedQuery.interval).toBe('hour');
+      expectIsApproximatelyNowMinus(state.executedQuery.start, 1, 'hour');
+      expectIsApproximatelyNow(state.executedQuery.end);
+    });
+  });
+
+  describe('saveQueryToHistory side effect', () => {
+    beforeEach(() => {
+      mockedSaveQueryToHistory.mockClear();
+    });
+
+    it('does not save to history when the URL had no explicit timestamps (fresh page load)', () => {
+      extractQueryStateFromSearchParams(makeLocation(''));
+
+      expect(mockedSaveQueryToHistory).not.toHaveBeenCalled();
+    });
+
+    it('saves to history when the URL has explicit start and end timestamps', () => {
+      extractQueryStateFromSearchParams(
+        makeLocation('?interval=custom&start=2025-01-01T00:00:00Z&end=2025-01-02T00:00:00Z')
+      );
+
+      expect(mockedSaveQueryToHistory).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/osprey_ui/src/utils/QueryStoreUtils.tsx
+++ b/osprey_ui/src/utils/QueryStoreUtils.tsx
@@ -5,6 +5,7 @@ import { saveQueryToHistory } from '../actions/QueryActions';
 import {
   BaseQuery,
   DefaultIntervals,
+  IntervalOptions,
   QueryState,
   CustomSummaryFeatures,
   ScanQueryOrder,
@@ -50,7 +51,7 @@ export function extractQueryStateFromSearchParams(location: Location): QueryStor
   // the user picked from the date-range picker.
   let start = startParam;
   let end = endParam;
-  if (interval != null && interval !== CUSTOM_RANGE_OPTION) {
+  if (interval != null && interval !== CUSTOM_RANGE_OPTION && interval in IntervalOptions) {
     const derived = getQueryDateRange(interval);
     start = derived.start;
     end = derived.end;

--- a/osprey_ui/src/utils/QueryStoreUtils.tsx
+++ b/osprey_ui/src/utils/QueryStoreUtils.tsx
@@ -12,7 +12,7 @@ import {
   TopNTable,
   Chart,
 } from '../types/QueryTypes';
-import { getQueryDateRange, isEmptyDateRange } from './QueryUtils';
+import { CUSTOM_RANGE_OPTION, getQueryDateRange, isEmptyDateRange } from './QueryUtils';
 
 import { Routes } from '../Constants';
 
@@ -35,15 +35,33 @@ export function extractQueryStateFromSearchParams(location: Location): QueryStor
 
   const customSummaryFeatures = queryString.getAll('customSummaryFeatures');
 
+  const intervalParam = queryString.get('interval');
+  const interval: DefaultIntervals =
+    intervalParam != null && intervalParam !== '' ? (intervalParam as DefaultIntervals) : 'day';
+
+  const startParam = queryString.get('start') || '';
+  const endParam = queryString.get('end') || '';
+  const hasExplicitDateRange = !isEmptyDateRange(startParam, endParam);
+
+  // For relative intervals ("Last Hour", "Last Day", etc.), always derive
+  // start/end from "now" so the query reflects the user-intended relative
+  // window — not whatever stale timestamps may be on the URL from a
+  // previous session. Custom intervals preserve the explicit timestamps
+  // the user picked from the date-range picker.
+  let start = startParam;
+  let end = endParam;
+  if (interval != null && interval !== CUSTOM_RANGE_OPTION) {
+    const derived = getQueryDateRange(interval);
+    start = derived.start;
+    end = derived.end;
+  }
+
   const queryState = {
     executedQuery: {
       queryFilter: queryString.get('queryFilter') || '',
-      start: queryString.get('start') || '',
-      end: queryString.get('end') || '',
-      interval:
-        queryString.get('interval') != null && queryString.get('interval') !== ''
-          ? (queryString.get('interval') as DefaultIntervals)
-          : 'day',
+      start,
+      end,
+      interval,
     },
     // Parse a `ScanQueryOrder` from the query string, defaulting to `descending` if the order isn't understood or
     // not provided.
@@ -55,10 +73,10 @@ export function extractQueryStateFromSearchParams(location: Location): QueryStor
     customSummaryFeatures: customSummaryFeatures.length === 0 ? null : customSummaryFeatures,
   };
 
-  const { start, end } = queryState.executedQuery;
-
-  // Do not save queries from the entity view yet
-  if (!isEntityView && !isEmptyDateRange(start, end)) {
+  // Only save to query history when the URL provided explicit timestamps —
+  // a derived default range from loading the page without explicit params
+  // is not a query the user ran.
+  if (!isEntityView && hasExplicitDateRange) {
     saveQueryToHistory(queryState);
   }
 


### PR DESCRIPTION
## Description

Fixes the issue from the friction log #96 (sub-item 4) where the query view shows no data by default.

### Root cause

Two failure modes shared one root cause: the URL stored `start`/`end` as **frozen literal timestamps** while `interval` (when not `custom`) carried the **semantic intent** of "relative to now". `extractQueryStateFromSearchParams` in \`osprey_ui/src/utils/QueryStoreUtils.tsx\` never derived start/end from the relative interval at extraction time.

Both theories from the dispatch were correct:

- **Fresh page load (operator's claim):** With no URL params, the initial state was \`{start: '', end: '', interval: 'day'}\`. \`Timeseries.tsx\` and \`EventStream.tsx\` short-circuit fetches on empty start/end (\`if (start !== '' && end !== '')\`), so graphs and the event stream sat empty until the user clicked Submit — without any indication that submit was needed.
- **Bookmarked URL with stale timestamps (friction log's theory):** When a user submitted \`interval=day\` at noon, the URL got \`start=2025-12-12T11:00Z&end=2025-12-12T12:00Z&interval=day\`. Reloading that URL the next day queried the now-stale 24h window from the previous session, so recent data fell outside the range and the graphs rendered "No data available".

### Fix

In \`extractQueryStateFromSearchParams\`:

- When \`interval\` is a non-\`custom\` value (and is a known \`IntervalOptions\` key), derive \`start\`/\`end\` from \`now\` via the existing \`getQueryDateRange\` utility. Custom intervals still preserve the explicit timestamps the user picked from the date-range picker.
- Only call \`saveQueryToHistory\` when the URL actually had explicit start/end timestamps, so a fresh page load with a derived default range doesn't record a phantom query history entry.

The defensive \`interval in IntervalOptions\` check guards against a URL with an unrecognized \`interval=\` value (which would otherwise blow up in \`getQueryDateRange\`'s destructuring).

### Tests

Added \`osprey_ui/src/utils/QueryStoreUtils.test.tsx\` covering:

- Fresh page load (no URL params) → start/end derived to \`now - 1d\` / \`now\`
- URL with relative interval + stale timestamps → start/end recomputed fresh
- URL with custom interval → explicit timestamps preserved
- URL with relative interval but no timestamps → derived
- URL with unknown interval value → falls through without throwing
- \`saveQueryToHistory\` only fires when URL had explicit timestamps

### Out of scope

- Browser caching of empty responses (friction log mentions this; it's a separate concern from the time-range bug and didn't seem like the right place to fix it).
- Adding a "Last hour" / "Last 30 min" quick-select option (the friction log mentions it; \`IntervalOptions\` already has \`hour\`, \`thirtyMinutes\`, \`tenMinutes\`, etc. — they're available in the dropdown, just not the default).

Closes #96 will be set once the operator confirms; for now this is sub-item 4 of the friction log, so refs roostorg/osprey#96.

## Checklist

- [x] Tests pass locally (\`react-scripts test\` — 8 tests, 0 failures)
- [x] \`uv run ruff check .\` passes — no Python changes; \`pre-commit run --all-files\` clean
- [x] \`uv tool run fawltydeps --check-unused --pyenv .venv\` — N/A (no Python changes)
- [x] Updated \`CHANGELOG.md\` — N/A