### PR TITLE
fix(ui): tolerate malformed URI escapes in EntityWithPopover

### DIFF
--- a/osprey_ui/src/components/entities/EntityWithPopover.tsx
+++ b/osprey_ui/src/components/entities/EntityWithPopover.tsx
@@ -103,8 +103,17 @@ const EntityWithPopover = ({ entityId, featureName, entityType }: EntityWithPopo
   }>();
 
   const isRouteEntity = entityRouteType === entityType && entityRouteId === entityId;
-  const decodedEntityType = decodeURIComponent(entityType);
-  const decodedEntityId = decodeURIComponent(entityId);
+  // `decodeURIComponent` throws on malformed input (stray `%`, etc.). Fall
+  // back to the raw value so a bad ID doesn't crash the whole popover.
+  const safeDecode = (s: string): string => {
+    try {
+      return decodeURIComponent(s);
+    } catch {
+      return s;
+    }
+  };
+  const decodedEntityType = safeDecode(entityType);
+  const decodedEntityId = safeDecode(entityId);
 
   const handleShowLabelDrawer = () => {
     updateShowLabelDrawer(true);


### PR DESCRIPTION
Closes #376. Unblocks #297.

## Bug

`EntityWithPopover.tsx:106-107` calls `decodeURIComponent(entityType)` and `decodeURIComponent(entityId)` unguarded. `decodeURIComponent` throws `URIError: URI malformed` on any input with a stray `%` or otherwise-malformed escape — which crashes the React tree and white-screens the app.

Latent until now because fresh demo deployments showed "No data for selected features" cards, so most entity values never made it to the popover. PR #297 (event-stream sensible defaults) exposes the crash: scrolling the event stream fast or picking features in the modal triggers it.

## Fix

Wrap the two calls in a `safeDecode` helper that returns the raw value on `URIError`. Ten-line change.

\`\`\`ts
const safeDecode = (s: string): string => {
  try {
    return decodeURIComponent(s);
  } catch {
    return s;
  }
};
\`\`\`

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`pnpm run format:check\` clean
- [ ] Live: with #297 also checked out, repro path-3 fast-scroll and path-2 picker selection in EventStream — both previously white-screened, now render the value undecoded (no crash)

🤖 with @claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of entity links with malformed route values, preventing crashes when decoding certain URLs.
  * Popover details and related actions now display using safely decoded entity type and ID values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->