### PR TITLE
Add GetActionId() stdlib UDF + ExecutionContext.get_action_id()

### DIFF
--- a/example_rules/models/base.sml
+++ b/example_rules/models/base.sml
@@ -12,3 +12,5 @@ EventType: Entity[str] = EntityJson(
 
 ActionName=GetActionName()
 
+ActionId=GetActionId()
+

--- a/osprey_worker/src/osprey/engine/executor/execution_context.py
+++ b/osprey_worker/src/osprey/engine/executor/execution_context.py
@@ -172,6 +172,10 @@ class ExecutionContext:
         """Returns the action name that the execution context is currently being invoked upon."""
         return self._action.action_name
 
+    def get_action_id(self) -> int:
+        """Returns the action id of the event that the execution context is currently being invoked upon."""
+        return self._action.action_id
+
     def get_action_time(self) -> datetime:
         """Returns the time of the action that the execution context is currently being invoked upon."""
         return self._action.timestamp

--- a/osprey_worker/src/osprey/engine/stdlib/udfs/get_action_id.py
+++ b/osprey_worker/src/osprey/engine/stdlib/udfs/get_action_id.py
@@ -1,0 +1,15 @@
+from ._prelude import ArgumentsBase, ExecutionContext, UDFBase
+from .categories import UdfCategories
+
+
+class Arguments(ArgumentsBase):
+    pass
+
+
+class GetActionId(UDFBase[Arguments, int]):
+    """Returns the Action ID of the event being processed."""
+
+    category = UdfCategories.ENGINE
+
+    def execute(self, execution_context: ExecutionContext, arguments: Arguments) -> int:
+        return execution_context.get_action_id()

--- a/osprey_worker/src/osprey/engine/stdlib/udfs/tests/test_get_action_id.py
+++ b/osprey_worker/src/osprey/engine/stdlib/udfs/tests/test_get_action_id.py
@@ -1,12 +1,10 @@
-from typing import Any, Callable, List
-
 import pytest
 from osprey.engine.ast_validator.validators.validate_call_kwargs import ValidateCallKwargs
 from osprey.engine.conftest import ExecuteFunction
 from osprey.engine.stdlib.udfs.get_action_id import GetActionId
 from osprey.engine.udf.registry import UDFRegistry
 
-pytestmark: List[Callable[[Any], Any]] = [
+pytestmark = [
     pytest.mark.use_validators([ValidateCallKwargs]),
     pytest.mark.use_udf_registry(UDFRegistry.with_udfs(GetActionId)),
 ]

--- a/osprey_worker/src/osprey/engine/stdlib/udfs/tests/test_get_action_id.py
+++ b/osprey_worker/src/osprey/engine/stdlib/udfs/tests/test_get_action_id.py
@@ -1,0 +1,18 @@
+from typing import Any, Callable, List
+
+import pytest
+from osprey.engine.ast_validator.validators.validate_call_kwargs import ValidateCallKwargs
+from osprey.engine.conftest import ExecuteFunction
+from osprey.engine.stdlib.udfs.get_action_id import GetActionId
+from osprey.engine.udf.registry import UDFRegistry
+
+pytestmark: List[Callable[[Any], Any]] = [
+    pytest.mark.use_validators([ValidateCallKwargs]),
+    pytest.mark.use_udf_registry(UDFRegistry.with_udfs(GetActionId)),
+]
+
+
+def test_execute(execute: ExecuteFunction) -> None:
+    data = execute('ActionId = GetActionId()', data={}, action_id=42)
+
+    assert data == {'ActionId': 42}

--- a/osprey_worker/src/osprey/worker/_stdlibplugin/udf_register.py
+++ b/osprey_worker/src/osprey/worker/_stdlibplugin/udf_register.py
@@ -12,6 +12,7 @@ from osprey.engine.stdlib.udfs.experiments import (
     InExperiment,
 )
 from osprey.engine.stdlib.udfs.extract_cookie import ExtractCookie
+from osprey.engine.stdlib.udfs.get_action_id import GetActionId
 from osprey.engine.stdlib.udfs.get_action_name import GetActionName
 from osprey.engine.stdlib.udfs.import_ import Import
 from osprey.engine.stdlib.udfs.ip_network import IpNetwork
@@ -86,6 +87,7 @@ def register_udfs() -> Sequence[Type[UDFBase[Any, Any]]]:
         ExperimentsBucketAssignment,
         InExperiment,
         ExtractCookie,
+        GetActionId,
         GetActionName,
         HasLabel,
         Import,


### PR DESCRIPTION
## Summary

Symmetric with the existing `GetActionName()` UDF: gives SML rules access to the `action_id` of the event being processed, so they can emit it as an extracted feature for round-trip tracking, audit trails, or dedup.

`example_rules/models/base.sml` is updated to expose `ActionId = GetActionId()` alongside the existing `ActionName`, so the default example rule set's output includes the action_id without requiring every rule author to wire it up themselves.

First of a five-PR split for the stress harness work tracked in #324. This PR is the engine-level primitive; the harness itself uses it but other rule authors will benefit too (audit trails, debugging, dedup, idempotency).

## Test plan

- [x] `pytest osprey_worker/src/osprey/engine/stdlib/udfs/tests/test_get_action_id.py` — passes
- [x] `pytest osprey_worker/src/osprey/engine/stdlib/udfs/tests/test_get_action_name.py` — still passes (regression check on the existing symmetric UDF)
- [x] `uv run ruff check` — clean
- [x] `uv run mypy` — clean
- [ ] Full integration suite — runs in CI

## Related

- Sibling PRs (to come): reporter, producer, consumer, CLI for `osprey-stress`
- Sub-issue of #304 (integration test design)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New GetActionId UDF available for rules to access the current action identifier.

* **Tests**
  * Added test coverage for GetActionId behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->