### PR TITLE
[docs] Explain SML ruleset configuration

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -35,6 +35,7 @@
 - [Concepts](concepts.md)
 - [Writing Rules](rules/README.md)
   - [Examples](rules/examples.md)
+  - [Ruleset Configuration](rules/configuration.md)
   - [Why a Bespoke Language?](rules/why-sml.md)
 - [User Research & Personas](research-personas.md)
 

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -4,6 +4,7 @@ Rules are how you teach Osprey what to look for and what to do when it finds it.
 
 See also: 
   - [Examples](examples.md) to apply all the concepts to complete, runnable rulesets
+  - [Ruleset Configuration](configuration.md) for YAML settings loaded alongside SML rules
   - [Why a Bespoke Language?](why-sml.md) for more about SML and why it exists
 
 ![A user's action flows from your production service into Osprey as an event, where rules call UDFs and produce execution output; output sinks return verdicts to your service—the user gets banned—and send features to the Osprey UI](../images/rules_architecture.png)

--- a/docs/rules/configuration.md
+++ b/docs/rules/configuration.md
@@ -1,0 +1,54 @@
+# Ruleset Configuration
+
+SML files define features, rules, and effects. A ruleset can also include YAML configuration for behavior that sits outside the SML execution graph, such as declaring labels or choosing what the UI displays.
+
+Configuration doesn't create SML variables and can't replace rule logic. Engine and worker components read each configuration section for their own purposes.
+
+## File layout
+
+A directory-backed ruleset needs at least one configuration source: `config.yaml` at the ruleset root or a file with a lowercase `.yaml` extension directly inside a directory named `config`. Osprey scans every directory named `config` in the ruleset tree and loads the `.yaml` files immediately inside it. Keep exactly one `config/` directory at the root to make file discovery predictable.
+
+```text
+my-rules/
+|-- main.sml
+|-- config.yaml
+|-- config/
+|   |-- labels.yaml
+|   `-- ui_config.yaml
+|-- models/
+`-- rules/
+```
+
+Use `{}` in `config.yaml` when the ruleset has no settings. Don't leave a discovered configuration file empty: if any file is empty, Osprey treats the entire merged configuration as empty, and publishing the ruleset can fail.
+
+Osprey deep-merges the files into one configuration object. Mappings combine and lists concatenate. Defining the same scalar key in more than one file causes ruleset loading to fail, even when the values match. Keeping each top-level section in one file avoids surprising merges.
+
+## Configuration sections
+
+Each top-level YAML key is a configuration section. Osprey registers a schema for every section it understands, then checks the merged configuration alongside SML source validation and before execution graph compilation. Unsupported sections and invalid values prevent the ruleset from activating.
+
+For example, the demo ruleset declares the `meow` label used by its SML rules:
+
+```yaml
+labels:
+  meow:
+    valid_for: [User]
+    connotation: positive
+    description: testing label
+```
+
+This configuration lets Osprey:
+
+- reject a rule that uses an undeclared label or applies it to the wrong entity type
+- show the label's description and connotation in the UI
+- give `LabelAdd`, `LabelRemove`, and `HasLabel` a shared label definition
+
+Other sections configure worker or UI behavior. For example, `ui_config` selects default summary features and external links. The available sections depend on the worker build in your deployment; a top-level key is valid only when that worker has registered it.
+
+## Applying updates
+
+Configuration is versioned with its SML sources and contributes to the ruleset hash. When a source provider delivers an updated ruleset, Osprey validates the YAML and SML, then compiles the execution graph before activating it. If validation or compilation fails, the update doesn't go live.
+
+A directory-backed worker reads the ruleset at startup; it doesn't watch files for changes. Use [`osprey-cli push-rules`](../development/cli-reference.md#osprey-cli-push-rules) when your deployment accepts pushed rules.
+
+See [Examples](examples.md) for a complete ruleset that uses `config/labels.yaml` alongside SML rules.

--- a/docs/rules/examples.md
+++ b/docs/rules/examples.md
@@ -99,6 +99,8 @@ labels:
     description: testing label
 ```
 
+[Ruleset Configuration](configuration.md) explains how Osprey loads and validates YAML alongside SML, and what happens when either changes.
+
 **What you'll see in the UI** once events flow: each processed post appears in the Event Stream with `UserId`, `EventType`, `PostText`, and `ContainsHello` among its extracted features; querying `ContainsHello == True` filters to the posts that matched; and clicking through to a matched post's author shows the `meow` label on their `User` entity, with the `BanUser` effect recorded on the event. [Getting Started](../development/) walks through this UI tour on live demo data.
 
 ## Labels as state


### PR DESCRIPTION
## Summary
Add a ruleset configuration reference that explains how YAML relates to SML, how files are discovered and merged, how validation gates activation, and how updates reach workers.

## Changes Made
- add `docs/rules/configuration.md` with a complete label example and loader edge cases
- add the page to the mdBook navigation and Writing Rules links
- link the existing demo walkthrough to the new reference

## Models used
- openai/gpt-5.6-sol: ~55%
- anthropic/claude-fable-5: ~35%
- anthropic/claude-haiku-4-5: ~10%

## Testing
- `uv run pre-commit run --files docs/SUMMARY.md docs/rules/README.md docs/rules/configuration.md docs/rules/examples.md`
- `git diff --cached --check`
- five cross-model documentation review passes against the loader and validation implementation
- `mdbook build docs` not run because `mdbook` is not installed locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive guidance for configuring rulesets with YAML, including file discovery, structure, validation, labels, worker and UI settings, and update workflows.
  - Added navigation links to the new Ruleset Configuration documentation from related writing-rules pages and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->