### PR TITLE
[osprey-ui] darkmode follows system preferences

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -213,7 +213,7 @@ services:
         gcloud beta emulators bigtable start --host-port=0.0.0.0:8361 --project=osprey-dev
       "
     healthcheck:
-      test: ["CMD", "bash", "-c", "pgrep -f cbtemulator > /dev/null || exit 1"]
+      test: ["CMD", "bash", "-c", "echo > /dev/tcp/127.0.0.1/8361"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -213,7 +213,7 @@ services:
         gcloud beta emulators bigtable start --host-port=0.0.0.0:8361 --project=osprey-dev
       "
     healthcheck:
-      test: ["CMD", "bash", "-c", "echo > /dev/tcp/127.0.0.1/8361"]
+      test: ["CMD", "bash", "-c", "pgrep -f cbtemulator > /dev/null || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/osprey_ui/public/index.html
+++ b/osprey_ui/public/index.html
@@ -20,13 +20,14 @@
     <title>Osprey</title>
     <script>
       // Apply theme before paint so dark-mode users don't see a flash of light
-      // mode. Mirrors getInitialMode() in stores/ThemeStore.tsx — keep in sync.
+      // mode. Mirrors getInitialPreference() in stores/ThemeStore.tsx — keep in
+      // sync.
       (function () {
         try {
-          var stored = window.localStorage.getItem('osprey-ui-dark-theme');
+          var pref = window.localStorage.getItem('osprey-ui-theme-preference');
           var isDark =
-            stored === 'true' ||
-            (stored === null &&
+            pref === 'dark' ||
+            (pref !== 'light' &&
               window.matchMedia &&
               window.matchMedia('(prefers-color-scheme: dark)').matches);
           if (isDark) document.documentElement.classList.add('dark-theme');

--- a/osprey_ui/src/stores/ThemeStore.tsx
+++ b/osprey_ui/src/stores/ThemeStore.tsx
@@ -1,44 +1,60 @@
 import create from 'zustand';
 
 export type ThemeMode = 'light' | 'dark';
+export type ThemePreference = 'system' | 'light' | 'dark';
 
-const STORAGE_KEY = 'osprey-ui-dark-theme';
+const STORAGE_KEY = 'osprey-ui-theme-preference';
 
-const getInitialMode = (): ThemeMode => {
-  if (typeof window === 'undefined') return 'light';
-  const stored = window.localStorage.getItem(STORAGE_KEY);
-  if (stored === 'true') return 'dark';
-  if (stored === 'false') return 'light';
-  // No localStorage value: honor the OS preference.
-  if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
-    return 'dark';
-  }
-  return 'light';
+const getSystemMode = (): ThemeMode => {
+  if (typeof window === 'undefined' || !window.matchMedia) return 'light';
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 };
+
+const getInitialPreference = (): ThemePreference => {
+  if (typeof window === 'undefined') return 'system';
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  if (stored === 'light' || stored === 'dark') return stored;
+  return 'system';
+};
+
+const resolveMode = (pref: ThemePreference): ThemeMode =>
+  pref === 'system' ? getSystemMode() : pref;
 
 type ThemeStore = {
+  preference: ThemePreference;
   mode: ThemeMode;
-  setMode: (mode: ThemeMode) => void;
-  toggleMode: () => void;
+  setPreference: (preference: ThemePreference) => void;
 };
 
-const persist = (mode: ThemeMode) => {
-  window.localStorage.setItem(STORAGE_KEY, String(mode === 'dark'));
-};
+const useThemeStore = create<ThemeStore>((set) => {
+  const preference = getInitialPreference();
+  return {
+    preference,
+    mode: resolveMode(preference),
+    setPreference: (next) => {
+      if (next === 'system') {
+        window.localStorage.removeItem(STORAGE_KEY);
+      } else {
+        window.localStorage.setItem(STORAGE_KEY, next);
+      }
+      set({ preference: next, mode: resolveMode(next) });
+    },
+  };
+});
 
-const useThemeStore = create<ThemeStore>((set) => ({
-  mode: getInitialMode(),
-  setMode: (mode) => {
-    persist(mode);
-    set({ mode });
-  },
-  toggleMode: () => {
-    return set((state) => {
-      const next: ThemeMode = state.mode === 'dark' ? 'light' : 'dark';
-      persist(next);
-      return { mode: next };
-    });
-  },
-}));
+if (typeof window !== 'undefined' && window.matchMedia) {
+  const mql = window.matchMedia('(prefers-color-scheme: dark)');
+  const handleChange = () => {
+    if (useThemeStore.getState().preference === 'system') {
+      useThemeStore.setState({ mode: getSystemMode() });
+    }
+  };
+  if (mql.addEventListener) {
+    mql.addEventListener('change', handleChange);
+  } else if (mql.addListener) {
+    // Safari < 14 fallback.
+    mql.addListener(handleChange);
+  }
+}
 
 export default useThemeStore;

--- a/osprey_ui/src/stores/ThemeStore.tsx
+++ b/osprey_ui/src/stores/ThemeStore.tsx
@@ -17,8 +17,7 @@ const getInitialPreference = (): ThemePreference => {
   return 'system';
 };
 
-const resolveMode = (pref: ThemePreference): ThemeMode =>
-  pref === 'system' ? getSystemMode() : pref;
+const resolveMode = (pref: ThemePreference): ThemeMode => (pref === 'system' ? getSystemMode() : pref);
 
 type ThemeStore = {
   preference: ThemePreference;

--- a/osprey_ui/src/uikit/ThemeToggle.tsx
+++ b/osprey_ui/src/uikit/ThemeToggle.tsx
@@ -1,23 +1,24 @@
-import { Switch } from 'antd';
-import { MoonOutlined, SunOutlined } from '@ant-design/icons';
+import { Segmented } from 'antd';
+import { DesktopOutlined, MoonOutlined, SunOutlined } from '@ant-design/icons';
 
-import useThemeStore from '../stores/ThemeStore';
+import useThemeStore, { ThemePreference } from '../stores/ThemeStore';
+
+const OPTIONS = [
+  { value: 'light' as const, icon: <SunOutlined />, title: 'Light theme' },
+  { value: 'system' as const, icon: <DesktopOutlined />, title: 'Use system theme' },
+  { value: 'dark' as const, icon: <MoonOutlined />, title: 'Dark theme' },
+];
 
 const ThemeToggle = () => {
-  const mode = useThemeStore((state) => {
-    return state.mode;
-  });
-  const toggleMode = useThemeStore((state) => {
-    return state.toggleMode;
-  });
+  const preference = useThemeStore((state) => state.preference);
+  const setPreference = useThemeStore((state) => state.setPreference);
 
   return (
-    <Switch
-      checked={mode === 'dark'}
-      onChange={toggleMode}
-      checkedChildren={<MoonOutlined />}
-      unCheckedChildren={<SunOutlined />}
-      aria-label={mode === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
+    <Segmented
+      value={preference}
+      onChange={(value) => setPreference(value as ThemePreference)}
+      options={OPTIONS}
+      aria-label="Theme"
     />
   );
 };


### PR DESCRIPTION
## Description

Previously the toggle was a binary light/dark switch that read the OS preference only at cold start; switching the OS after Osprey was open did not propagate. Replace with a system/light/dark `preference` plus a resolved `mode`, and subscribe to `matchMedia('(prefers-color-scheme: dark)')` so the resolved mode updates live while `preference === 'system'`.

The toggle UI is now a 3-segment control (sun / desktop / moon). Storage moves from a boolean `osprey-ui-dark-theme` to `osprey-ui-theme-preference` holding the literal `light`/`dark`/(absent → system).

https://github.com/user-attachments/assets/87be1c87-1076-4c63-9724-baf54eb23fb4

Fixes #352