### PR TITLE
docs: Update release process details

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -20,7 +20,7 @@
   - [CLI Reference](development/cli-reference.md)
   - [Troubleshooting](development/troubleshooting.md)
   - [IDE Setup](development/ide.md)
-  - [Release Process](development/releases.md)
+  - [Releases](development/releases.md)
 
 ---
 

--- a/docs/development/releases.md
+++ b/docs/development/releases.md
@@ -1,36 +1,36 @@
-# Release Process
+# Releases
 
-Osprey uses [Semantic Versioning](https://semver.org/) (SemVer) with a 1.x.y series. This is a lightweight, bootstrap release process so downstream users can depend on version tags instead of commit hashes. The process may evolve as project usage grows.
+Osprey follows a lightweight, bootstrap release process so downstream users can depend on version tags (e.g. `1.0.1`) instead of commit hashes. The process may evolve as project usage grows. There is currently no fixed release cadence; releases are made when:
 
-## Patch releases (1.x.y)
+- Downstream users need an updated stable version tag, or
+- Meaningful changes have accumulated and CI is green
 
-Patch releases are backward-compatible fixes or small improvements already merged to `main`.
+## Versioning
 
-Cut a patch release when:
+Osprey uses [Semantic Versioning (SemVer)](https://semver.org/) following the MAJOR.MINOR.PATCH version format. In brief:
 
-- Downstream users need a stable version tag, or
-- Meaningful fixes have accumulated and CI is green
+- **Patch releases** (x.y.**Z**): backward-compatible fixes or small improvements
+- **Minor releases** (x.**Y**.z): new functionality or substantial improvements; changes to public API are backward-compatible
+- **Major releases** (**X**.y.z): backward-incompatible changes to public API, or major feature or user interface overhauls
 
-There is no fixed cadence; releases are event-driven.
+## Creating a release
 
-## Patch release checklist
+Before cutting a release, ensure:
 
-Before cutting a release:
+- [ ] **Code quality CI is passing** for the `main` branch
+- [ ] **You understand the correct version** according to SemVer
+- [ ] **[CHANGELOG.md](https://github.com/roostorg/osprey/blob/main/CHANGELOG.md) is up-to-date**
 
-- [ ] Code quality CI passing on `main` (see [Code Quality Checks](https://github.com/roostorg/osprey/actions))
-- [ ] No breaking changes
-- [ ] [CHANGELOG.md](https://github.com/roostorg/osprey/blob/main/CHANGELOG.md) updated (if applicable)
+Then:
 
-## How to cut a release
+1. In GitHub: **Releases** → **Draft a new release**
+2. **Create a tag** in SemVer format `x.y.z` from the `main` branch
+3. **Draft the release notes**, starting from [CHANGELOG.md](https://github.com/roostorg/osprey/blob/main/CHANGELOG.md)
+4. Check **Create a discussion for this release** for at least major and minor releases
+5. **Publish** the release
 
-1. Ensure the checklist above is satisfied.
-2. In GitHub: **Releases** → **Draft a new release**.
-3. Choose or create a tag `X.Y.Z` (e.g. `1.0.1`) from `main`.
-4. Publish the release.
+Publishing a release triggers automations:
 
-Publishing the release triggers existing automation:
-
-- **osprey-rpc**: build and attach sdist (and zip) to the release ([release-osprey-rpc](https://github.com/roostorg/osprey/blob/main/.github/workflows/release-osprey-rpc.yml)).
-- **Osprey Coordinator**: build and push Docker image to GHCR with version tags ([publish-coordinator-image](https://github.com/roostorg/osprey/blob/main/.github/workflows/publish-coordinator-image.yml)).
-
-Downstreams can depend on version tags (e.g. `1.0.1`) instead of commit SHAs.
+- **osprey-rpc**: builds and attaches sdist (and zip) to the release
+- **Osprey Coordinator**: builds and pushes Docker image to GHCR with version tags
+- **Docs**: adds a folder for the release to the [index](https://roostorg.github.io/osprey/) with a snapshot of the docs  

--- a/docs/development/releases.md
+++ b/docs/development/releases.md
@@ -1,9 +1,10 @@
 # Releases
 
-Osprey follows a lightweight, bootstrap release process so downstream users can depend on version tags (e.g. `1.0.1`) instead of commit hashes. The process may evolve as project usage grows. There is currently no fixed release cadence; releases are made when:
+Osprey follows a lightweight release process so downstream users can depend on version tags (e.g. `1.0.1`) instead of commit hashes. The process may evolve as project usage grows. There is currently no fixed release cadence; generally, releases are made when:
 
-- Downstream users need an updated stable version tag, or
-- Meaningful changes have accumulated and CI is green
+- Downstream users need an updated stable version tag,
+- Meaningful changes have accumulated and CI is green, and/or
+- A [security advisory](https://github.com/roostorg/osprey/security/) is addressed
 
 ## Versioning
 
@@ -17,7 +18,7 @@ Osprey uses [Semantic Versioning (SemVer)](https://semver.org/) following the MA
 
 Before cutting a release, ensure:
 
-- [ ] **Code quality CI is passing** for the `main` branch
+- [ ] **CI is passing** for the `main` branch
 - [ ] **You understand the correct version** according to SemVer
 - [ ] **[CHANGELOG.md](https://github.com/roostorg/osprey/blob/main/CHANGELOG.md) is up-to-date**
 

--- a/docs/development/releases.md
+++ b/docs/development/releases.md
@@ -6,6 +6,8 @@ Osprey follows a lightweight release process so downstream users can depend on v
 - Meaningful changes have accumulated and CI is green, and/or
 - A [security advisory](https://github.com/roostorg/osprey/security/) is addressed
 
+We do not currently backport changes to or release patches for versions other than the latest.
+
 ## Versioning
 
 Osprey uses [Semantic Versioning (SemVer)](https://semver.org/) following the MAJOR.MINOR.PATCH version format. In brief:


### PR DESCRIPTION
Tackles https://github.com/roostorg/community/issues/74, plus clarifies when to make major/minor/patch releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Renamed the development documentation section from “Release Process” to “Releases.”
  - Expanded SemVer guidance for patch, minor, and major releases.
  - Added release triggers, security advisory handling, and latest-version-only patching guidance.
  - Documented release readiness checks, release notes, and discussion requirements for major and minor releases.
  - Clarified automation for publishing packages, Docker images, and documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->