### PR TITLE
 Fix excessive CPU load in generate_test_data.sh

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -222,6 +222,7 @@ services:
     entrypoint:
       - /bin/bash
     command: ["/osprey/example_data/generate_test_data.sh"]
+    restart: unless-stopped
 
   postgres:
     hostname: postgres

--- a/example_data/generate_test_data.sh
+++ b/example_data/generate_test_data.sh
@@ -56,10 +56,21 @@ build_kafka_command() {
     echo "$cmd"
 }
 
+# FIFO used to stream messages into a single long-lived producer process
+FIFO="$(mktemp -u /tmp/kafka_producer_fifo.XXXXXX)"
+producer_pid=""
+
 # Function to handle cleanup on script termination
 cleanup() {
     echo
     echo "Stopping data generation..."
+    # Close our write end of the FIFO so the producer sees EOF and exits
+    exec 3>&- 2>/dev/null
+    if [ -n "$producer_pid" ] && kill -0 "$producer_pid" 2>/dev/null; then
+        kill "$producer_pid" 2>/dev/null
+        wait "$producer_pid" 2>/dev/null
+    fi
+    rm -f "$FIFO"
     exit 0
 }
 
@@ -78,11 +89,21 @@ echo
 # Build the kafka command
 kafka_cmd=$(build_kafka_command)
 
+# Start a single long-lived producer reading from the FIFO, instead of
+# spawning a brand-new JVM producer process per message.
+mkfifo "$FIFO"
+eval "$kafka_cmd" < "$FIFO" &
+producer_pid=$!
+
+# Open the FIFO for writing on fd 3 and keep it open for the life of the
+# script, so the producer never sees EOF between messages.
+exec 3> "$FIFO"
+
 # Infinite loop to generate and send actions
 while true; do
     action=$(generate_action)
     echo -e "Sending $action"
-    echo -e "$action" | $kafka_cmd
+    echo -e "$action" >&3
 
     # Increment action_id in the main shell
     ((action_id++))

--- a/example_data/generate_test_data.sh
+++ b/example_data/generate_test_data.sh
@@ -45,19 +45,20 @@ generate_action() {
     eval "$cmd" "$SCRIPT_DIR/template.json"
 }
 
-# Function to build kafka-console-producer command
+# Function to build kafka-console-producer command as an array (avoids
+# eval'ing environment-controlled values as shell code)
 build_kafka_command() {
-    local cmd="kafka-console-producer --broker-list $KAFKA_BROKER --topic $KAFKA_TOPIC"
+    kafka_cmd=(kafka-console-producer --broker-list "$KAFKA_BROKER" --topic "$KAFKA_TOPIC")
 
     if [ -n "$KAFKA_CONFIG_FILE" ]; then
-        cmd="$cmd --producer.config $KAFKA_CONFIG_FILE"
+        kafka_cmd+=(--producer.config "$KAFKA_CONFIG_FILE")
     fi
-
-    echo "$cmd"
 }
 
-# FIFO used to stream messages into a single long-lived producer process
-FIFO="$(mktemp -u /tmp/kafka_producer_fifo.XXXXXX)"
+# Directory + FIFO used to stream messages into a single long-lived producer
+# process. Using our own mktemp -d directory avoids writing into shared /tmp.
+FIFO_DIR="$(mktemp -d)"
+FIFO="$FIFO_DIR/kafka_producer_fifo"
 producer_pid=""
 
 # Function to handle cleanup on script termination
@@ -66,11 +67,18 @@ cleanup() {
     echo "Stopping data generation..."
     # Close our write end of the FIFO so the producer sees EOF and exits
     exec 3>&- 2>/dev/null
-    if [ -n "$producer_pid" ] && kill -0 "$producer_pid" 2>/dev/null; then
-        kill "$producer_pid" 2>/dev/null
+    if [ -n "$producer_pid" ]; then
+        # Give the producer a chance to exit on its own after seeing EOF
+        for _ in $(seq 1 20); do
+            kill -0 "$producer_pid" 2>/dev/null || break
+            sleep 0.1
+        done
+        if kill -0 "$producer_pid" 2>/dev/null; then
+            kill "$producer_pid" 2>/dev/null
+        fi
         wait "$producer_pid" 2>/dev/null
     fi
-    rm -f "$FIFO"
+    rm -rf "$FIFO_DIR"
     exit 0
 }
 
@@ -86,13 +94,13 @@ fi
 echo "Press Ctrl+C to stop..."
 echo
 
-# Build the kafka command
-kafka_cmd=$(build_kafka_command)
+# Build the kafka command (populates the kafka_cmd array)
+build_kafka_command
 
 # Start a single long-lived producer reading from the FIFO, instead of
 # spawning a brand-new JVM producer process per message.
-mkfifo "$FIFO"
-eval "$kafka_cmd" < "$FIFO" &
+mkfifo "$FIFO" || { echo "Failed to create FIFO at $FIFO" >&2; exit 1; }
+"${kafka_cmd[@]}" < "$FIFO" &
 producer_pid=$!
 
 # Open the FIFO for writing on fd 3 and keep it open for the life of the


### PR DESCRIPTION
## Summary
- `generate_test_data.sh` was spawning a brand-new `kafka-console-producer` JVM process per message (once/sec), paying full JVM startup + classpath scan + producer init/metadata fetch every iteration, forever — this pegged the `osprey-kafka-test-data-producer` container at 180-200% CPU cycling every 1-2s under `docker top`.
- Now starts a single long-lived `kafka-console-producer` process and streams generated messages to it over a FIFO, instead of forking a new producer per line.
- Same JSON generation logic (`generate_action`, `template.json` substitution) and ~1 msg/sec cadence are preserved.
- `cleanup()` now also closes the FIFO write end and kills the persistent producer on SIGINT/SIGTERM, so it isn't left orphaned.

## Test plan
- [x] Restarted the running `osprey-kafka-test-data-producer` container with the fix applied (volume-mounted `example_data`).
- [x] `docker top` shows a single persistent `ConsoleProducer` JVM process across multiple message sends, instead of a new one per second.
- [x] `docker stats` shows CPU settling to ~2-3% instead of 180-200%.
- [x] Sent SIGTERM to the script and confirmed the trap fires ("Stopping data generation...", exit 0) and the producer JVM is killed rather than orphaned.
- [x] confirmed test data generation still works: 
<img width="1676" height="810" alt="Screenshot 2026-08-14 at 15 50 16" src="https://github.com/user-attachments/assets/85664ac0-d6ce-4a1b-afd0-21337831c9b0" />

## Checklist

- [ ] Tests pass locally
- [ ] `uv run ruff check .` passes (no unused imports or other lint errors)
- [ ] `uv tool run fawltydeps --check-unused --pyenv .venv` passes (no unused dependencies)
- [X] Updated `CHANGELOG.md` with my changes, if notable (refer to [Keep a Changelog](https://keepachangelog.com/en/2.0.0/) conventions)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved test data generation by streaming actions through a persistent messaging process.
  * Reduced process startup overhead when generating large volumes of test data.

* **Reliability**
  * Added orderly cleanup of temporary resources and background processes.
  * Improved recovery and restart behavior for the test data producer service.

* **Security**
  * Improved command handling to reduce risks associated with special characters and unexpected input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->