### PR TITLE
[async worker] run unit tests in CI

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -51,6 +51,9 @@ jobs:
           uv run pre-commit install --install-hooks
           uv run pre-commit run --show-diff-on-failure --color=always --all-files
 
+      - name: Run async worker unit tests
+        run: uv run pytest -q osprey_async_worker
+
       - name: Check for unused and undeclared dependencies
         run: uv tool run fawltydeps --pyenv .venv
 


### PR DESCRIPTION
## 🤖 summary
runs the experimental async worker's existing unit suite in the python quality job so those tests gate every pull request

## related issues/tasks
- https://github.com/roostorg/osprey/pull/415
- https://github.com/roostorg/osprey/pull/468
- https://github.com/roostorg/osprey/pull/469

## changes made (˶ᵔ ᵕ ᵔ˶)
- add a focused async worker pytest step after dependency and static checks
- keep the stable worker testpaths and integration image unchanged

## models used
- anthropic/claude-opus-4-8: ~55%
- openai/gpt-5.6-sol: ~25%
- anthropic/claude-fable-5: ~10%
- anthropic/claude-haiku-4-5: ~10%
