### PR TITLE
ci: create license-check workflows

### DIFF
--- a/.github/allowed-licenses.txt
+++ b/.github/allowed-licenses.txt
@@ -1,0 +1,14 @@
+0BSD
+Apache-2.0
+Apache-2.0 WITH LLVM-exception
+BSD-2-Clause
+BSD-3-Clause
+BlueOak-1.0.0
+BSL-1.0
+CC0-1.0
+ISC
+MIT
+MPL-2.0
+Python-2.0
+Unicode-3.0
+Unlicense

--- a/.github/allowed-licenses.txt
+++ b/.github/allowed-licenses.txt
@@ -10,6 +10,5 @@ ISC
 MIT
 MPL-2.0
 Python-2.0
-Python Software Foundation License
 Unicode-3.0
 Unlicense

--- a/.github/allowed-licenses.txt
+++ b/.github/allowed-licenses.txt
@@ -10,5 +10,6 @@ ISC
 MIT
 MPL-2.0
 Python-2.0
+Python Software Foundation License
 Unicode-3.0
 Unlicense

--- a/.github/allowed-licenses.txt
+++ b/.github/allowed-licenses.txt
@@ -12,3 +12,4 @@ MPL-2.0
 Python-2.0
 Unicode-3.0
 Unlicense
+ZPL-2.1

--- a/.github/pip-licenses-classifiers.txt
+++ b/.github/pip-licenses-classifiers.txt
@@ -1,5 +1,15 @@
 Apache Software License
+Apache 2.0
+Apache License 2.0
 BSD License
+BSD
 3-Clause BSD License
+BSD License; Public Domain
+Apache Software License; BSD License
 MIT License
+Mozilla Public License 2.0 (MPL 2.0)
+ISC License (ISCL)
+CC0 1.0 Universal (CC0 1.0) Public Domain Dedication
 Python Software Foundation License
+Apache-2.0 OR BSD-2-Clause
+BSD 3-Clause OR Apache-2.0

--- a/.github/pip-licenses-classifiers.txt
+++ b/.github/pip-licenses-classifiers.txt
@@ -1,0 +1,4 @@
+Apache Software License
+BSD License
+MIT License
+Python Software Foundation License

--- a/.github/pip-licenses-classifiers.txt
+++ b/.github/pip-licenses-classifiers.txt
@@ -1,4 +1,5 @@
 Apache Software License
 BSD License
+3-Clause BSD License
 MIT License
 Python Software Foundation License

--- a/.github/workflows/license-check-node.yml
+++ b/.github/workflows/license-check-node.yml
@@ -31,4 +31,5 @@ jobs:
 
       - name: Check licenses
         working-directory: osprey_ui
-        run: pnpm dlx license-checker@25.0.1 --production --excludePrivatePackages --onlyAllow "$ALLOWED_LICENSES"
+        # highcharts is excluded pending license resolution in #319
+        run: pnpm dlx license-checker@25.0.1 --production --excludePrivatePackages --excludePackages highcharts --onlyAllow "$ALLOWED_LICENSES"

--- a/.github/workflows/license-check-node.yml
+++ b/.github/workflows/license-check-node.yml
@@ -1,0 +1,33 @@
+name: License Check (Node)
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'osprey_ui/package.json'
+      - 'osprey_ui/package-lock.json'
+      - '.github/allowed-licenses.txt'
+permissions:
+  contents: read
+jobs:
+  check:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "18"
+          cache: npm
+          cache-dependency-path: osprey_ui/package-lock.json
+
+      - name: Format license list
+        run: echo "ALLOWED_LICENSES=$(tr '\n' ';' < .github/allowed-licenses.txt | sed 's/;$//')" >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        working-directory: osprey_ui
+        run: npm ci --omit=dev --ignore-scripts
+
+      - name: Check licenses
+        working-directory: osprey_ui
+        run: npx --yes license-checker@25.0.1 --production --excludePrivatePackages --onlyAllow "$ALLOWED_LICENSES"

--- a/.github/workflows/license-check-node.yml
+++ b/.github/workflows/license-check-node.yml
@@ -23,7 +23,10 @@ jobs:
           cache-dependency-path: osprey_ui/pnpm-lock.yaml
 
       - name: Format license list
