### PR TITLE
fix(ui): show the event-stream timezone once, not twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ For more information about each release including git tags and artifacts, see [R
 - Tolerate malformed URI escapes in `EntityWithPopover` UI component ([#377](https://github.com/roostorg/osprey/pull/377) by [@julietshen](https://github.com/julietshen))
 - Add retention limits to Kafka topics to prevent unbounded disk growth ([#249](https://github.com/roostorg/osprey/pull/249) by [@VINODvoid](https://github.com/VINODvoid))
 - Fix failed UDF query ([#233](https://github.com/roostorg/osprey/pull/233) by [@chimosky](https://github.com/chimosky))
+- Show the event-stream timezone once instead of twice; `zz` rendered a doubled abbreviation (e.g. `EDTEDT`) after the moment-to-dayjs migration ([#419](https://github.com/roostorg/osprey/pull/419) by [@julietshen](https://github.com/julietshen))
 
 ## [1.0.1] - 2026-02-27
 

--- a/osprey_ui/src/Constants.tsx
+++ b/osprey_ui/src/Constants.tsx
@@ -13,7 +13,7 @@ export const Routes = {
   BULK_ACTION: '/bulk-action',
 };
 
-export const DATE_FORMAT = 'M/D/YYYY h:mm:ssa zz';
+export const DATE_FORMAT = 'M/D/YYYY h:mm:ssa z';
 
 // These should mirror the `--status-primary` colors in Colors.module.css
 export const StatusColors = {

--- a/osprey_ui/src/utils/DayjsSetup.tsx
+++ b/osprey_ui/src/utils/DayjsSetup.tsx
@@ -1,4 +1,5 @@
 import dayjs from 'dayjs';
+import advancedFormat from 'dayjs/plugin/advancedFormat';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
 import duration from 'dayjs/plugin/duration';
 import timezone from 'dayjs/plugin/timezone';
@@ -8,3 +9,5 @@ dayjs.extend(utc);
 dayjs.extend(timezone);
 dayjs.extend(duration);
 dayjs.extend(customParseFormat);
+// advancedFormat provides the `z` timezone-abbreviation token used by DATE_FORMAT.
+dayjs.extend(advancedFormat);


### PR DESCRIPTION
Closes #416.

## Problem

Event-stream timestamps render the timezone twice — e.g. `7/13/2026 2:42:11pm EDTEDT`.

## Cause

`DATE_FORMAT` (`Constants.tsx`) has used the `zz` token since the initial commit. Under **moment.js** that rendered a single timezone abbreviation, so it was correct. The **moment → dayjs migration (#238)** kept `zz`, but dayjs parses it as two `z` tokens (→ `EDT`+`EDT`). That migration also never added dayjs's `advancedFormat` plugin, which is what provides the `z` token in the first place.

## Fix

- Load `advancedFormat` in `DayjsSetup.tsx` so `z` resolves to a timezone abbreviation.
- Change `DATE_FORMAT` from `zz` to `z`.

Result: `7/13/2026 2:42:11pm EDT`.

Verified with the app's dayjs + plugin set that `z` → `EDT` (once). `tsc --noEmit`, `eslint`, and `prettier --check` all pass on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved doubled timezone abbreviation rendering in event-stream timestamps (now appears once).
  * Updated date/time timezone formatting to use a single timezone token for consistent abbreviation display across the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->