### PR TITLE
[engine] Remove leftover debug print from RegexMatchMap

### DIFF
--- a/osprey_worker/src/osprey/engine/stdlib/udfs/regex_match.py
+++ b/osprey_worker/src/osprey/engine/stdlib/udfs/regex_match.py
@@ -64,5 +64,4 @@ class RegexMatchMap(RegexUDFBase, UDFBase[RegexMatchMapArguments, bool]):
         self._op = all if mode == 'all' else any
 
     def execute(self, execution_context: ExecutionContext, arguments: RegexMatchMapArguments) -> bool:
-        print(self._op, list(self._compiled.search(target) is not None for target in arguments.target))
         return self._op(self._compiled.search(target) is not None for target in arguments.target)

--- a/osprey_worker/src/osprey/engine/stdlib/udfs/tests/test_regex_match.py
+++ b/osprey_worker/src/osprey/engine/stdlib/udfs/tests/test_regex_match.py
@@ -102,10 +102,3 @@ def test_can_be_case_insensitive(
 def test_rejects_invalid_regex(run_validation: RunValidationFunction, check_failure: CheckFailureFunction) -> None:
     with check_failure():
         run_validation('Foo = RegexMatch(pattern="(", target="")')
-
-
-def test_regex_map_does_not_write_to_stdout(execute: ExecuteFunction, capsys: 'pytest.CaptureFixture[str]') -> None:
-    # Regression: RegexMatchMap.execute must not emit debug output on the hot path.
-    capsys.readouterr()
-    execute('Match = RegexMatchMap(pattern="[abc]+", target=["abc", "xyz"])')
-    assert capsys.readouterr().out == ''

--- a/osprey_worker/src/osprey/engine/stdlib/udfs/tests/test_regex_match.py
+++ b/osprey_worker/src/osprey/engine/stdlib/udfs/tests/test_regex_match.py
@@ -102,3 +102,10 @@ def test_can_be_case_insensitive(
 def test_rejects_invalid_regex(run_validation: RunValidationFunction, check_failure: CheckFailureFunction) -> None:
     with check_failure():
         run_validation('Foo = RegexMatch(pattern="(", target="")')
+
+
+def test_regex_map_does_not_write_to_stdout(execute: ExecuteFunction, capsys: 'pytest.CaptureFixture[str]') -> None:
+    # Regression: RegexMatchMap.execute must not emit debug output on the hot path.
+    capsys.readouterr()
+    execute('Match = RegexMatchMap(pattern="[abc]+", target=["abc", "xyz"])')
+    assert capsys.readouterr().out == ''


### PR DESCRIPTION
## Summary
`RegexMatchMap.execute` left a debug `print()` on the per-action hot path. It wrote event-derived data to stdout (captured into container logs) and forced a full-N regex pass that defeats the `any`/`all` short-circuit on the return line.

## Related Issues/Tasks
Found via an SML-engine bug hunt. No GitHub issue (N/A).

## Changes Made
- Removed the `print(...)` from `RegexMatchMap.execute` in `stdlib/udfs/regex_match.py`.
- Added a regression test asserting the UDF emits no stdout.

## Confidence Level
Confidence Level: Claude

## Testing
- `uv run pytest osprey_worker/src/osprey/engine/stdlib/udfs/tests/test_regex_match.py` (incl. new test) passes.
- Full engine unit suite passes locally (Docker integration suite not run locally).
- `uv run ruff check .` and `uv tool run fawltydeps --check-unused --pyenv .venv` pass.

## Checklist
- [x] Tests pass locally
- [x] `uv run ruff check .` passes (no unused imports or other lint errors)
- [x] `uv tool run fawltydeps --check-unused --pyenv .venv` passes (no unused dependencies)
- [ ] Updated `CHANGELOG.md` with my changes, if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed debug output from regex matching functionality to prevent unwanted logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->