### PR TITLE
[test] Verify -T docker compose flag fixes integration hang (do not merge)

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker compose -f docker-compose.yaml -f docker-compose.test.yaml --profile test run --rm --remove-orphans test_runner run-tests "${@}"
+docker compose -f docker-compose.yaml -f docker-compose.test.yaml --profile test run --rm --remove-orphans -T test_runner run-tests "${@}"


### PR DESCRIPTION
## Description

Experiment only — **do not merge**. Reproduces the `-T` (disable pseudo-TTY) change from #370 on an org-owned branch so the integration-tests workflow actually exercises it (fork PRs may not). Purpose: objectively determine whether disabling TTY allocation on `docker compose run` resolves the CI hang from #368, independent of the conftest force-exit in #369.

## Confidence Level

Confidence Level: Claude

## Testing

Watching the integration-tests job on this PR.