### PR TITLE
fix: use a pinned Git source for jsonpath-rw

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ default-groups = ["common", "dev"]
 [tool.uv.sources]
 greenlet = { git = "https://github.com/discord/greenlet.git", rev = "a75d78f1547c74a81134644a179467525a255466" }
 gunicorn = { git = "https://github.com/discord/gunicorn.git", rev = "979efdcb918daa536d8923668241c6e6bf1edb58" }
-jsonpath-rw = { url = "https://github.com/kennknowles/python-jsonpath-rw/archive/6f5647bb3ad2395c20f0191fef07a1df51c9fed8.tar.gz" }
+jsonpath-rw = { git = "https://github.com/kennknowles/python-jsonpath-rw.git", rev = "6f5647bb3ad2395c20f0191fef07a1df51c9fed8" }
 osprey_rpc = { workspace = true }
 osprey_worker = { workspace = true }
 osprey_async_worker = { workspace = true }

--- a/uv.lock
+++ b/uv.lock
@@ -58,7 +58,7 @@ common = [
     { name = "grpcio-tools", marker = "platform_machine == 'x86_64'", specifier = "==1.49.1" },
     { name = "gunicorn", git = "https://github.com/discord/gunicorn.git?rev=979efdcb918daa536d8923668241c6e6bf1edb58" },
     { name = "intervals", specifier = "==0.9.2" },
-    { name = "jsonpath-rw", url = "https://github.com/kennknowles/python-jsonpath-rw/archive/6f5647bb3ad2395c20f0191fef07a1df51c9fed8.tar.gz" },
+    { name = "jsonpath-rw", git = "https://github.com/kennknowles/python-jsonpath-rw.git?rev=6f5647bb3ad2395c20f0191fef07a1df51c9fed8" },
     { name = "kafka-python", specifier = "==1.4.7" },
     { name = "markupsafe", specifier = "<2.1" },
     { name = "minio", specifier = ">=7.2.16" },
@@ -1182,16 +1182,8 @@ wheels = [
 [[package]]
 name = "jsonpath-rw"
 version = "1.4.0"
-source = { url = "https://github.com/kennknowles/python-jsonpath-rw/archive/6f5647bb3ad2395c20f0191fef07a1df51c9fed8.tar.gz" }
+source = { git = "https://github.com/kennknowles/python-jsonpath-rw.git?rev=6f5647bb3ad2395c20f0191fef07a1df51c9fed8#6f5647bb3ad2395c20f0191fef07a1df51c9fed8" }
 dependencies = [
-    { name = "decorator" },
-    { name = "ply" },
-    { name = "six" },
-]
-sdist = { hash = "sha256:df5e3ee97cf486d9872b301982218ab27976647d4c2ffabe459f8b3f8d2c65c8" }
-
-[package.metadata]
-requires-dist = [
     { name = "decorator" },
     { name = "ply" },
     { name = "six" },


### PR DESCRIPTION
## Summary

- replace the URL-based `jsonpath-rw` source with a pinned Git source
- preserve the exact upstream commit revision
- refresh only the affected lockfile entry

## Verification

- `uv lock --check`
- `uv tree --package jsonpath-rw`
- `git diff --check`

Closes #480


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the dependency source configuration to use a Git repository at the same pinned revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->