### PR TITLE
docs: Update README for concision and consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,29 +4,25 @@
 
 **Automate the obvious and investigate the ambiguous.** Osprey is a safety rules engine and investigation console for real-time event processing at scale.
 
-Your platform streams events to Osprey, and human-written rules evaluate each one as it arrives—taking automatic action, applying labels to the entities involved, and sending verdicts and custom effects to your own systems. Analysts then query and chart the results to spot patterns, investigate, and turn what they find into new rules. Originally developed internally at [Discord](https://discord.com/) to combat spam, abuse, botting, and scripting across its platform, Osprey has been open-sourced to help other platforms facing similar challenges.
+Your platform streams events to Osprey, and human-written rules evaluate each one as it arrives—taking automatic action, applying labels to the entities involved, and sending verdicts and custom effects to your own systems. Analysts query and chart the results to spot patterns, investigate, and turn what they find into new rules.
+
+Originally developed internally at [Discord](https://discord.com/) to combat spam, abuse, botting, and scripting across its platform, Osprey has been open sourced and is developed in the open by the [ROOST](https://roost.tools) community to help other platforms facing similar challenges.
 
 ![The Query page with an SML filter for post-creation events and its history of past queries, beside a timeseries chart showing matching event volume in fifteen-minute buckets](docs/images/query-and-charts.png)
 
 Rules are written in SML, Osprey's structured rule language, and extended with user-defined functions (UDFs). Osprey tracks state across events by labeling entities when you provide a labels service backend; see [labels_service.py](./example_plugins/src/services/labels_service.py) for a Postgres-backed example.
 
-Osprey is built for engineers and Trust & Safety teams who want to explore, test, and integrate it into their platform for incident response and investigations. [Read more about user research and personas](docs/research-personas.md).
+Osprey is built for engineers and Trust & Safety teams who want to explore, test, and integrate it into their platform for incident response and investigations. [Read more about user research and personas]([docs/research-personas.md](https://roostorg.github.io/osprey/latest/research-personas).
 
-## Try it
+## Quick start
 
-If you have Docker with Compose v2, one command brings up the full stack with sample data and opens the UI on a pre-filled query:
-
-```sh
-./demo.sh
-```
-
-Or, without cloning the repo first:
+If you have [Docker Compose](https://docs.docker.com/compose/install), get a demo running with sample data with one command:
 
 ```sh
 curl -sSL https://raw.githubusercontent.com/roostorg/osprey/main/demo.sh | bash
 ```
 
-The [Getting Started guide](https://roostorg.github.io/osprey/latest/development/) explains what the demo starts, what to try in the UI, and how to shut it all down. The rest of the documentation lives at [roostorg.github.io/osprey/latest](https://roostorg.github.io/osprey/latest/).
+See the [Getting Started guide](https://roostorg.github.io/osprey/latest/development/) for more, including what to try in the UI. See the [full documentation](https://roostorg.github.io/osprey/latest/) for a user guide, development setup, basic concepts, integration information, and more.
 
 ## Adopters
 
@@ -37,30 +33,18 @@ Osprey is used by:
 
 Using Osprey and want to add your project/organization to this list? [Open a pull request!](https://github.com/roostorg/osprey/edit/main/README.md)
 
-## Development
+### Built in the open
 
-See the [development guide](./docs/development/) for development setup and workflow documentation, including the linting, type checking, and pre-commit hooks that changes are expected to pass.
+Osprey is an open source project undergoing active development. Features and documentation will evolve based on community feedback; we want to hear from you! Please [open an issue](https://github.com/roostorg/osprey/issues), [join or start a discussion](https://github.com/roostorg/osprey/discussions), or come chat with the community including developers and adopters in our [Discord server](https://discord.gg/2brrzbqgJF) to share.
 
-## Join us
-
-Writing code is not the only way to help the project. Reviewing pull requests, answering questions in issues and discussions, providing feedback from a domain expert perspective, teaching tutorials, and improving the documentation are all priceless contributions.
-
-- Join us in [our Discord server](https://discord.gg/5Csqnw2FSQ)
-- Join our [newsletter](https://roost.tools/#get-started) for more announcements and information
-- Follow us on [Bluesky](https://bsky.app/profile/roost.tools) or [LinkedIn](https://www.linkedin.com/company/roost-tools/)
-
-_[ROOST](https://roost.tools) (Robust Open Online Safety Tools) is a non-profit organization that brings together expertise, resources, and investments from major technology companies and philanthropies to build scalable, interoperable safety infrastructure for the AI era._
-
-### Feedback wanted
-
-This is a working system, not a prototype. Try it locally, connect your data, write some rules, and tell us what's missing for your use case. We're particularly interested in:
+Try it locally, connect your data, write some rules, and tell us what's missing for your use case. We're particularly interested in:
 
 - Integration challenges with your existing platform infrastructure
 - Performance characteristics with your event volumes and rule complexity
 - Missing detection capabilities or response actions you need
 - API improvements that would make adoption easier for your team
 
-Your feedback will directly shape future priorities and help us build the most useful Trust & Safety tooling for the community.
+Your feedback directly shapes our [roadmap](https://roostorg.github.io/community/roadmap) and helps us build the most useful Trust & Safety tooling for the community.
 
 ## Recognition
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Originally developed internally at [Discord](https://discord.com/) to combat spa
 
 Rules are written in SML, Osprey's structured rule language, and extended with user-defined functions (UDFs). Osprey tracks state across events by labeling entities when you provide a labels service backend; see [labels_service.py](./example_plugins/src/services/labels_service.py) for a Postgres-backed example.
 
-Osprey is built for engineers and Trust & Safety teams who want to explore, test, and integrate it into their platform for incident response and investigations. [Read more about user research and personas]([docs/research-personas.md](https://roostorg.github.io/osprey/latest/research-personas).
+Osprey is built for engineers and Trust & Safety teams who want to explore, test, and integrate it into their platform for incident response and investigations. [Read more about user research and personas](https://roostorg.github.io/osprey/latest/research-personas).
 
 ## Quick start
 


### PR DESCRIPTION
I started by just adding a link to the ROOST roadmap for https://github.com/roostorg/community/issues/74, but ended up doing a bit more copy cleanup while I was here. Some of it is inspired by the Coop README rework, and some was just to clean up the copy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Restructured the project overview into clearer, distinct sections.
  * Added a Quick start guide with Docker Compose instructions and documentation links.
  * Corrected the personas link.
  * Updated community and contribution information, including development areas and roadmap feedback channels.
  * Identified ROOST as the open-source community maintaining the project.
  * Removed the previous “Try it” instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->