### PR TITLE
fix: overly-broad regular expressions

### DIFF
--- a/osprey_ui/src/components/entities/RichDescription.tsx
+++ b/osprey_ui/src/components/entities/RichDescription.tsx
@@ -7,8 +7,8 @@ interface RichDescriptionProps {
   features: { [featureName: string]: string };
 }
 
-const INTERPOLATE_REG_EX = /{([A-Za-z0-9_]+)}/;
-const SPLIT_REG_EX = /(:?{[A-Za-z0-9_]+})/;
+const INTERPOLATE_REG_EX = /{(\w+)}/;
+const SPLIT_REG_EX = /(:?{\w+})/;
 
 const RichDescription = ({ description, features }: RichDescriptionProps) => {
   const interpolatedDescription = description.split(SPLIT_REG_EX).map((part, i) => {

--- a/osprey_ui/src/components/entities/RichDescription.tsx
+++ b/osprey_ui/src/components/entities/RichDescription.tsx
@@ -7,8 +7,8 @@ interface RichDescriptionProps {
   features: { [featureName: string]: string };
 }
 
-const INTERPOLATE_REG_EX = /{([A-z0-9_]+)}/;
-const SPLIT_REG_EX = /(:?{[A-z0-9_]+})/;
+const INTERPOLATE_REG_EX = /{([A-Za-z0-9_]+)}/;
+const SPLIT_REG_EX = /(:?{[A-Za-z0-9_]+})/;
 
 const RichDescription = ({ description, features }: RichDescriptionProps) => {
   const interpolatedDescription = description.split(SPLIT_REG_EX).map((part, i) => {

--- a/osprey_worker/src/osprey/engine/stdlib/udfs/string.py
+++ b/osprey_worker/src/osprey/engine/stdlib/udfs/string.py
@@ -235,6 +235,7 @@ _EMOJI_PATTERN: re.Pattern[str] = re.compile(
 )
 
 # sub for l33t -> leet
+# with IGNORECASE this matches 3s surrounded by unicode letters like İ, ı, ſ, and K which is expected
 _L33T_THREES_SUB_PATTERN: re.Pattern[str] = re.compile(r'([A-Za-z]?)(3+)([A-Za-z]?)', flags=re.IGNORECASE)
 
 # sub for |7 -> 17

--- a/osprey_worker/src/osprey/engine/stdlib/udfs/string.py
+++ b/osprey_worker/src/osprey/engine/stdlib/udfs/string.py
@@ -235,7 +235,7 @@ _EMOJI_PATTERN: re.Pattern[str] = re.compile(
 )
 
 # sub for l33t -> leet
-_L33T_THREES_SUB_PATTERN: re.Pattern[str] = re.compile(r'([A-z]?)(3+)([A-z]?)', flags=re.IGNORECASE)
+_L33T_THREES_SUB_PATTERN: re.Pattern[str] = re.compile(r'([A-Za-z]?)(3+)([A-Za-z]?)', flags=re.IGNORECASE)
 
 # sub for |7 -> 17
 _L33T_PIPE_NUMBER_SUB_PATTERN: re.Pattern[str] = re.compile(r'\|(\d)')


### PR DESCRIPTION
## Description

I noticed these when looking into something else, and they seemed easy enough to fix! For context, `[A-z]` matches punctuation between `Z` and `a`, making it overly broad and usually not what was intended. Instead, we should explicitly match `[A-Za-z]`.

## Checklist

- [x] Tests pass locally
- [x] `uv run ruff check .` passes (no unused imports or other lint errors)
- [x] `uv tool run fawltydeps --check-unused --pyenv .venv` passes (no unused dependencies)
- [ ] Updated `CHANGELOG.md` with my changes, if notable (refer to [Keep a Changelog](https://keepachangelog.com/en/2.0.0/) conventions)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text interpolation handling for word characters, including letters, numbers, and underscores.
  * Corrected leetspeak matching to exclude punctuation characters that were previously treated as letters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->