### PR TITLE
[engine] Escape literal braces when parsing f-strings

### DIFF
--- a/osprey_worker/src/osprey/engine/ast/py_ast.py
+++ b/osprey_worker/src/osprey/engine/ast/py_ast.py
@@ -289,15 +289,21 @@ class OspreyAstNodeTransformer:
     def transform_JoinedStr(self, node: ast.JoinedStr) -> FormatString:
         format_string_parts: ListT[str] = []
         names = []
+        # Tracks the unescaped length of the parts seen so far, so error carets stay positioned
+        # the same way even though literal braces are doubled in `format_string_parts` below.
+        unescaped_length = 0
 
         for value in node.values:
             if isinstance(value, ast.Str):
                 assert isinstance(value.s, str)
-                format_string_parts.append(value.s)
+                # Escape literal braces so the reconstructed `format_string` is a valid
+                # `str.format()` template; interpolated names are added as `{name}` fields below.
+                format_string_parts.append(value.s.replace('{', '{{').replace('}', '}}'))
+                unescaped_length += len(value.s)
                 continue
 
             if isinstance(value, ast.FormattedValue):
-                offset_by = sum(len(n) for n in format_string_parts) + 3
+                offset_by = unescaped_length + 3
                 self.invariant(
                     value.format_spec is None and value.conversion == -1,
                     'a format string cannot have a format spec',
@@ -328,7 +334,9 @@ class OspreyAstNodeTransformer:
                     node=node,
                 )
                 names.append(name)
-                format_string_parts.append(f'{{{name.identifier}}}')
+                placeholder = f'{{{name.identifier}}}'
+                format_string_parts.append(placeholder)
+                unescaped_length += len(placeholder)
 
         format_string = ''.join(format_string_parts)
         return FormatString(span=self.span_for(node), format_string=format_string, names=names)

--- a/osprey_worker/src/osprey/engine/executor/tests/test_literals.py
+++ b/osprey_worker/src/osprey/engine/executor/tests/test_literals.py
@@ -93,6 +93,18 @@ def test_fstring_literal(execute: ExecuteFunction) -> None:
     assert data == {'Bar': 'world', 'Baz': '[hello - world]', 'Foo': 'hello'}
 
 
+def test_fstring_with_literal_braces(execute: ExecuteFunction) -> None:
+    # Regression: literal braces in an f-string must render as literal braces, not be
+    # reinterpreted as str.format() substitution fields (which raised KeyError).
+    data = execute(
+        """
+        Name: ExtractLiteral[str] = "world"
+        Greeting: ExtractLiteral[str] = f"{{hello}} {Name} {{{{}}}}"
+        """
+    )
+    assert data == {'Name': 'world', 'Greeting': '{hello} world {{}}'}
+
+
 def test_export_fails_on_non_literal(check_failure: CheckFailureFunction, execute: ExecuteFunction) -> None:
     with check_failure():
         execute(


### PR DESCRIPTION
## Summary
CPython collapses escaped braces (`{{`/`}}`) in an f-string's literal segments, so the reconstructed `format_string` fed to `str.format()` in the executor reinterpreted them as substitution fields and raised `KeyError`/`ValueError`, silently failing the node and its dependents. Escape literal braces at parse time so `format_string` is a valid `str.format()` template.

## Related Issues/Tasks
Found via an SML-engine bug hunt. No GitHub issue (N/A).

## Changes Made
- `transform_JoinedStr` (`ast/py_ast.py`) escapes literal braces in f-string text segments; interpolated names are still added as `{name}` fields.
- Tracks the unescaped length separately so syntax-error caret offsets are unchanged.
- Added a regression test rendering literal braces in an f-string.

## Confidence Level
Confidence Level: Claude

## Testing
- `uv run pytest osprey_worker/src/osprey/engine/executor/tests/test_literals.py` (incl. new test) passes.
- Full engine unit suite passes locally (Docker integration suite not run locally).
- No production f-string uses literal braces, so escaping is a no-op for existing rules.
- `uv run ruff check .`, `uv run mypy ast/py_ast.py`, and `fawltydeps` pass.

## Checklist
- [x] Tests pass locally
- [x] `uv run ruff check .` passes (no unused imports or other lint errors)
- [x] `uv tool run fawltydeps --check-unused --pyenv .venv` passes (no unused dependencies)
- [ ] Updated `CHANGELOG.md` with my changes, if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved f-string parsing issues with escaped literal braces. Literal brace characters in f-strings now correctly render as their intended output while maintaining accurate error message positioning and caret alignment. Double braces are properly handled as literal characters rather than format-like substitution fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->