### PR TITLE
Fix apply_label --reason help text to match actual default

### DIFF
--- a/osprey_worker/src/osprey/worker/lib/cli.py
+++ b/osprey_worker/src/osprey/worker/lib/cli.py
@@ -209,7 +209,7 @@ def get_lines_from_file_as_set(file_path: str) -> set[str]:
     '--reason',
     help=(
         'If specified, the reason the label is being applied.'
-        ' Should be camel case, without spaces. Defaults to "CliLabelMutation".'
+        ' Should be camel case, without spaces. Defaults to "CliLabelMutationWithoutEffects".'
     ),
 )
 @click.option(


### PR DESCRIPTION
## Summary

The `--reason` option help text for the `apply_label` CLI command says the reason "Defaults to \"CliLabelMutation\"", but the code actually falls back to `CliLabelMutationWithoutEffects` in both branches of the `expire_instantly` conditional (`osprey_worker/src/osprey/worker/lib/cli.py`). The sibling `bulk_apply_label` command already documents this correctly, so this brings `apply_label`'s help text in line with it and with the actual runtime behavior.

## Test plan

- [x] Confirmed the current default in the `apply_label` implementation (`reason_name=reason or 'CliLabelMutationWithoutEffects'`, both branches) via the linked source.
- [x] Confirmed `bulk_apply_label`'s existing help string already reads "CliLabelMutationWithoutEffects" for comparison.
- [x] Docs-only string change, no behavior change; verified `cli.py` still parses (`ast.parse`).

Fixes #422

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the bulk label application command’s `--reason` help text to display the correct default value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->