### PR TITLE
 Fix shell scripts checked out with CRLF on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,12 +1,2 @@
-# Shell scripts must keep LF endings even when checked out on Windows.
-#
-# With core.autocrlf=true these get CRLF on checkout, which turns the shebang
-# into `#!/bin/bash\r`. Linux containers then fail to exec them with the very
-# unhelpful "no such file or directory" -- entrypoint.sh, the Druid spec
-# submitter and the MinIO bucket init all break this way.
-*.sh text eol=lf
-
-# Same reasoning: these are executed inside containers.
-Dockerfile text eol=lf
-Dockerfile.* text eol=lf
-*.dockerfile text eol=lf
+# Normalize line-endings for text files
+* text=auto eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Shell scripts must keep LF endings even when checked out on Windows.
+#
+# With core.autocrlf=true these get CRLF on checkout, which turns the shebang
+# into `#!/bin/bash\r`. Linux containers then fail to exec them with the very
+# unhelpful "no such file or directory" -- entrypoint.sh, the Druid spec
+# submitter and the MinIO bucket init all break this way.
+*.sh text eol=lf
+
+# Same reasoning: these are executed inside containers.
+Dockerfile text eol=lf
+Dockerfile.* text eol=lf
+*.dockerfile text eol=lf


### PR DESCRIPTION
## Description

On Windows with `core.autocrlf=true` (the Git for Windows default), `*.sh` files
are checked out with CRLF line endings. The shebang becomes `#!/bin/bash\r`, and
every container that execs one fails with a misleading error:

    exec /osprey/entrypoint.sh: no such file or directory

This breaks the stock `docker compose up` path. Affected scripts include
`entrypoint.sh`, `druid/specs/submit-specs.sh` and `init-minio-bucket.sh`.

The project already has an LF policy — `.pre-commit-config.yaml` runs
`mixed-line-ending --fix=lf` — but it is only enforced at **commit** time.
Nothing enforces LF at **checkout** time, which is where autocrlf breaks it.
This PR closes that half of the gap.

### Why no `.sh` files are in this diff

The repository already stores LF. Verified with:

    git show HEAD:entrypoint.sh | od -c | head -3

Only `\n` appears — no `\r`. The CRLF is introduced purely on checkout, so
`.gitattributes` alone is the complete fix and no file contents change.

### Verification

Before, on Windows:

    $ file entrypoint.sh
    entrypoint.sh: Bourne-Again shell script, ASCII text executable, with CRLF line terminators
    $ docker compose up
    osprey-worker | exec /osprey/entrypoint.sh: no such file or directory

After, on a fresh clone with this change:

    $ file entrypoint.sh
    entrypoint.sh: Bourne-Again shell script, ASCII text executable
    $ docker compose up   # worker starts normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized text file formatting to use consistent LF line endings across development environments.
  * Improved consistency when viewing, editing, and sharing text-based files across different operating systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->