-        run: echo "ALLOWED_LICENSES=$(tr '\n' ';' < .github/allowed-licenses.txt | sed 's/;$//')" >> "$GITHUB_ENV"
+        run: |
+          SPDX=$(tr '\n' ';' < .github/allowed-licenses.txt | sed 's/;$//')
+          # highcharts uses a custom proprietary license; allowed for now pending #319
+          echo "ALLOWED_LICENSES=${SPDX};Custom: https://www.npmjs.com/package/highcharts-export-server" >> "$GITHUB_ENV"
 
       - name: Install dependencies
         working-directory: osprey_ui
@@ -31,5 +34,4 @@ jobs:
 
       - name: Check licenses
         working-directory: osprey_ui
-        # highcharts is excluded pending license resolution in #319
-        run: pnpm dlx license-checker@25.0.1 --production --excludePrivatePackages --excludePackages highcharts --onlyAllow "$ALLOWED_LICENSES"
+        run: pnpm dlx license-checker@25.0.1 --production --excludePrivatePackages --onlyAllow "$ALLOWED_LICENSES"

--- a/.github/workflows/license-check-node.yml
+++ b/.github/workflows/license-check-node.yml
@@ -4,7 +4,7 @@ on:
     branches: [main]
     paths:
       - 'osprey_ui/package.json'
-      - 'osprey_ui/package-lock.json'
+      - 'osprey_ui/pnpm-lock.yaml'
       - '.github/allowed-licenses.txt'
 permissions:
   contents: read
@@ -15,19 +15,20 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - run: corepack enable pnpm
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "18"
-          cache: npm
-          cache-dependency-path: osprey_ui/package-lock.json
+          node-version: "22"
+          cache: pnpm
+          cache-dependency-path: osprey_ui/pnpm-lock.yaml
 
       - name: Format license list
         run: echo "ALLOWED_LICENSES=$(tr '\n' ';' < .github/allowed-licenses.txt | sed 's/;$//')" >> "$GITHUB_ENV"
 
       - name: Install dependencies
         working-directory: osprey_ui
-        run: npm ci --omit=dev --ignore-scripts
+        run: pnpm install --prod --frozen-lockfile --ignore-scripts
 
       - name: Check licenses
         working-directory: osprey_ui
-        run: npx --yes license-checker@25.0.1 --production --excludePrivatePackages --onlyAllow "$ALLOWED_LICENSES"
+        run: pnpm dlx license-checker@25.0.1 --production --excludePrivatePackages --onlyAllow "$ALLOWED_LICENSES"

--- a/.github/workflows/license-check-node.yml
+++ b/.github/workflows/license-check-node.yml
@@ -19,8 +19,6 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "22"
-          cache: pnpm
-          cache-dependency-path: osprey_ui/pnpm-lock.yaml
 
       - name: Format license list
         run: |

--- a/.github/workflows/license-check-python.yml
+++ b/.github/workflows/license-check-python.yml
@@ -1,0 +1,36 @@
+name: License Check (Python)
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - 'osprey_rpc/pyproject.toml'
+      - 'osprey_worker/pyproject.toml'
+      - 'example_plugins/pyproject.toml'
+      - '.github/allowed-licenses.txt'
+permissions:
+  contents: read
+jobs:
+  check:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version-file: .python-version
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
+      - name: Format license list
+        run: echo "ALLOWED_LICENSES=$(tr '\n' ';' < .github/allowed-licenses.txt | sed 's/;$//')" >> "$GITHUB_ENV"
+
+      - name: Install production dependencies
+        run: uv sync --only-group common
+
+      - name: Install pip-licenses
+        run: uv pip install pip-licenses==5.0.0
+
+      - name: Check licenses
+        run: uv run pip-licenses --allow-only "$ALLOWED_LICENSES"

--- a/.github/workflows/license-check-python.yml
+++ b/.github/workflows/license-check-python.yml
@@ -39,4 +39,7 @@ jobs:
         run: uv pip install pip-licenses==5.0.0
 
       - name: Check licenses
-        run: uv run pip-licenses --allow-only "$ALLOWED_LICENSES"
+        run: |
+          # google-crc32c is Apache-2.0 but 1.8.0 omits license metadata in PyPI (fix merged,
+          # not yet released); ignored pending googleapis/google-cloud-python#16515
+          uv run pip-licenses --allow-only "$ALLOWED_LICENSES" --ignore-packages google-crc32c

--- a/.github/workflows/license-check-python.yml
+++ b/.github/workflows/license-check-python.yml
@@ -9,6 +9,7 @@ on:
       - 'osprey_worker/pyproject.toml'
       - 'example_plugins/pyproject.toml'
       - '.github/allowed-licenses.txt'
+      - '.github/pip-licenses-classifiers.txt'
 permissions:
   contents: read
 jobs:
