### PR TITLE
README: Fix 404-ing DEVELOPMENT.md link

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Using Osprey and want to add your project/organization to this list? [Open a pul
 
 ## Development
 
-- See [DEVELOPMENT.md](./docs/DEVELOPMENT.md) for comprehensive development setup and workflow documentation
+- See [DEVELOPMENT](./docs/development) for comprehensive development setup and workflow documentation
 - All code changes should pass linting (Ruff) and type checking (MyPy)
 - Pre-commit hooks automatically run on each commit to maintain code quality
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Using Osprey and want to add your project/organization to this list? [Open a pul
 
 ## Development
 
-- See [DEVELOPMENT](./docs/development) for comprehensive development setup and workflow documentation
+- See the [development guide](./docs/development/) for comprehensive development setup and workflow documentation
 - All code changes should pass linting (Ruff) and type checking (MyPy)
 - Pre-commit hooks automatically run on each commit to maintain code quality
 


### PR DESCRIPTION
Path is no longer docs/DEVELOPMENT.md; updates link in README.md to match new folder path (https://github.com/roostorg/osprey/tree/main/docs/development)


## Checklist

- [ ] Tests pass locally
- [ ] `uv run ruff check .` passes (no unused imports or other lint errors)
- [ ] `uv tool run fawltydeps --check-unused --pyenv .venv` passes (no unused dependencies)
- [ ] Updated `CHANGELOG.md` with my changes, if applicable



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the “Development” section link in the README to point to the current documentation location (`./docs/development/`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->