### PR TITLE
ci: Remove nostril from excepted package licenses

### DIFF
--- a/.github/workflows/license-check-python.yml
+++ b/.github/workflows/license-check-python.yml
@@ -48,7 +48,6 @@ jobs:
           # Packages pending license policy review:
           #   unidecode: GPL v2+ (#354)
           #   tld: GPL v2 / LGPL / MPL 1.1 (#355)
-          #   nostril: LGPL 2.1 (#356)
           #   psycopg2-binary: LGPL (#357)
           #   simplejson: Academic Free License + MIT (#358)
           #   text-unidecode: Artistic + GPL (transitive via faker) (#359)
@@ -57,4 +56,4 @@ jobs:
               google-crc32c \
               ddtrace \
               osprey-rpc osprey-worker example_plugins \
-              unidecode tld nostril psycopg2-binary simplejson text-unidecode
+              unidecode tld psycopg2-binary simplejson text-unidecode


### PR DESCRIPTION
It was removed in #391, so we don't need it in the license-check workflow anymore.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated license-check settings so one Python dependency is now included in license policy validation instead of being skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->