@@ -25,10 +26,11 @@ jobs:
 
       - name: Format license list
         run: |
-          # pip-licenses uses PyPI classifier names, not SPDX IDs, for some packages.
-          # Append the pip-licenses equivalents for licenses already approved in allowed-licenses.txt.
+          # pip-licenses reports PyPI classifier names rather than SPDX IDs for some packages.
+          # allowed-licenses.txt is the policy (SPDX); pip-licenses-classifiers.txt is the translation layer.
           SPDX=$(tr '\n' ';' < .github/allowed-licenses.txt | sed 's/;$//')
-          echo "ALLOWED_LICENSES=${SPDX};Apache Software License;BSD License;Python Software Foundation License" >> "$GITHUB_ENV"
+          CLASSIFIERS=$(tr '\n' ';' < .github/pip-licenses-classifiers.txt | sed 's/;$//')
+          echo "ALLOWED_LICENSES=${SPDX};${CLASSIFIERS}" >> "$GITHUB_ENV"
 
       - name: Install production dependencies
         run: uv sync --only-group common

--- a/.github/workflows/license-check-python.yml
+++ b/.github/workflows/license-check-python.yml
@@ -28,7 +28,7 @@ jobs:
           # pip-licenses uses PyPI classifier names, not SPDX IDs, for some packages.
           # Append the pip-licenses equivalents for licenses already approved in allowed-licenses.txt.
           SPDX=$(tr '\n' ';' < .github/allowed-licenses.txt | sed 's/;$//')
-          echo "ALLOWED_LICENSES=${SPDX};Apache Software License;Python Software Foundation License" >> "$GITHUB_ENV"
+          echo "ALLOWED_LICENSES=${SPDX};Apache Software License;BSD License;Python Software Foundation License" >> "$GITHUB_ENV"
 
       - name: Install production dependencies
         run: uv sync --only-group common

--- a/.github/workflows/license-check-python.yml
+++ b/.github/workflows/license-check-python.yml
@@ -36,7 +36,7 @@ jobs:
         run: uv sync --only-group common
 
       - name: Install pip-licenses
-        run: uv pip install pip-licenses==5.0.0
+        run: uv pip install pip-licenses==5.5.5
 
       - name: Check licenses
         run: |

--- a/.github/workflows/license-check-python.yml
+++ b/.github/workflows/license-check-python.yml
@@ -40,6 +40,21 @@ jobs:
 
       - name: Check licenses
         run: |
-          # google-crc32c is Apache-2.0 but 1.8.0 omits license metadata in PyPI (fix merged,
-          # not yet released); ignored pending googleapis/google-cloud-python#16515
-          uv run pip-licenses --allow-only "$ALLOWED_LICENSES" --ignore-packages google-crc32c
+          # Packages ignored due to broken/missing PyPI metadata (license is known and approved):
+          #   google-crc32c: Apache-2.0; no metadata in 1.8.0 (googleapis/google-cloud-python#16515)
+          #   ddtrace: Apache-2.0 OR BSD-3-Clause; sets License field to a filename ("LICENSE.BSD3")
+          # First-party packages (no license metadata needed):
+          #   osprey-rpc, osprey-worker, example_plugins
+          # Packages pending license policy review:
+          #   unidecode: GPL v2+ (#354)
+          #   tld: GPL v2 / LGPL / MPL 1.1 (#355)
+          #   nostril: LGPL 2.1 (#356)
+          #   psycopg2-binary: LGPL (#357)
+          #   simplejson: Academic Free License + MIT (#358)
+          #   text-unidecode: Artistic + GPL (transitive via faker) (#359)
+          uv run pip-licenses --allow-only "$ALLOWED_LICENSES" \
+            --ignore-packages \
+              google-crc32c \
+              ddtrace \
+              osprey-rpc osprey-worker example_plugins \
+              unidecode tld nostril psycopg2-binary simplejson text-unidecode

--- a/.github/workflows/license-check-python.yml
+++ b/.github/workflows/license-check-python.yml
@@ -24,7 +24,11 @@ jobs:
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Format license list
-        run: echo "ALLOWED_LICENSES=$(tr '\n' ';' < .github/allowed-licenses.txt | sed 's/;$//')" >> "$GITHUB_ENV"
+        run: |
+          # pip-licenses uses PyPI classifier names, not SPDX IDs, for some packages.
+          # Append the pip-licenses equivalents for licenses already approved in allowed-licenses.txt.
+          SPDX=$(tr '\n' ';' < .github/allowed-licenses.txt | sed 's/;$//')
+          echo "ALLOWED_LICENSES=${SPDX};Apache Software License;Python Software Foundation License" >> "$GITHUB_ENV"
 
       - name: Install production dependencies
         run: uv sync --only-group common

