### PR TITLE
[easy] remove jslog4kube reference from entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,7 +25,6 @@ cli-osprey-ui-api() {
     --reload \
     --access-logfile - \
     --error-logfile - \
-    --logger-class jslog4kube.GunicornLogger \
     --name osprey_ui_api \
     --worker-class gevent \
     --chdir /osprey/osprey_worker/src \


### PR DESCRIPTION
## Problem

`entrypoint.sh` fails to start the `osprey-ui-api` container after #341 removed `jslog4kube` from the Python dependencies:

```
Error: class uri 'jslog4kube.GunicornLogger' invalid or not found:
ModuleNotFoundError: No module named 'jslog4kube'
```

## Fix

Drop the `--logger-class jslog4kube.GunicornLogger` flag from the gunicorn command in `entrypoint.sh`. The existing `--access-logfile -` and `--error-logfile -` flags already route access and error logs to stdout/stderr using gunicorn's built-in logger.

## Test plan

- [X] `docker build` the `osprey-ui-api` image
- [X] `docker run ... osprey-ui-api` starts without the `ModuleNotFoundError`
- [X] Access logs appear on stdout as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the API startup configuration to use the default Gunicorn logging setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->