### PR TITLE
CODEOWNERS: update to community team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 
 # Maintainers, plus ROOST-maintained teams of other trusted contributors
 # See https://roostorg.github.io/community/roles.html#maintainers
-* @ayubun @EXBreder @haileyok @vinaysrao1 @roostorg/roosters @roostorg/discord
+* @ayubun @EXBreder @haileyok @roostorg/community @roostorg/discord


### PR DESCRIPTION
Swap ROOSTers team out for Community team, like we did for Coop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository maintenance ownership metadata to reflect the current community support structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->