### PR TITLE
[ci] isolate compose test stack

### DIFF
--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -2,18 +2,29 @@
 # Usage: docker compose -f docker-compose.yaml -f docker-compose.test.yaml --profile test <command>
 
 services:
+  # reset fixed names and host ports so test stacks can coexist
+  # dependencies communicate over the compose project network
   postgres:
+    container_name: !reset null
     ports: !reset []
     volumes: !reset []
 
+  osprey-kafka:
+    container_name: !reset null
+    ports: !reset []
+
   minio:
+    container_name: !reset null
+    ports: !reset []
     volumes: !reset []
 
+  snowflake-id-worker:
+    container_name: !reset null
+    ports: !reset []
+
   etcd:
-    container_name: etcd
+    container_name: !reset null
     image: quay.io/coreos/etcd:v3.4.18
-    ports:
-      - "127.0.0.1:2379:2379"
     environment:
       - ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379
       - ETCD_ADVERTISE_CLIENT_URLS=http://etcd:2379
@@ -38,7 +49,6 @@ services:
     restart: unless-stopped
 
   test_runner:
-    container_name: osprey_test_runner
     build:
       context: .
       dockerfile: osprey_worker/Dockerfile


### PR DESCRIPTION
## 🤖 summary
isolates the compose test dependency graph from host ports and fixed container names so test stacks can coexist across worktrees

## related issues/tasks
- https://github.com/roostorg/osprey/pull/415
- https://github.com/roostorg/osprey/pull/467
- https://github.com/roostorg/osprey/pull/468

## changes made (˶ᵔ ᵕ ᵔ˶)
- reset inherited container names for test dependencies
- remove host port publications that the test runner does not use
- preserve internal service names, ports, healthchecks, and dependency ordering

## models used
- anthropic/claude-opus-4-8: ~45%
- anthropic/claude-fable-5: ~25%
- openai/gpt-5.6-sol: ~20%
- anthropic/claude-haiku-4-5: ~10%

## testing
- ran the full compose integration suite alongside an existing Osprey stack
- 1,308 tests completed with 0 errors and 0 failures, then all run-owned resources were removed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved test environment reliability by allowing multiple test stacks to run concurrently without container name or host port conflicts.
  - Updated service networking so test components communicate through the compose project network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->