### PR TITLE
docker: pin cloud-sdk image

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -205,7 +205,7 @@ services:
   bigtable:
     hostname: bigtable
     container_name: bigtable
-    image: gcr.io/google.com/cloudsdktool/cloud-sdk:573.0.0@sha256:e032d744e8de1312d7461684ef365777c0036933c39c47c72cfc1adafc22de67
+    image: gcr.io/google.com/cloudsdktool/cloud-sdk:572.0.0@sha256:f67318c2d4719e3d9579ee724dd16b9d028ae916c4919586ae01e9e26d6c1beb
     ports:
       - "127.0.0.1:8361:8361"
     command: >
@@ -222,7 +222,7 @@ services:
 
   bigtable-initializer:
     container_name: bigtable-initializer
-    image: gcr.io/google.com/cloudsdktool/cloud-sdk:573.0.0@sha256:e032d744e8de1312d7461684ef365777c0036933c39c47c72cfc1adafc22de67
+    image: gcr.io/google.com/cloudsdktool/cloud-sdk:572.0.0@sha256:f67318c2d4719e3d9579ee724dd16b9d028ae916c4919586ae01e9e26d6c1beb
     depends_on:
       bigtable:
         condition: service_healthy

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -205,7 +205,7 @@ services:
   bigtable:
     hostname: bigtable
     container_name: bigtable
-    image: gcr.io/google.com/cloudsdktool/cloud-sdk:latest
+    image: gcr.io/google.com/cloudsdktool/cloud-sdk:573.0.0@sha256:a7194b826ef8cb400ef25baceffcb1a29ab4d6b7af8a4a22440a8c82afcd8be2
     ports:
       - "127.0.0.1:8361:8361"
     command: >
@@ -217,11 +217,12 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+      start_period: 60s
     restart: unless-stopped
 
   bigtable-initializer:
     container_name: bigtable-initializer
-    image: gcr.io/google.com/cloudsdktool/cloud-sdk:latest
+    image: gcr.io/google.com/cloudsdktool/cloud-sdk:573.0.0@sha256:a7194b826ef8cb400ef25baceffcb1a29ab4d6b7af8a4a22440a8c82afcd8be2
     depends_on:
       bigtable:
         condition: service_healthy

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -205,7 +205,7 @@ services:
   bigtable:
     hostname: bigtable
     container_name: bigtable
-    image: gcr.io/google.com/cloudsdktool/cloud-sdk:573.0.0@sha256:a7194b826ef8cb400ef25baceffcb1a29ab4d6b7af8a4a22440a8c82afcd8be2
+    image: gcr.io/google.com/cloudsdktool/cloud-sdk:573.0.0@sha256:e032d744e8de1312d7461684ef365777c0036933c39c47c72cfc1adafc22de67
     ports:
       - "127.0.0.1:8361:8361"
     command: >
@@ -222,7 +222,7 @@ services:
 
   bigtable-initializer:
     container_name: bigtable-initializer
-    image: gcr.io/google.com/cloudsdktool/cloud-sdk:573.0.0@sha256:a7194b826ef8cb400ef25baceffcb1a29ab4d6b7af8a4a22440a8c82afcd8be2
+    image: gcr.io/google.com/cloudsdktool/cloud-sdk:573.0.0@sha256:e032d744e8de1312d7461684ef365777c0036933c39c47c72cfc1adafc22de67
     depends_on:
       bigtable:
         condition: service_healthy


### PR DESCRIPTION
The cloud-sdk:latest tag was floating, so any upstream image update could silently change startup behavior. It looks like this may have happened with 573.0.0, so let's pin the previous version until the fix is released.

cbtemulator is also not pre-installed; it gets downloaded at runtime, so the 50s healthcheck window (5 retries × 10s) could be too short when the runner or network was a little slow.

Pin both cloud-sdk references to 572.0.0 with digest, and add start_period: 60s so the cbtemulator download time doesn't count against retries.

Fixes #363

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker Compose services to use pinned container image digests instead of the moving `latest` tag.
  * Improved service startup reliability by extending the health check initialization window for the Bigtable service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->