### PR TITLE
ci: Correct mdbook site-url using env variable

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -85,6 +85,8 @@ jobs:
           rm mdbook.tar.gz
 
       - name: Build with mdBook
+        env:
+          MDBOOK_OUTPUT__HTML__SITE_URL: /osprey/${{ steps.deploy-path.outputs.path }}/
         run: ${{ github.workspace }}/mdbook-bin/mdbook build docs
 
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
Fixes #365

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how documentation pages are built so links and assets use the correct site URL for the deployed version or latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->