### PR TITLE
Fix apply-label reason help default

### DIFF
--- a/osprey_worker/src/osprey/worker/lib/cli.py
+++ b/osprey_worker/src/osprey/worker/lib/cli.py
@@ -209,7 +209,7 @@ def get_lines_from_file_as_set(file_path: str) -> set[str]:
     '--reason',
     help=(
         'If specified, the reason the label is being applied.'
-        ' Should be camel case, without spaces. Defaults to "CliLabelMutation".'
+        ' Should be camel case, without spaces. Defaults to "CliLabelMutationWithoutEffects".'
     ),
 )
 @click.option(


### PR DESCRIPTION
## Description

Correct the `apply_label --reason` help text so its documented default matches the existing `CliLabelMutationWithoutEffects` fallback. The sibling `bulk_apply_label` command already documents the same default.

Closes #422.

## Validation

- `ruff 0.12.9 check osprey_worker/src/osprey/worker/lib/cli.py`
- `ruff 0.12.9 format --check osprey_worker/src/osprey/worker/lib/cli.py`
- `python -m py_compile osprey_worker/src/osprey/worker/lib/cli.py`
- Static consistency check: both help strings now match all four runtime fallbacks
- `git diff --check`

The full `uv`-based integration suite was not run because `uv` is unavailable in this environment. This one-line change only updates a static Click help string and does not alter control flow.

## Checklist

- [ ] Tests pass locally — full integration suite not run; focused static and syntax checks are listed above
- [x] Repository-pinned Ruff lint and formatting checks pass
- [ ] `uv tool run fawltydeps --check-unused --pyenv .venv` — not run; no dependency or import changes
- [x] No `CHANGELOG.md` entry is needed for this non-notable help-text correction

## AI assistance disclosure

Codex was used to screen the issue, implement the one-line change, and run the documented validation. The PR is intentionally limited to the reported help-text mismatch.
