### PR TITLE
Bound integration-tests teardown hang (fixes #368)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -37,6 +37,7 @@ jobs:
           docker compose -f docker-compose.yaml -f docker-compose.test.yaml --profile test build
 
       - name: Run integration tests
+        timeout-minutes: 12  # cap; see issue #368
         run: ./run-tests.sh --junitxml=/tmp/test-results/junit-pytest.xml
 
       - name: Upload test results

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,3 +1,25 @@
 #!/bin/bash
+# See issue #368 for the teardown-hang the wrappers below bound.
+set -euo pipefail
 
-docker compose -f docker-compose.yaml -f docker-compose.test.yaml --profile test run --rm --remove-orphans test_runner run-tests "${@}"
+COMPOSE_FILES=(-f docker-compose.yaml -f docker-compose.test.yaml --profile test)
+RUN_TESTS_TIMEOUT_SECONDS="${RUN_TESTS_TIMEOUT_SECONDS:-600}"
+
+cleanup_on_failure() {
+    local exit_code=$?
+    if [ "${exit_code}" -ne 0 ]; then
+        docker compose "${COMPOSE_FILES[@]}" ps -a 2>/dev/null || true
+        timeout 60 docker compose "${COMPOSE_FILES[@]}" down --timeout 10 --volumes 2>/dev/null || true
+    fi
+}
+trap cleanup_on_failure EXIT
+
+exit_code=0
+timeout "${RUN_TESTS_TIMEOUT_SECONDS}" \
+    docker compose "${COMPOSE_FILES[@]}" run --rm test_runner run-tests "${@}" || exit_code=$?
+
+if [ "${exit_code}" -eq 124 ]; then
+    echo "::error::run-tests.sh exceeded ${RUN_TESTS_TIMEOUT_SECONDS}s (issue #368)" >&2
+fi
+
+exit "${exit_code}"


### PR DESCRIPTION
## Summary

Three coordinated changes so a docker-compose teardown hang can't eat the workflow's 30-min cap:

1. **Drop `--remove-orphans`** from `docker compose run` — the most likely source of the hang. It scans the compose project for stray containers and under GHA's docker daemon appears to wedge.
2. **Wrap the run in `timeout 10m`** (overridable via `RUN_TESTS_TIMEOUT_SECONDS`) inside `run-tests.sh`, and surface a `::error::` annotation if the cap fires so the failure is unambiguous.
3. **Add a trap that fires on non-zero exit only.** Dumps `docker compose ps -a` for diagnostics and tears the stack down with bounded `docker compose down --timeout 10 --volumes`. **Success path is unchanged** — dependencies stay up so local iteration via `./run-tests.sh` stays fast.
4. **Step-level `timeout-minutes: 12`** in the workflow as belt-and-suspenders, so the step fails in ~12 min instead of 30 if both internal timeouts somehow miss.

Closes #368.

## Why each piece earns its keep

- Dropping `--remove-orphans` alone might fix the hang on its own, but if it doesn't, (2) and (3) bound the worst case.
- The internal `timeout 10m` (2) bounds the docker compose call itself, not just the step. If the docker daemon is wedged at process-tree level, the step-level cap (4) is still needed.
- The trap (3) only fires on failure so it doesn't slow down successful local runs by tearing dependencies down. The earlier hang would have been a non-zero exit (timeout's 124), so the trap would have caught it and the next CI run would start clean instead of accumulating wedged state.
- The diagnostic `ps -a` dump (3) means the next time this fails, we'll have evidence of *which* container was wedged — there's none today.

## Test plan

- [x] `bash -n run-tests.sh` — syntax check passes
- [ ] CI on this PR exercises the new wrapping (success path)
- [ ] First merge to a PR that previously triggered the hang (e.g. anything touching `osprey_worker/`) — confirm no regression on the happy path
- [ ] If the hang surfaces again in CI, the new `::error::` annotation will name it and `ps -a` output will give us a target to investigate

## Risk

- Local `./run-tests.sh` behavior is unchanged on success (just adds `set -euo pipefail` for safety + the timeout wrapper which finishes in the same time).
- On failure, local users see compose state and a cleanup — slight slowdown of subsequent runs but cleaner state.
- Dropping `--remove-orphans` means orphans from a previous compose project on a local dev machine won't be auto-cleaned. They can run `docker compose down --remove-orphans` themselves; CI runners are always fresh so it's a non-issue there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced integration test reliability with timeout protections to prevent indefinite test runs
  * Improved test failure diagnostics and automatic resource cleanup on errors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->