### PR TITLE
[async worker] include atproto workspace in image

### DIFF
--- a/osprey_async_worker/Dockerfile
+++ b/osprey_async_worker/Dockerfile
@@ -45,7 +45,7 @@ ADD osprey_rpc/pyproject.toml /osprey/osprey_rpc/pyproject.toml
 ADD osprey_worker/pyproject.toml /osprey/osprey_worker/pyproject.toml
 ADD osprey_async_worker/pyproject.toml /osprey/osprey_async_worker/pyproject.toml
 ADD example_plugins/pyproject.toml /osprey/example_plugins/pyproject.toml
-ADD example_atproto_plugins/pyproject.toml /osprey/example_atproto_plugins/pyproject.toml
+COPY example_atproto_plugins/pyproject.toml /osprey/example_atproto_plugins/pyproject.toml
 
 # Create minimal package structure required by uv
 RUN mkdir -p /osprey/osprey_worker /osprey/osprey_async_worker /osprey/osprey_rpc /osprey/example_plugins/src /osprey/example_atproto_plugins/src/atproto_plugin && \
@@ -66,7 +66,7 @@ ADD osprey_worker /osprey/osprey_worker
 ADD osprey_async_worker /osprey/osprey_async_worker
 ADD osprey_rpc /osprey/osprey_rpc
 ADD example_plugins /osprey/example_plugins
-ADD example_atproto_plugins /osprey/example_atproto_plugins
+COPY example_atproto_plugins /osprey/example_atproto_plugins
 
 COPY entrypoint.sh /osprey/entrypoint.sh
 

--- a/osprey_async_worker/Dockerfile
+++ b/osprey_async_worker/Dockerfile
@@ -45,10 +45,11 @@ ADD osprey_rpc/pyproject.toml /osprey/osprey_rpc/pyproject.toml
 ADD osprey_worker/pyproject.toml /osprey/osprey_worker/pyproject.toml
 ADD osprey_async_worker/pyproject.toml /osprey/osprey_async_worker/pyproject.toml
 ADD example_plugins/pyproject.toml /osprey/example_plugins/pyproject.toml
+ADD example_atproto_plugins/pyproject.toml /osprey/example_atproto_plugins/pyproject.toml
 
 # Create minimal package structure required by uv
-RUN mkdir -p /osprey/osprey_worker /osprey/osprey_async_worker /osprey/osprey_rpc /osprey/example_plugins/src && \
-    touch /osprey/osprey_worker/__init__.py /osprey/osprey_async_worker/__init__.py /osprey/osprey_rpc/__init__.py /osprey/example_plugins/src/__init__.py
+RUN mkdir -p /osprey/osprey_worker /osprey/osprey_async_worker /osprey/osprey_rpc /osprey/example_plugins/src /osprey/example_atproto_plugins/src/atproto_plugin && \
+    touch /osprey/osprey_worker/__init__.py /osprey/osprey_async_worker/__init__.py /osprey/osprey_rpc/__init__.py /osprey/example_plugins/src/__init__.py /osprey/example_atproto_plugins/src/atproto_plugin/__init__.py
 
 # Install the full workspace, including osprey_async_worker (this is the one image
 # that does). This layer is cached when only source code changes.
@@ -65,6 +66,7 @@ ADD osprey_worker /osprey/osprey_worker
 ADD osprey_async_worker /osprey/osprey_async_worker
 ADD osprey_rpc /osprey/osprey_rpc
 ADD example_plugins /osprey/example_plugins
+ADD example_atproto_plugins /osprey/example_atproto_plugins
 
 COPY entrypoint.sh /osprey/entrypoint.sh
 


### PR DESCRIPTION
## Description

Include the existing `example_atproto_plugins` workspace member in the async-worker image dependency layer. The root lockfile was already current; the image build failed because its partial workspace omitted this member before `uv sync --locked`.

The change mirrors the stable-worker image by staging the member metadata and minimal package before dependency installation, then overlaying the real source afterward. `example_atproto_rules` remains out of scope because it is not a workspace member and does not affect locked dependency resolution.

## Related Issues/Tasks

- shared async engine test correction: https://github.com/roostorg/osprey/pull/460 — merge before this PR
- cancellation cleanup: https://github.com/roostorg/osprey/pull/459 — merge after this PR
- timeout enforcement: https://github.com/roostorg/osprey/pull/452 — merge after this PR, after #459

## Changes Made

- copy `example_atproto_plugins/pyproject.toml` before locked workspace sync
- create its real `src/atproto_plugin` package shape in the cached dependency layer
- copy the complete plugin source in the final image layer

## Models used

- openai/gpt-5.6-sol: ~82%
- anthropic/claude-opus-4-8: ~18%

## Testing

- `uv lock --check`
- `docker build --label osprey.oss-e2e.harness=workspace-parity-pr -f osprey_async_worker/Dockerfile -t osprey-async-workspace-parity:standalone .`
- `docker build -f osprey_async_worker/Dockerfile -t osprey-async-workspace-parity:bot-review .` after replacing local `ADD` instructions with `COPY`
- OSS end-to-end validation on both #452 and #459 heads confirmed async-worker image builds and container entrypoint runs pass with the same change

## Checklist

- [x] Tests pass locally
- [x] `uv run ruff check .` passes (not applicable; Dockerfile-only change)
- [x] `uv tool run fawltydeps --check-unused --pyenv .venv` passes (not applicable; no dependency declaration changed)
- [x] Updated `CHANGELOG.md` with my changes, if notable (not applicable; build-context correction)
