### PR TITLE
QueryUtils: Replace all quotes instead of just the first

### DIFF
--- a/osprey_ui/src/utils/QueryUtils.tsx
+++ b/osprey_ui/src/utils/QueryUtils.tsx
@@ -62,7 +62,7 @@ const renderValueWithType = (value: string | null, type: string | undefined): st
         return renderValueWithType(value, type.slice(0, type.length - 1));
       }
     } else if (type === 'str') {
-      const escapedId = value.replace(`'`, `\\'`);
+      const escapedId = value.replaceAll('\\', '\\\\').replaceAll(`'`, `\\'`);
       return `'${escapedId}'`;
     } else if (type === 'int' || type === 'float') {
       return value;


### PR DESCRIPTION
String.prototype.replace() only replaces the first instance of a string; it seems like we should be replacing each, instead. Also escape any existing backslashes first.

## Checklist

- [x] Tests pass locally
- [x] `uv run ruff check .` passes (no unused imports or other lint errors)
- [x] `uv tool run fawltydeps --check-unused --pyenv .venv` passes (no unused dependencies)
- [ ] ~~Updated `CHANGELOG.md` with my changes, if notable (refer to [Keep a Changelog](https://keepachangelog.com/en/2.0.0/) conventions)~~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query string rendering by properly escaping backslashes and apostrophes, preventing malformed quoted values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->