### PR TITLE
Wire UI API to the MinIO execution-result backend (fixes #331)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -142,6 +142,7 @@ services:
       - druid-broker
       - postgres
       - snowflake-id-worker
+      - minio
     ports:
       - "127.0.0.1:5004:5004"
     command: ["osprey-ui-api"]
@@ -160,6 +161,16 @@ services:
       - BIGTABLE_EMULATOR_HOST=bigtable:8361
       - SNOWFLAKE_API_ENDPOINT=http://snowflake-id-worker:8088
       - SNOWFLAKE_EPOCH=1420070400000
+      # Must mirror the worker's storage backend config so the UI API can
+      # read back the execution results the worker wrote. Without these,
+      # POST /events/scan returns 500 with "No storage backend registered".
+      # See #331.
+      - OSPREY_EXECUTION_RESULT_STORAGE_BACKEND=minio
+      - OSPREY_MINIO_ENDPOINT=minio:9000
+      - OSPREY_MINIO_ACCESS_KEY=minioadmin
+      - OSPREY_MINIO_SECRET_KEY=minioadmin123
+      - OSPREY_MINIO_SECURE=false
+      - OSPREY_MINIO_EXECUTION_RESULTS_BUCKET=execution-output
     volumes:
       - ./osprey_worker:/osprey/osprey_worker
       - ./osprey_rpc:/osprey/osprey_rpc


### PR DESCRIPTION
## Summary

The base \`docker-compose.yaml\` has been configuring the **worker** to write execution results to MinIO but not telling the **UI API** how to read them back, so any UI page that calls \`POST /events/scan\` returns 500 with \`AssertionError: No storage backend registered\`.

Mirrors the worker's six MinIO env vars on \`osprey-ui-api\` and adds \`minio\` to its \`depends_on\` so it doesn't race the bucket-init on cold starts.

Closes #331.

## How long this has been broken

Bisected to #15 (\"Add an output sink writing results to minio, pluggify storage option\", Sep 29, 2025) — that PR refactored \`/events/scan\` to require explicit storage-backend config and added \`OSPREY_EXECUTION_RESULT_STORAGE_BACKEND=minio\` to the worker's compose env but missed the UI API. Druid-backed UI pages (timeseries, topn) kept working, so the bug went unnoticed until the row-scan view was exercised against the default stack.

## Test plan

- [x] \`docker compose config\` — validates clean
- [x] Manually verified locally (against the JetStream demo from #236): with the env added, \`POST /events/scan\` returns 200 with a populated result payload (~113 KB in my run). Without the env, the same call returns 500 with the AssertionError.
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated configuration to enable the application to properly retrieve and display stored execution results through the storage backend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->