--- a/.github/workflows/license-check-rust.yml
+++ b/.github/workflows/license-check-rust.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - 'osprey_coordinator/Cargo.toml'
+      - 'osprey_coordinator/**/Cargo.toml'
       - '.github/allowed-licenses.txt'
 permissions:
   contents: read

--- a/.github/workflows/license-check-rust.yml
+++ b/.github/workflows/license-check-rust.yml
@@ -1,0 +1,26 @@
+name: License Check (Rust)
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'osprey_coordinator/Cargo.toml'
+      - '.github/allowed-licenses.txt'
+permissions:
+  contents: read
+jobs:
+  check:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Generate deny.toml
+        run: |
+          { echo '[licenses]'; echo 'allow = ['; sed 's/.*/"&",/' .github/allowed-licenses.txt; echo ']'; } \
+            > osprey_coordinator/deny.toml
+
+      - uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20
+        with:
+          command: check licenses
+          manifest-path: osprey_coordinator/Cargo.toml

--- a/.github/workflows/license-check-rust.yml
+++ b/.github/workflows/license-check-rust.yml
@@ -17,7 +17,8 @@ jobs:
 
       - name: Generate deny.toml
         run: |
-          { echo '[licenses]'; echo 'allow = ['; sed 's/.*/"&",/' .github/allowed-licenses.txt; echo ']'; } \
+          { echo '[licenses]'; echo 'allow = ['; sed 's/.*/"&",/' .github/allowed-licenses.txt; echo ']'; \
+            echo ''; echo '[licenses.private]'; echo 'ignore = true'; } \
             > osprey_coordinator/deny.toml
 
       - uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20

--- a/.github/workflows/license-check-rust.yml
+++ b/.github/workflows/license-check-rust.yml
@@ -17,8 +17,7 @@ jobs:
 
       - name: Generate deny.toml
         run: |
-          { echo '[licenses]'; echo 'allow = ['; sed 's/.*/"&",/' .github/allowed-licenses.txt; echo ']'; \
-            echo ''; echo '[licenses.private]'; echo 'ignore = true'; } \
+          { echo '[licenses]'; echo 'allow = ['; sed 's/.*/"&",/' .github/allowed-licenses.txt; echo ']'; } \
             > osprey_coordinator/deny.toml
 
       - uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20

--- a/osprey_coordinator/Cargo.toml
+++ b/osprey_coordinator/Cargo.toml
@@ -2,6 +2,7 @@
 name = "osprey_coordinator"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/osprey_coordinator/etcd_config_derive/Cargo.toml
+++ b/osprey_coordinator/etcd_config_derive/Cargo.toml
@@ -2,6 +2,8 @@
 name = "osprey_coordinator_etcd_config_derive"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/osprey_coordinator/metrics_derive/Cargo.toml
+++ b/osprey_coordinator/metrics_derive/Cargo.toml
@@ -3,6 +3,7 @@ name = "osprey_coordinator_metrics_derive"
 version = "0.1.0"
 authors = ["osprey"]
 edition = "2021"
+publish = false
 
 [lib]
 proc-macro = true

--- a/osprey_coordinator/metrics_derive/Cargo.toml
+++ b/osprey_coordinator/metrics_derive/Cargo.toml
@@ -3,6 +3,7 @@ name = "osprey_coordinator_metrics_derive"
 version = "0.1.0"
 authors = ["osprey"]
 edition = "2021"
+license = "Apache-2.0"
 publish = false
 
 [lib]


### PR DESCRIPTION
## Description

Adds license check workflows to ci for node, Python, and Rust dependencies using a shared source of allowed licenses.

- Fixes #308 

## Checklist

- [ ] Tests pass locally
- [ ] `uv run ruff check .` passes (no unused imports or other lint errors)
- [ ] `uv tool run fawltydeps --check-unused --pyenv .venv` passes (no unused dependencies)
- [ ] Updated `CHANGELOG.md` with my changes, if applicable



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated dependency license compliance checks for Node, Python, and Rust during pull requests.
  * Introduced centralized license allowlists and pip license classifier policies to standardize what’s permitted.
  * Updated Rust crate metadata with explicit licensing details and adjusted publish settings for internal crates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->