### PR TITLE
[async worker] align engine tests with runtime behavior

### DIFF
--- a/osprey_async_worker/src/osprey/async_worker/tests/test_engine.py
+++ b/osprey_async_worker/src/osprey/async_worker/tests/test_engine.py
@@ -1,10 +1,11 @@
 """Tests for AsyncOspreyEngine recompile behavior on etcd updates."""
 
 import threading
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 from osprey.async_worker.engine import AsyncOspreyEngine
+from osprey.engine.ast.sources import Sources
 
 
 def _make_engine_with_stub_compile(initial_graph, recompile_graph):
@@ -63,27 +64,24 @@ async def test_handle_updated_sources_runs_compile_off_event_loop():
 
 
 @pytest.mark.asyncio
-async def test_handle_updated_sources_does_not_force_gc():
-    """We deliberately do NOT call gc.collect() after swap.
-
-    Forcing gen-2 collection promotes every surviving object to gen 2, which
-    makes subsequent automatic collections during action processing more
-    expensive. We let CPython's reference counting reclaim the old graph
-    naturally — same as the gevent engine.
-    """
+async def test_handle_updated_sources_freezes_resident_graph():
     import gc as gc_module
 
     initial = MagicMock(name='initial_graph')
     new = MagicMock(name='new_graph')
     engine = _make_engine_with_stub_compile(initial, new)
+    gc_calls = MagicMock()
 
     with (
         patch.object(engine, '_compile_execution_graph_sync', return_value=new),
         patch.object(gc_module, 'collect') as mock_collect,
+        patch.object(gc_module, 'freeze') as mock_freeze,
     ):
+        gc_calls.attach_mock(mock_collect, 'collect')
+        gc_calls.attach_mock(mock_freeze, 'freeze')
         await engine._handle_updated_sources()
 
-    assert mock_collect.call_count == 0
+    assert gc_calls.mock_calls == [call.collect(), call.freeze()]
 
 
 @pytest.mark.asyncio
@@ -142,7 +140,9 @@ async def test_handle_updated_sources_nulls_parents_on_old_graph():
             src.ast_root._test_nodes = nodes
             sources.append(src)
         validated = MagicMock()
-        validated.sources = sources
+        validated.sources = MagicMock(spec=Sources)
+        validated.sources.__iter__.side_effect = lambda: iter(sources)
+        validated.sources.hash.return_value = 'test_hash'
         graph = MagicMock(validated_sources=validated)
         return graph
 


### PR DESCRIPTION
## Description

Align the async engine recompile tests with the runtime behavior introduced by #454. The GC test now verifies the required collect-then-freeze sequence, and the cycle-break fixture now models the iterable, hashable `Sources` contract instead of using a plain list.

## Related Issues/Tasks

- async image workspace parity: https://github.com/roostorg/osprey/pull/461 — merge after this PR
- cancellation cleanup: https://github.com/roostorg/osprey/pull/459 — merge after this PR, after #461
- timeout enforcement: https://github.com/roostorg/osprey/pull/452 — merge after this PR, after #459

## Models used

- openai/gpt-5.6-sol: ~70%
- anthropic/claude-opus-4-8: ~20%
- anthropic/claude-haiku-4-5: ~10%

## Testing

- RED: both targeted tests failed before the change with the observed `gc.collect()` expectation and missing `Sources.hash()` errors
- `uv run pytest osprey_async_worker/src/osprey/async_worker/tests/test_engine.py -q` (7 passed)
- `uv run pytest osprey_async_worker/src/osprey/async_worker/tests -q` (124 passed)
- `uv run ruff check .`
- `uv run ruff format --diff osprey_async_worker/src/osprey/async_worker/tests/test_engine.py`
- `uv run mypy osprey_async_worker/src/osprey/async_worker/tests/test_engine.py`
- `uv tool run fawltydeps --check-unused --pyenv .venv`

## Checklist

- [x] Tests pass locally
- [x] `uv run ruff check .` passes (no unused imports or other lint errors)
- [x] `uv tool run fawltydeps --check-unused --pyenv .venv` passes (no unused dependencies)
- [x] Updated `CHANGELOG.md` with my changes, if notable (not applicable; test-only correction)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated coverage for source updates and graph validation.
  * Added checks confirming reliable handling of source collections, iteration, hashing, and memory cleanup sequencing.
  * These tests help protect application stability during updates involving validated sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->