### PR TITLE
docs: Specify minimum Docker Compose version

### DIFF
--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -4,7 +4,7 @@ Quickly see Osprey working with sample data and a real rule using the demo scrip
 
 To run the demo:
 
-1. **Ensure you have prerequisites** installed: Docker with the Compose v2 plugin, and the Docker daemon running. The script checks these before doing anything.
+1. **Ensure you have prerequisites** installed: Docker with Docker Compose 2.24.4+, and the Docker daemon running. The script checks these before doing anything.
 
    ```sh
    docker --version && docker compose version

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -4,7 +4,7 @@ Quickly see Osprey working with sample data and a real rule using the demo scrip
 
 To run the demo:
 
-1. **Ensure you have prerequisites** installed: Docker with Docker Compose 2.24.4+, and the Docker daemon running. The script checks these before doing anything.
+1. **Ensure you have prerequisites** installed: Docker with Docker Compose 2.24.4+, and the Docker daemon running.
 
    ```sh
    docker --version && docker compose version

--- a/docs/development/local.md
+++ b/docs/development/local.md
@@ -5,8 +5,9 @@ Set up a full local development environment for Osprey. To just get up and runni
 ## Prerequisites
 
 - **Operating System**: macOS, Linux, or Windows (with WSL recommended)
-- **[Python](https://www.python.org/) 3.11 or higher** (check with `python --version`)
 - **[Git](https://git-scm.com/)** for version control
+- **Docker** with **[Docker Compose](https://docs.docker.com/compose/) 2.24.4 or higher**
+- **[Python](https://www.python.org/) 3.11 or higher** (check with `python --version`)
 - **[uv](https://docs.astral.sh/uv/)** for Python package management
 - **[Node.js](https://nodejs.org/en/download/) 22+** for the UI (Corepack ships with Node and auto-resolves pnpm from `osprey_ui/package.json`'s `packageManager` field; no separate pnpm install needed)
 


### PR DESCRIPTION
Resolves https://github.com/roostorg/osprey/pull/469#discussion_r3855653235

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated local development prerequisites to list Git before Docker and require Docker Compose 2.24.4 or newer.
  * Retained the requirement for Python 3.11 or newer.
  * Removed outdated documentation stating that the demo script checks Docker and Compose prerequisites before running.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->