### PR TITLE
Fix docker-compose hang in CI

### DIFF
--- a/osprey_worker/conftest.py
+++ b/osprey_worker/conftest.py
@@ -9,6 +9,9 @@ or from within osprey_worker/ subpaths.
 
 from typing import TYPE_CHECKING
 
+import pytest
+from gevent import monkey
+
 if TYPE_CHECKING:
     from _pytest.config import Config
     from _pytest.config.argparsing import Parser
@@ -55,3 +58,25 @@ def pytest_configure(config: 'Config') -> None:
         'vary_output_by_py_version(): instructs the `check_output` feature to record a separate file for '
         'different python major/minor versions',
     )
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_sessionfinish(session: object, exitstatus: int) -> None:
+    """Force-exit the gevent-monkey-patched test process once the run is done.
+
+    The test runner launches pytest under gevent monkey-patching
+    (``python -m gevent.monkey --module pytest``). After the suite finishes,
+    the process can stall inside gevent's interpreter finalization and never
+    exit, so the integration-tests CI job hangs until its 30-minute timeout.
+    Exit immediately here (trylast, so this runs after the junit/terminal
+    hooks) to skip that teardown. Guarded on gevent being active so a plain
+    ``pytest`` run finalizes normally.
+    """
+    import os
+    import sys
+
+    if not monkey.is_module_patched('socket'):
+        return
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(exitstatus)

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker compose -f docker-compose.yaml -f docker-compose.test.yaml --profile test run --rm --remove-orphans -T test_runner run-tests "${@}"
+docker compose -f docker-compose.yaml -f docker-compose.test.yaml --profile test run --rm -T test_runner run-tests "${@}"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker compose -f docker-compose.yaml -f docker-compose.test.yaml --profile test run --rm --remove-orphans test_runner run-tests "${@}"
+docker compose -f docker-compose.yaml -f docker-compose.test.yaml --profile test run --rm --remove-orphans -T test_runner run-tests "${@}"


### PR DESCRIPTION
## Description

The `integration-tests` job was consistently timing out at 30 minutes despite pytest finishing cleanly in ~60 seconds. Two separate issues were compounding:

**Root cause:** When pytest is launched via `python -m gevent.monkey --module pytest`, gevent's interpreter finalization stalls after the suite completes — the hub waits on pending I/O events that never unwind, so the process never exits, the container never exits, and `docker compose run` waits forever. Fixed by adding a `pytest_sessionfinish` hook (`trylast`, so junit output is already written) that calls `os._exit(exitstatus)` when gevent monkey-patching is active. Plain `pytest` runs are unaffected.

**Secondary:** `docker compose run --remove-orphans` triggers a teardown of dependency services (Kafka, Postgres, Bigtable, etc.) after the one-off container finishes, which can block for minutes. Removed it — each CI job runs on a fresh VM so there's nothing to clean up. Also added `-T` (no pseudo-TTY) as correct hygiene for non-interactive CI.

Fixes #368.

## Checklist

- [ ] Tests pass locally
- [ ] `uv run ruff check .` passes (no unused imports or other lint errors)
- [ ] `uv tool run fawltydeps --check-unused --pyenv .venv` passes (no unused dependencies)
- [ ] Updated `CHANGELOG.md` with my changes, if applicable