### PR TITLE
Rule Authoring UI

### DIFF
--- a/osprey_ui/src/App.tsx
+++ b/osprey_ui/src/App.tsx
@@ -6,6 +6,7 @@ import { getApplicationConfig } from './actions/ConfigActions';
 import UdfDocsView from './components/docs/UdfDocsView';
 import BulkJobHistoryView from './components/bulk_job_history/BulkJobHistory';
 import { FeaturesPage } from './components/features/FeaturesPage';
+import { RuleEditorPage } from './components/rules/RuleEditorPage';
 import { RulesPage } from './components/rules/RulesPage';
 import RulesVisualizerView from './components/rules_visualizer/RulesVisualizer';
 import EntityViewBar from './components/entities/EntityViewBar';
@@ -104,6 +105,12 @@ const AppRouter: React.FC = () => {
                     </Route>
                     <Route path={Routes.FEATURES}>
                       <FeaturesPage />
+                    </Route>
+                    <Route exact path={Routes.RULES_NEW}>
+                      <RuleEditorPage />
+                    </Route>
+                    <Route exact path={Routes.RULES_EDIT}>
+                      <RuleEditorPage />
                     </Route>
                     <Route path={Routes.RULES}>
                       <RulesPage />

--- a/osprey_ui/src/Constants.tsx
+++ b/osprey_ui/src/Constants.tsx
@@ -6,6 +6,8 @@ export const Routes = {
   ENTITY: '/entity/:entityType/:entityId',
   FEATURES: '/features',
   RULES: '/rules',
+  RULES_NEW: '/rules/new',
+  RULES_EDIT: '/rules/edit',
   SAVED_QUERY: '/saved-query/:savedQueryId',
   SAVED_QUERY_LATEST: '/saved-query/:savedQueryId/latest',
   BULK_JOB_HISTORY: '/bulk-job-history',

--- a/osprey_ui/src/actions/ConfigActions.tsx
+++ b/osprey_ui/src/actions/ConfigActions.tsx
@@ -53,5 +53,8 @@ export async function getApplicationConfig(): Promise<ApplicationConfig> {
     knownActionNames: new Set(rawConfigData.known_action_names.sort()),
     currentUser: rawConfigData.current_user,
     ruleInfoMapping: new Map(Object.entries(rawConfigData.rule_info_mapping)),
+    ruleDeploymentEnabled: rawConfigData.rule_deployment_enabled ?? false,
+    canDeployRules: rawConfigData.can_deploy_rules ?? false,
+    canEditRules: rawConfigData.can_edit_rules ?? false,
   };
 }

--- a/osprey_ui/src/actions/RulesActions.tsx
+++ b/osprey_ui/src/actions/RulesActions.tsx
@@ -1,10 +1,229 @@
 import HTTPUtils, { HTTPResponse } from '../utils/HTTPUtils';
-import { RulesListResponse } from '../types/RulesTypes';
+import {
+  ParseIntoBuilderResponse,
+  RawParseIntoBuilderResponse,
+  RawRuleBuilderModel,
+  RuleBuilderModel,
+  RuleDeployPlan,
+  RuleDeployment,
+  RuleDraftValidationResponse,
+  RuleDraftsListResponse,
+  RuleRecord,
+  RuleSourceResponse,
+  RuleVocabulary,
+  RulesListResponse,
+} from '../types/RulesTypes';
 
 export async function getRulesList(): Promise<RulesListResponse> {
   const response: HTTPResponse = await HTTPUtils.get('rules');
   if (response.ok) {
     return response.data;
   }
-  throw new Error(response.error.message ?? 'Failed to fetch rules list');
+  throw new Error(errorMessageFrom(response) ?? 'Failed to fetch rules list');
+}
+
+export async function getRuleSource(path: string): Promise<RuleSourceResponse> {
+  const response: HTTPResponse = await HTTPUtils.get('rules/source', { params: { path } });
+  if (response.ok) {
+    return response.data;
+  }
+  throw new Error(errorMessageFrom(response) ?? `Failed to fetch rule source at ${path}`);
+}
+
+// `signal` lets a caller abandon a validation that has been superseded. The editor
+// re-validates as you type, and validating means assembling and checking the engine's
+// whole source set server-side — so a request nobody is waiting for any more is worth
+// actually cancelling, not just ignoring the reply to.
+export async function validateRuleDraft(
+  path: string,
+  source: string,
+  signal?: AbortSignal
+): Promise<RuleDraftValidationResponse> {
+  // SML validation errors come back as 200 with {ok: false}; backend-shape problems come back as 400
+  // with the same envelope. Both paths surface the structured errors to the UI without throwing.
+  const response: HTTPResponse = await HTTPUtils.post('rules/drafts/validate', { path, source }, { signal });
+  if (response.ok) {
+    return response.data;
+  }
+  if (response.error.response?.data) {
+    return response.error.response.data as RuleDraftValidationResponse;
+  }
+  throw new Error(response.error.message ?? 'Validation request failed');
+}
+
+// The builder models are the one place the wire shape and the view shape differ: the API
+// serialises snake_case throughout, and these used to be the sole endpoint emitting
+// camelCase aliases. Converting here keeps snake_case out of the editor's state.
+function toBuilderModel(raw: RawRuleBuilderModel): RuleBuilderModel {
+  return {
+    ruleName: raw.rule_name,
+    description: raw.description,
+    conditions: raw.conditions.map((c) => {
+      return { feature: c.feature, operator: c.operator, rhs: c.rhs, rhsIsFeature: c.rhs_is_feature };
+    }),
+    outcomes: raw.outcomes.map((o) => {
+      return {
+        effect: o.effect,
+        args: o.args.map((arg) => {
+          return { name: arg.name, value: arg.value, isFeature: arg.is_feature };
+        }),
+      };
+    }),
+  };
+}
+
+export async function parseRuleDraftIntoBuilder(path: string, source: string): Promise<ParseIntoBuilderResponse> {
+  const response: HTTPResponse = await HTTPUtils.post('rules/drafts/parse', { path, source });
+  if (!response.ok) {
+    throw new Error(errorMessageFrom(response) ?? 'Failed to parse rule into builder model');
+  }
+  const raw: RawParseIntoBuilderResponse = response.data;
+  // "Can't be represented" is an answer, not a failure — the editor uses it to decide
+  // whether to offer the Rule Builder toggle at all.
+  if (!raw.supported || raw.model == null) {
+    return { supported: false, reason: raw.reason ?? 'This file uses SML the Rule Builder cannot represent.' };
+  }
+  return { supported: true, model: toBuilderModel(raw.model) };
+}
+
+export async function getRuleVocabulary(): Promise<RuleVocabulary> {
+  const response: HTTPResponse = await HTTPUtils.get('rules/vocabulary');
+  if (response.ok) {
+    return response.data;
+  }
+  throw new Error(errorMessageFrom(response) ?? 'Failed to fetch rule vocabulary');
+}
+
+export interface CreateRuleDraftBody {
+  path: string;
+  source: string;
+  rule_name: string;
+  summary: string;
+}
+
+// A refused save is an outcome the editor renders, not an exception: 422 (SML that
+// doesn't compile, or main.sml as the target) and 409 (the rule name belongs to another
+// draft) both answer with the same `DraftValidation` envelope `validateRuleDraft`
+// returns, so the editor can show them through the validation panel it already has.
+export type CreateRuleDraftResult =
+  | { ok: true; draft: RuleRecord }
+  | { ok: false; validation: RuleDraftValidationResponse };
+
+// Saves a draft into the rules table (upserted by path). The draft is staged for someone
+// with the deploy ability to review; saving never changes any live rules.
+export async function createRuleDraft(body: CreateRuleDraftBody): Promise<CreateRuleDraftResult> {
+  const response: HTTPResponse = await HTTPUtils.post('rules/drafts', body);
+  if (response.ok) {
+    return { ok: true, draft: response.data };
+  }
+  const validation = draftValidationFrom(response);
+  if (validation != null) {
+    return { ok: false, validation };
+  }
+  throw new Error(errorMessageFrom(response) ?? 'Failed to save rule draft');
+}
+
+// Loads a single draft (its SML lives in the table, not on disk, so editing a draft
+// reads it from here rather than from the rules directory).
+export async function getRuleDraft(id: string): Promise<RuleRecord> {
+  const response: HTTPResponse = await HTTPUtils.get(`rules/drafts/${encodeURIComponent(id)}`);
+  if (response.ok) {
+    return response.data;
+  }
+  throw new Error(errorMessageFrom(response) ?? 'Failed to load rule draft');
+}
+
+export async function getRuleDrafts(): Promise<RuleDraftsListResponse> {
+  // Returns an empty list rather than throwing on failure so the RulesPage still renders
+  // for someone who can view rules but not edit them — listing drafts needs CAN_EDIT_RULES.
+  const response: HTTPResponse = await HTTPUtils.get('rules/drafts');
+  if (response.ok) {
+    return response.data;
+  }
+  const errPayload = response.error.response?.data as RuleDraftsListResponse | undefined;
+  if (errPayload && Array.isArray(errPayload.drafts)) {
+    return errPayload;
+  }
+  return { drafts: [] };
+}
+
+// What a deploy would do, according to the side that can read the rules directory.
+// Returns null rather than throwing when the endpoint is unavailable — a deployment
+// running a build without it should still be able to deploy, falling back to a plan that
+// says what the API contract guarantees instead of what the disk currently holds.
+// Takes no wiring argument: the plan answers for both choices at once, so the dialog's
+// checkbox re-renders from a plan it already holds rather than re-requesting one.
+export async function getDeployPlan(id: string): Promise<RuleDeployPlan | null> {
+  const response: HTTPResponse = await HTTPUtils.get(`rules/drafts/${encodeURIComponent(id)}/deploy-plan`, {
+    // Every status counts as a resolution rather than a rejection. A deployment whose
+    // build predates this endpoint answers 404, and the shared interceptor would file
+    // that in the global error store — where an unrelated page later renders it as a
+    // real failure. An absent optional endpoint is not an error worth reporting.
+    validateStatus: () => true,
+  });
+  if (!response.ok || response.status !== 200) return null;
+  return response.data;
+}
+
+// Marks a draft as ready for someone who can deploy to pick up. Needs CAN_EDIT_RULES, not
+// CAN_DEPLOY_RULES — it exists precisely for authors who cannot deploy. Idempotent, and
+// editing the draft afterwards returns it to `draft`, because the request was for
+// particular text and the text changed.
+export async function requestDeploy(id: string): Promise<RuleRecord> {
+  const response: HTTPResponse = await HTTPUtils.post(`rules/drafts/${encodeURIComponent(id)}/request-deploy`, {});
+  if (response.ok) {
+    return response.data;
+  }
+  throw new Error(errorMessageFrom(response) ?? 'Failed to request deployment');
+}
+
+export type DeployRuleDraftResult =
+  | { ok: true; deployment: RuleDeployment }
+  | { ok: false; validation: RuleDraftValidationResponse };
+
+// Writes the draft's SML into the configured rules directory and marks the row deployed.
+// With `wireIntoMain`, also appends a `Require(...)` line to main.sml — without which the
+// deployed file sits on disk inert.
+export async function deployRuleDraft(id: string, wireIntoMain: boolean): Promise<DeployRuleDraftResult> {
+  const response: HTTPResponse = await HTTPUtils.post(`rules/drafts/${encodeURIComponent(id)}/deploy`, {
+    wire_into_main: wireIntoMain,
+  });
+  if (response.ok) {
+    return { ok: true, deployment: response.data };
+  }
+  // 422 means the stored SML no longer validates against the engine's current sources,
+  // and answers with the same envelope as validation. Everything else deploy can refuse
+  // with — 404 no such draft, 409 a main.sml that is missing or doesn't parse, 503 no
+  // rules directory — answers `{error: ...}` and has nothing to attach to a source path.
+  const validation = draftValidationFrom(response);
+  if (validation != null) {
+    return { ok: false, validation };
+  }
+  throw new Error(errorMessageFrom(response) ?? 'Failed to deploy rule draft');
+}
+
+// The API answers a refusal one of three ways: `{error: ...}` for 404/409/503, a
+// `DraftValidation` for 422 and for a name collision, and the request validator's own
+// error array for a body it rejected outright (400). Prefer whichever the response
+// actually holds over axios's generic "Request failed with status code 4xx".
+function errorMessageFrom(response: HTTPResponse): string | undefined {
+  if (response.ok) return undefined;
+  const data = response.error.response?.data;
+  if (data != null && typeof data === 'object' && 'error' in data) {
+    const { error } = data as { error?: unknown };
+    if (typeof error === 'string') return error;
+  }
+  const validation = draftValidationFrom(response);
+  const firstError = validation?.errors[0]?.message;
+  if (firstError != null) return firstError;
+  return response.error.message ?? undefined;
+}
+
+function draftValidationFrom(response: HTTPResponse): RuleDraftValidationResponse | undefined {
+  if (response.ok) return undefined;
+  const data = response.error.response?.data;
+  if (data == null || typeof data !== 'object') return undefined;
+  const candidate = data as Partial<RuleDraftValidationResponse>;
+  if (typeof candidate.ok !== 'boolean' || !Array.isArray(candidate.errors)) return undefined;
+  return { ...candidate, ok: candidate.ok, errors: candidate.errors, warnings: candidate.warnings ?? [] };
 }

--- a/osprey_ui/src/components/navigation/NavBar.module.css
+++ b/osprey_ui/src/components/navigation/NavBar.module.css
@@ -1,7 +1,14 @@
+/* A fixed shell: exactly the viewport, never the document. This is what the rest of the
+   layout already assumes — `.mainColumn` sets `min-width: 0`, `.contentWrapper` sets
+   `min-height: 0`, and a dozen view roots set `height: 100%` with their own inner scroll
+   region. All of those are inert against a `min-height` wrapper, because a percentage
+   height resolves to `auto` unless its parent's height is definite, so the page scrolled
+   as one document and every inner scroll area silently grew instead of scrolling. */
 .appWrapper {
   display: flex;
   flex-direction: row;
-  min-height: 100vh;
+  height: 100vh;
+  overflow: hidden;
   width: 100%;
 }
 
@@ -28,6 +35,9 @@
   align-items: center;
   justify-content: space-between;
   height: 48px;
+  /* Same reason as `.topBar`: fixed chrome in a now-bounded column, and it sits above a
+     `flex: 1 1 auto` menu that would otherwise be able to compress it. */
+  flex: 0 0 auto;
   padding: 0 12px;
   border-bottom: 1px solid var(--divider);
 }
@@ -70,6 +80,10 @@
 
 .sidebarMenu {
   flex: 1 1 auto;
+  /* The sidebar is `overflow: hidden` and now bounded to the viewport, so a nav list
+     taller than a short window would be unreachable rather than merely long. */
+  min-height: 0;
+  overflow-y: auto;
   border-right: none !important; /* Antd Menu inline mode adds a right border we don't want here */
 }
 
@@ -103,6 +117,10 @@
   align-items: center;
   justify-content: space-between;
   height: 48px;
+  /* `height` alone is a suggestion for a flex item: `flex-shrink` defaults to 1, so once
+     the shell became a bounded 100vh column this bar was free to be squeezed by whatever
+     wanted the space below it. It is fixed chrome, so it never gives any up. */
+  flex: 0 0 auto;
   padding: 0 16px;
   background-color: var(--background-primary);
   border-bottom: 1px solid var(--divider);
@@ -116,9 +134,14 @@
   min-height: 32px; /* reserve vertical space even when empty */
 }
 
+/* `auto`, not `hidden`: a view that manages its own scrolling sets `height: 100%` and
+   fills this box exactly, so no scrollbar appears here — but a view that doesn't would
+   otherwise be clipped by the shell above, with no way to reach the rest of it. This
+   keeps the shell bounded without making the bound a trap. */
 .contentWrapper {
   flex: 1 1 auto;
   min-height: 0;
+  overflow-y: auto;
 }
 
 /* Suppress browser extend-selection on antd link buttons while shift-click

--- a/osprey_ui/src/components/rules/DeployButton.tsx
+++ b/osprey_ui/src/components/rules/DeployButton.tsx
@@ -1,0 +1,171 @@
+import * as React from 'react';
+import { Button, Tooltip, message } from 'antd';
+import { CloudUploadOutlined } from '@ant-design/icons';
+
+import { requestDeploy } from '../../actions/RulesActions';
+import useApplicationConfigStore from '../../stores/ApplicationConfigStore';
+import { RuleDeployment, RuleDraftSummary, RuleRecord } from '../../types/RulesTypes';
+
+import { DeployModal } from './DeployModal';
+
+interface DeployButtonProps {
+  // The summary, not the full record: this reads `id`, `path`, `rule_name` and `status`
+  // and nothing else. Typing it to the narrower shape is what lets one control serve both
+  // hosts — the drafts list, which no longer carries SML, and the editor, which holds a
+  // full `RuleRecord` that structurally satisfies this.
+  //
+  // Null when there is nothing saved to act on yet — a new rule, or a `?path=` edit that
+  // has never been staged. The control still renders, disabled with a reason, so the
+  // header keeps its shape instead of growing a button the first time you save.
+  draft: RuleDraftSummary | null;
+  onDeployed?: (deployment: RuleDeployment) => void;
+  // Fires when a draft is marked as awaiting deployment, so the host can pick up the new
+  // status. Separate from `onDeployed` because nothing was deployed — the row moved state
+  // and that is all.
+  onRequested?: (rule: RuleRecord) => void;
+  size?: 'small' | 'middle';
+  // A host-supplied reason this particular draft can't be acted on right now — the editor
+  // uses it for unsaved changes. Ranks below the ability check: someone who may not deploy
+  // at all doesn't need to hear about their unsaved edits first.
+  disabledReason?: string;
+}
+
+/**
+ * Which action this user gets for a draft, and whether they can take it right now.
+ *
+ * Gating only — the deploy confirmation and everything it needs live in
+ * `DeployModal`, which is mounted just while open so that opening is its own reset.
+ *
+ * The two config flags gate differently on purpose. `ruleDeploymentEnabled` false means
+ * the deployment has no rules directory and therefore no deploy story at all, so the
+ * control is absent rather than broken. `canDeployRules` false means the deployment does
+ * deploy and this user may not — which gets them the action they *can* take rather than a
+ * disabled version of one they can't, because that is a standing property of the person
+ * and a greyed-out Deploy would never become enabled for them.
+ */
+export const DeployButton: React.FC<DeployButtonProps> = ({
+  draft,
+  onDeployed,
+  onRequested,
+  size = 'small',
+  disabledReason,
+}) => {
+  const ruleDeploymentEnabled = useApplicationConfigStore((state) => state.ruleDeploymentEnabled);
+  const canDeployRules = useApplicationConfigStore((state) => state.canDeployRules);
+  const [isOpen, setIsOpen] = React.useState<boolean>(false);
+
+  if (!ruleDeploymentEnabled) return null;
+
+  if (!canDeployRules) {
+    return <RequestDeployButton draft={draft} size={size} disabledReason={disabledReason} onRequested={onRequested} />;
+  }
+
+  // Nothing saved yet, or saved but since edited. Both mean there is no stored text this
+  // could act on, so both disable rather than hide — the control keeps its place in the
+  // header and says what would make it usable.
+  const unavailable = draft == null ? 'Save this draft before deploying it.' : disabledReason;
+
+  if (unavailable != null || draft == null) {
+    return (
+      <Tooltip title={unavailable}>
+        <Button size={size} icon={<CloudUploadOutlined />} disabled>
+          Deploy
+        </Button>
+      </Tooltip>
+    );
+  }
+
+  const label = draft.status === 'deployed' ? 'Redeploy' : 'Deploy';
+
+  return (
+    <>
+      {/* Deliberately not `type="primary" ghost`. Ghost paints the primary colour as ink
+          rather than as fill, and #404ec1 on the near-black page measures 2.77:1 — under
+          WCAG AA for text (4.5:1) and even for a UI boundary (3:1). The default outlined
+          button uses the normal foreground colour instead, at 13.4:1.
+
+          Quieter than Save is also the right hierarchy: saving is the routine action,
+          deploying is the deliberate one, and a consequential control should not be the
+          easiest thing on the row to hit by reflex. */}
+      <Button size={size} icon={<CloudUploadOutlined />} onClick={() => setIsOpen(true)}>
+        {label}
+      </Button>
+
+      {/* Mounted only while open, so every piece of the dialog's state is initialised
+          rather than reset. Unmounting is what discards a dismissed attempt. */}
+      {isOpen && (
+        <DeployModal
+          draft={draft}
+          label={label}
+          onClose={() => setIsOpen(false)}
+          onDeployed={(deployment) => {
+            setIsOpen(false);
+            onDeployed?.(deployment);
+          }}
+        />
+      )}
+    </>
+  );
+};
+
+/**
+ * What an author who cannot deploy gets in place of the Deploy button: a way to say the
+ * draft is finished and hand it to someone who can ship it.
+ *
+ * No confirmation dialog and no type-to-confirm. Requesting is reversible, changes
+ * nothing live, and is idempotent server-side — the friction that guards a deploy would
+ * only be ceremony here. The `summary` field on the draft is the accompanying note, which
+ * is why the editor labels it "What's changing? (for the developer)".
+ */
+const RequestDeployButton: React.FC<{
+  draft: RuleDraftSummary | null;
+  size: 'small' | 'middle';
+  disabledReason?: string;
+  onRequested?: (rule: RuleRecord) => void;
+}> = ({ draft, size, disabledReason, onRequested }) => {
+  const [isRequesting, setIsRequesting] = React.useState<boolean>(false);
+  const alreadyRequested = draft?.status === 'deploy_requested';
+
+  // Unsaved changes block a request for the same reason they block a deploy: the request
+  // is for whatever text is stored, and editing afterwards resets the row to `draft`
+  // server-side — so requesting now would be undone by the next save. Nothing saved at
+  // all is the same problem one step earlier.
+  const blockedBy = draft == null ? 'Save this draft before requesting deployment.' : disabledReason;
+
+  if (blockedBy != null || draft == null) {
+    return (
+      <Tooltip title={blockedBy}>
+        <Button size={size} icon={<CloudUploadOutlined />} disabled>
+          Request deployment
+        </Button>
+      </Tooltip>
+    );
+  }
+
+  const onClick = async () => {
+    setIsRequesting(true);
+    try {
+      const rule = await requestDeploy(draft.id);
+      message.success('Marked as ready. Someone who can deploy will pick it up from the Rules page.');
+      onRequested?.(rule);
+    } catch (e) {
+      message.error(e instanceof Error ? e.message : String(e));
+    } finally {
+      setIsRequesting(false);
+    }
+  };
+
+  return (
+    <Tooltip
+      title={
+        alreadyRequested
+          ? 'Already marked as ready. Requesting again changes nothing; editing the draft returns it to a draft.'
+          : 'You do not hold CAN_DEPLOY_RULES, so this hands the draft to someone who does.'
+      }
+    >
+      <Button size={size} icon={<CloudUploadOutlined />} loading={isRequesting} onClick={onClick}>
+        {alreadyRequested ? 'Deployment requested' : 'Request deployment'}
+      </Button>
+    </Tooltip>
+  );
+};

--- a/osprey_ui/src/components/rules/DeployModal.module.css
+++ b/osprey_ui/src/components/rules/DeployModal.module.css
@@ -1,0 +1,68 @@
+/* The deploy modal renders a plan rather than a description: one row per file the deploy
+   touches, so the consequence is shown instead of narrated. */
+
+.planHeading {
+  display: block;
+  margin-bottom: 8px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-light-secondary);
+}
+
+.planList {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+/* The marker is a column of its own rather than a `list-style`, so the effect line below
+   each path aligns with the path and not with the bullet. */
+.planItem {
+  display: grid;
+  grid-template-columns: 16px minmax(0, 1fr);
+  gap: 2px 4px;
+  align-items: start;
+}
+
+.planItem::before {
+  content: '↳';
+  grid-row: 1;
+  color: var(--text-light-secondary);
+  line-height: 22px;
+}
+
+.planPath {
+  grid-column: 2;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  font-size: 13px;
+  overflow-wrap: anywhere;
+}
+
+.planEffect {
+  grid-column: 2;
+  font-size: 12px;
+  color: var(--text-light-secondary);
+}
+
+/* A file the deploy will leave alone. Dimmed, but the effect text says so in words too —
+   the state is never carried by colour alone. */
+.planItemInactive .planPath {
+  opacity: 0.55;
+  text-decoration: line-through;
+}
+
+.checkboxHint {
+  margin: 4px 0 0 24px;
+  font-size: 12px;
+  color: var(--text-light-secondary);
+}
+
+.confirmLabel {
+  display: block;
+  margin-bottom: 4px;
+}

--- a/osprey_ui/src/components/rules/DeployModal.tsx
+++ b/osprey_ui/src/components/rules/DeployModal.tsx
@@ -1,0 +1,380 @@
+import * as React from 'react';
+import { Alert, Checkbox, Input, Modal, Space, Typography, message } from 'antd';
+
+import { deployRuleDraft, getDeployPlan } from '../../actions/RulesActions';
+import {
+  MainSmlPlanState,
+  RuleDeployPlan,
+  RuleDeployment,
+  RuleDraftSummary,
+  RuleDraftValidationMessage,
+  RuleFilePlanState,
+} from '../../types/RulesTypes';
+
+import styles from './DeployModal.module.css';
+
+const { Text } = Typography;
+
+// The plan resolves in a few milliseconds against a local rules directory, which makes a
+// deploy dialog that snaps fully-formed into place the instant it opens — and something
+// that appears instantly reads as a formality rather than a check. Holding the loading
+// state for a beat is deliberate friction, of a piece with typing the rule name to
+// confirm: this is the one irreversible action in the editor, and it should feel
+// considered rather than quick.
+//
+// It also gates the confirm button, which stays disabled while the plan is loading — so
+// the beat is not merely decorative, it is a moment where deploying is genuinely not yet
+// possible.
+//
+// Thirteen 60ms units. The page's transitions are 180ms — three of the same unit — so the
+// pause reads as part of the interface's rhythm rather than an arbitrary wait; keep it on
+// that grid if you change it.
+//
+// The duration is chosen to sit in the band between the ~100ms that reads as instantaneous
+// and the ~1s where an interface starts to feel broken: long enough to register as a
+// deliberate pause, short enough that nobody wonders whether it has hung. Nothing else
+// depends on the value.
+const PLAN_MIN_LOADING_MS = 780;
+
+// Effect copy, one entry per state the server can report.
+const RULE_FILE_EFFECT: Record<RuleFilePlanState, string> = {
+  new: 'new file',
+  identical: 'identical — nothing changes',
+  differs: 'overwrites what is on disk',
+};
+
+const MAIN_SML_EFFECT: Record<MainSmlPlanState, string> = {
+  would_append: 'append Require(…)',
+  already_required: 'already required — nothing changes',
+  missing: 'missing from the rules directory',
+  unparseable: 'could not be parsed',
+};
+
+const CHECKING = 'checking…';
+
+interface DeployModalProps {
+  // Non-null: the modal is only mounted once there is something to act on, which is what
+  // lets every piece of state below be initialised rather than reset.
+  draft: RuleDraftSummary;
+  label: string;
+  onClose: () => void;
+  onDeployed?: (deployment: RuleDeployment) => void;
+}
+
+/**
+ * The deploy confirmation, and everything only it needs: the plan, the wiring choice, the
+ * type-to-confirm gate, and the in-flight state of the deploy itself.
+ *
+ * Mounted only while open — the caller renders it conditionally — so opening *is* the
+ * reset. That replaces a block of `setX(initial)` calls that previously ran on every open
+ * to undo the last one, and it means a dismissed attempt cannot leave anything behind.
+ */
+export const DeployModal: React.FC<DeployModalProps> = ({ draft, label, onClose, onDeployed }) => {
+  // Wiring the rule into main.sml is on by default: a deployed file that nothing
+  // `Require`s sits on disk inert, so an unwired deploy looks like it worked and changes
+  // nothing. Appending is idempotent server-side, so re-deploying an already-wired rule
+  // leaves main.sml alone.
+  const [wireIntoMain, setWireIntoMain] = React.useState<boolean>(true);
+  const [isDeploying, setIsDeploying] = React.useState<boolean>(false);
+  // Validation failures are rendered inside the modal rather than in a second modal on
+  // top of it: the errors are about the draft you are looking at, and stacking dialogs
+  // would hide the thing they describe.
+  const [errors, setErrors] = React.useState<RuleDraftValidationMessage[] | null>(null);
+  // Typing the rule name to confirm. Deliberate friction: this is the one action in the
+  // editor that changes what the engine actually runs, and it is one button press away
+  // from a routine save. Making the hand type the name means the deploy can't be the
+  // muscle-memory continuation of saving.
+  const [confirmText, setConfirmText] = React.useState<string>('');
+  // Ties the plain <label> to the input. Generated rather than hardcoded because the
+  // control renders once per draft row on the rules page, and duplicate ids would point
+  // every label at the first input.
+  const confirmInputId = React.useId();
+  // What the server says a deploy would actually do. `undefined` while in flight, `null`
+  // when the endpoint is unavailable — the plan then falls back to what the API contract
+  // guarantees rather than what the disk holds, which is weaker but never wrong.
+  const [plan, setPlan] = React.useState<RuleDeployPlan | null | undefined>(undefined);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    // Derived from the function rather than written as `number`, so this stays correct
+    // whichever `setTimeout` is in scope.
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const startedAt = Date.now();
+    // Held to `PLAN_MIN_LOADING_MS` from the request going out, not added to it: a plan
+    // that genuinely takes longer than the floor is shown the moment it lands, so the
+    // beat never stacks on top of a slow backend.
+    const settle = (next: RuleDeployPlan | null) => {
+      timer = setTimeout(
+        () => {
+          if (!cancelled) setPlan(next);
+        },
+        Math.max(0, PLAN_MIN_LOADING_MS - (Date.now() - startedAt))
+      );
+    };
+    getDeployPlan(draft.id)
+      .then(settle)
+      .catch(() => settle(null));
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+    // Runs once per mount, and a mount is one opening. Not keyed on `wireIntoMain`: the
+    // plan answers for both wiring choices, so toggling re-renders from the plan already
+    // in hand rather than refetching and flashing a loading state mid-decision.
+  }, [draft.id]);
+
+  // Exact match, not trimmed or case-folded: rule names are SML identifiers and are
+  // compared exactly everywhere else, so accepting a looser spelling here would teach a
+  // looser rule than the one that actually applies. Paste is not blocked: it defeats
+  // nothing an attentive person wouldn't also type, and blocking it mainly punishes
+  // anyone using a password manager or assistive input.
+  const isConfirmed = confirmText === draft.rule_name;
+
+  // `undefined` (still asking) and `null` (nothing to ask) are different answers and must
+  // not render alike. Showing the hedged fallback while loading means someone can read
+  // "append Require(…) if not already present" and then watch it become "already required
+  // — nothing changes"; a plan that rewrites itself under the reader is worse than one
+  // that admits it does not know yet.
+  //
+  // Falling back to the raw state rather than to nothing: these maps are exact-match, so
+  // a value this build has not seen would otherwise render an empty cell that looks like
+  // the plan has no opinion, which is the one thing it must never look like.
+  const isPlanLoading = plan === undefined;
+
+  const ruleFileEffect = isPlanLoading
+    ? CHECKING
+    : plan
+      ? (RULE_FILE_EFFECT[plan.rule_file.state] ?? plan.rule_file.state)
+      : 'the rule';
+
+  // Unchecking does not *remove* a Require line, it only declines to add one. So a rule
+  // main.sml already requires keeps firing either way, and saying "the rule will not
+  // fire" there would be flatly untrue — the one reading that could talk someone out of
+  // a deploy they actually wanted.
+  const alreadyRequired = plan?.main_sml.state === 'already_required';
+  const willFire = wireIntoMain || alreadyRequired;
+
+  // `would_append` shows the literal line the server would write rather than paraphrasing
+  // it — the plan can quote itself now that `require_line` is served.
+  const mainSmlEffect = !wireIntoMain
+    ? alreadyRequired
+      ? 'unchanged — already required, so the rule still fires'
+      : 'unchanged — the rule will not fire'
+    : isPlanLoading
+      ? CHECKING
+      : plan
+        ? plan.main_sml.state === 'would_append' && plan.main_sml.require_line
+          ? `append ${plan.main_sml.require_line}`
+          : (MAIN_SML_EFFECT[plan.main_sml.state] ?? plan.main_sml.state)
+        : 'append Require(…) if not already present';
+
+  // A deploy that would change nothing. Worth saying plainly: it is the one case where
+  // the right move is to close the dialog rather than confirm it.
+  const isNoOp =
+    plan != null &&
+    plan.rule_file.state === 'identical' &&
+    (!wireIntoMain || plan.main_sml.state === 'already_required');
+
+  // Two independent gates, mirroring the two the plan reports. The checkbox is disabled
+  // when main.sml can't take the line; Deploy is disabled when the file can't be written,
+  // or when wiring was asked for and isn't possible.
+  const wireable = plan == null || plan.wireable_into_main;
+  const canDeploy = plan == null || (plan.deployable && (!wireIntoMain || plan.wireable_into_main));
+
+  // Rendered from the same states the plan rows render from, rather than a parallel list
+  // of reasons — so an explanation can never disagree with the row above it.
+  const problem =
+    plan == null
+      ? null
+      : plan.source.state === 'invalid'
+        ? {
+            message: 'This draft no longer compiles',
+            description:
+              'Something it depends on has changed since it was written. Open it in the editor — the validation panel will say what.',
+          }
+        : wireIntoMain && plan.main_sml.state === 'missing'
+          ? {
+              message: 'main.sml is missing',
+              description:
+                'There is no main.sml in the rules directory to require the rule from. Deploy without wiring to write the file anyway.',
+            }
+          : wireIntoMain && plan.main_sml.state === 'unparseable'
+            ? {
+                message: 'main.sml does not compile',
+                description:
+                  'Whether the rule is already required is unanswerable while main.sml is broken, so deploy will not append to it. Deploy without wiring to write the file anyway.',
+              }
+            : null;
+
+  const onConfirm = async () => {
+    setIsDeploying(true);
+    setErrors(null);
+    try {
+      const result = await deployRuleDraft(draft.id, wireIntoMain);
+      if (!result.ok) {
+        // The stored SML no longer validates against the engine's current sources —
+        // something it depended on moved since the draft was written.
+        setErrors(result.validation.errors);
+        return;
+      }
+      const { deployment } = result;
+      // `main_sml_updated: false` means two opposite things: the rule was already
+      // required (fine, it runs), or it was deliberately not wired (it does not run).
+      // Reporting both as "main.sml was not changed" hides the only outcome anyone needs
+      // to act on, so the wiring choice disambiguates it.
+      const where = `Deployed to ${deployment.path_on_disk}.`;
+      if (deployment.main_sml_updated) {
+        message.success(`${where} Required from main.sml — it is now live.`);
+      } else if (wireIntoMain) {
+        message.success(`${where} It was already required from main.sml.`);
+      } else {
+        message.info(`${where} Not required from main.sml, so the rule will not fire yet.`);
+      }
+      onClose();
+      onDeployed?.(deployment);
+    } catch (e) {
+      message.error(e instanceof Error ? e.message : String(e));
+    } finally {
+      setIsDeploying(false);
+    }
+  };
+
+  return (
+    <Modal
+      open
+      title={`${label} ${draft.rule_name}?`}
+      okText={label}
+      cancelText="Cancel"
+      confirmLoading={isDeploying}
+      // Blocked or still loading the plan both prevent confirming: deploying against an
+      // unknown plan is the thing this dialog exists to stop.
+      okButtonProps={{ disabled: !isConfirmed || !canDeploy || isPlanLoading }}
+      onOk={onConfirm}
+      onCancel={onClose}
+      maskClosable={!isDeploying}
+    >
+      <Space direction="vertical" size={16} style={{ width: '100%' }}>
+        {/* One headline, four states, so it can never contradict itself. A separate
+            "nothing would change" notice below the plan used to sit under a warning
+            about live traffic — both true in their own terms, and incoherent together.
+            Severity tracks the actual stakes: no-op is reassuring, unwired is merely
+            informational because the file lands but nothing loads it, and only a wiring
+            deploy that changes something earns a warning. Loading says so rather than
+            guessing, so the banner never flips valence under the reader. */}
+        <Alert
+          type={isPlanLoading ? 'info' : isNoOp ? 'success' : willFire ? 'warning' : 'info'}
+          showIcon
+          message={
+            isPlanLoading
+              ? 'Checking what this would change…'
+              : isNoOp
+                ? 'Nothing would change'
+                : willFire
+                  ? `${draft.rule_name} will run against live traffic.`
+                  : `Written but not loaded — ${draft.rule_name} will not start firing.`
+          }
+          description={
+            isNoOp
+              ? 'What is on disk already matches this draft. Deploying is harmless but pointless — you can close this.'
+              : undefined
+          }
+        />
+
+        <div>
+          {/* No spinner on the heading: each row says "checking…" in the slot whose
+              value is actually unknown, which is more precise than one indicator over a
+              list that is half known already — the paths are certain from the start. */}
+          <Text className={styles.planHeading}>What this writes</Text>
+          <ul className={styles.planList}>
+            <li
+              className={`${styles.planItem}${plan?.rule_file.state === 'identical' ? ` ${styles.planItemInactive}` : ''}`}
+            >
+              <span className={styles.planPath}>{plan?.rule_file.path ?? draft.path}</span>
+              <span className={styles.planEffect}>{ruleFileEffect}</span>
+            </li>
+            {/* The second row is the checkbox's consequence, rendered rather than
+                described: toggling below rewrites this line, so the plan can be watched
+                changing instead of imagined. */}
+            <li
+              className={`${styles.planItem}${
+                !wireIntoMain || plan?.main_sml.state === 'already_required' ? ` ${styles.planItemInactive}` : ''
+              }`}
+            >
+              <span className={styles.planPath}>main.sml</span>
+              <span className={styles.planEffect}>{mainSmlEffect}</span>
+            </li>
+          </ul>
+        </div>
+
+        {problem != null && <Alert type="error" showIcon message={problem.message} description={problem.description} />}
+
+        <div>
+          {/* No refetch on change: the plan already answers for both wiring choices, so
+              this only re-renders. */}
+          <Checkbox
+            checked={wireIntoMain}
+            disabled={!wireable}
+            onChange={(e) => {
+              setWireIntoMain(e.target.checked);
+            }}
+          >
+            Require from <code>main.sml</code>
+          </Checkbox>
+          <p className={styles.checkboxHint}>
+            {!wireable
+              ? 'Unavailable — main.sml cannot take the line right now.'
+              : 'Added only if it isn’t already there, so re-deploying a live rule leaves main.sml alone.'}
+          </p>
+        </div>
+
+        {/* Deliberately not a `Form.Item`. `App.module.css` uppercases every
+            `.ant-form-item-label`, which would render the instruction in capitals while
+            the check below compares exactly — telling someone to type a string that would
+            be rejected. A plain label sidesteps a global style whose whole purpose is to
+            shout, in the one place the text has to be quoted verbatim. */}
+        <div>
+          <label htmlFor={confirmInputId} className={styles.confirmLabel}>
+            Type <code>{draft.rule_name}</code> to confirm
+          </label>
+          <Input
+            id={confirmInputId}
+            value={confirmText}
+            onChange={(e) => {
+              setConfirmText(e.target.value);
+            }}
+            onPressEnter={() => {
+              if (isConfirmed && canDeploy && !isDeploying) void onConfirm();
+            }}
+            placeholder={draft.rule_name}
+            autoComplete="off"
+            spellCheck={false}
+            // Not autofocused: the modal's job is to make someone read it, and dropping
+            // the caret straight into the field invites typing before that.
+          />
+        </div>
+
+        {errors != null && errors.length > 0 && (
+          <Alert
+            type="error"
+            showIcon
+            message="Draft no longer validates, so it was not deployed"
+            description={
+              <Space direction="vertical" size={4} style={{ width: '100%' }}>
+                {errors.map((err, i) => {
+                  return (
+                    <div key={i}>
+                      <div>{err.message}</div>
+                      <Text type="secondary" style={{ fontSize: 12 }}>
+                        {err.source_path}:{err.line}:{err.column}
+                      </Text>
+                    </div>
+                  );
+                })}
+              </Space>
+            }
+          />
+        )}
+      </Space>
+    </Modal>
+  );
+};

--- a/osprey_ui/src/components/rules/RuleEditorPage.module.css
+++ b/osprey_ui/src/components/rules/RuleEditorPage.module.css
@@ -1,0 +1,289 @@
+.viewContainer {
+  height: 100%;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* Used by the ability guard, which renders a single alert with no editor behind it. */
+.scrollArea {
+  flex: 1;
+  overflow-y: auto;
+  padding: 24px;
+}
+
+/* The header sits outside the scrolling region rather than being `position: sticky`
+   inside it. Sticky would need an opaque background to stop content passing underneath,
+   a z-index, and negative margins to cover the scroll area's side gutters — and the
+   sidebar below would then need to know the header's height to offset against, which
+   changes with the title and the wrapped action bar. Taking the header out of the
+   scroll flow removes all four problems: nothing scrolls under it, and the columns
+   beneath start at the top of their own scroll area. */
+.header {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 24px 24px 16px;
+  border-bottom: 1px solid var(--divider);
+  transition:
+    gap 0.18s ease,
+    padding 0.18s ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .header {
+    transition: none;
+  }
+}
+
+.headerLeft {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+/* Collapsed rather than unmounted, so the height animates instead of snapping and the
+   text stays in the accessibility tree for anyone who wants it read. `max-height` is a
+   generous cap for two wrapped lines — it only has to exceed the real height, since the
+   transition runs to `0` and the element is `overflow: hidden` throughout. */
+.headerBlurb {
+  display: block;
+  max-height: 60px;
+  overflow: hidden;
+  opacity: 1;
+  transition:
+    max-height 0.18s ease,
+    opacity 0.18s ease;
+}
+
+.headerCompact .headerBlurb {
+  max-height: 0;
+  opacity: 0;
+}
+
+/* Give the reclaimed space back rather than leaving a gap where the text was. */
+.headerCompact {
+  gap: 8px;
+  padding-top: 16px;
+  padding-bottom: 12px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .headerBlurb {
+    transition: none;
+  }
+}
+
+/* Mode switcher hard left, actions hard right. They are different kinds of control —
+   one chooses what you are looking at, the others act on it — so they sit at opposite
+   ends rather than reading as one run of five buttons. */
+.headerActions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.headerButtons {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* One scroll area spanning both columns, so its scrollbar lands on the window's right
+   edge rather than in the seam between the editor and the side panel.
+
+   Flex rather than grid, deliberately: `.sidePanel` needs `max-height: 100%` to resolve
+   against this scroll area's height. A grid item's containing block is its grid area,
+   whose height is content-driven, so the percentage would resolve against the panel's
+   own content and cap nothing. A flex item's containing block is this element's content
+   box, which has a definite height from `flex: 1` in a bounded column.
+
+   The padding lives on the children, not here: `top: 0` and `max-height: 100%` are then
+   exact against the scroll area instead of needing the padding subtracted back out. */
+.body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  gap: 16px;
+  overflow-y: auto;
+}
+
+/* `align-self` matters here for the same reason it does on `.sidePanel`, and it is easy
+   to miss: the flex default is `stretch`, which would fix this column's height to the
+   scroll area's rather than its content's. The column would then be exactly one viewport
+   tall with its `padding-bottom` sitting at that mark, and every card past the fold would
+   spill out below the padding — content running flush into the bottom edge with the
+   24px stranded somewhere up in the middle of the page. Sized to its content, the
+   padding lands after the last card where it belongs. */
+.editorColumn {
+  flex: 1 1 auto;
+  min-width: 0;
+  align-self: flex-start;
+  padding: 16px 0 24px 24px;
+}
+
+.codeArea {
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace !important;
+  font-size: 13px;
+  line-height: 1.5;
+  min-height: 480px;
+}
+
+/* Pinned while the shared scroll area moves under it. `align-self: flex-start` keeps the
+   panel its content's height instead of stretching, which is what `position: sticky`
+   needs in order to have anywhere to travel.
+
+   `max-height` + `overflow-y` are the guard sticky needs on its own: pinning the top of
+   an element taller than the scroll area leaves its bottom permanently out of reach, and
+   the vocabulary list runs to sixty tags plus effects, so it gets there. Capped to the
+   scroll area, the overflow becomes this panel's own scroll instead of unreachable. */
+.sidePanel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  flex: 0 0 360px;
+  padding: 16px 24px 24px 0;
+  position: sticky;
+  top: 0;
+  align-self: flex-start;
+  max-height: 100%;
+  overflow-y: auto;
+}
+
+/* Must follow the `.sidePanel` and `.editorColumn` rules above, not precede them: a media
+   query adds no specificity, so an earlier one loses to a later rule on the same
+   selector. */
+@media (max-width: 1100px) {
+  /* Stacked below the split point: the panel becomes a normal block under the editor, so
+     nothing is pinned and the single scroll area just gets longer. */
+  .body {
+    flex-direction: column;
+  }
+
+  /* `align-self` has to go back to `stretch` for both. Stacked, the cross axis is
+     horizontal, so the `flex-start` that correctly sizes these to their content height in
+     the two-column layout would instead shrink them to their content *width* and leave
+     the page ragged down the right. */
+  .editorColumn {
+    align-self: stretch;
+    padding: 16px 24px 0;
+  }
+
+  .sidePanel {
+    flex: 0 0 auto;
+    align-self: stretch;
+    position: static;
+    max-height: none;
+    overflow-y: visible;
+    padding: 0 24px 24px;
+  }
+}
+
+.validationCard pre {
+  margin: 0;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  font-size: 12px;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+}
+
+.errorList {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.errorItem {
+  padding: 8px 10px;
+  background: var(--background-secondary);
+  border-left: 3px solid var(--status-error);
+  border-radius: 2px;
+}
+
+.warningItem {
+  padding: 8px 10px;
+  background: var(--background-secondary);
+  border-left: 3px solid var(--status-warning);
+  border-radius: 2px;
+}
+
+.errorLocation {
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  font-size: 11px;
+  color: var(--text-light-secondary);
+}
+
+/* One source of vertical rhythm for the whole section: 8px between every child — the
+   heading, the blurb, each row, and the add button — rather than margins on some children
+   and not others, which is how the rows ended up flush against each other. */
+.builderSection {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+/* antd's Typography carries its own bottom margin, which would stack on top of the gap. */
+.builderSection > :global(.ant-typography) {
+  margin-bottom: 0;
+}
+
+/* The add button is the one child that should size to its content rather than stretch to
+   the row width the flex column gives everything else. */
+.builderSection > :global(.ant-btn) {
+  align-self: flex-start;
+}
+
+.builderRow {
+  display: grid;
+  grid-template-columns: minmax(140px, 1fr) 130px minmax(140px, 1fr) 32px;
+  gap: 8px;
+  align-items: start;
+}
+
+.builderRowOutcome {
+  display: grid;
+  grid-template-columns: minmax(140px, 1fr) 32px;
+  gap: 8px;
+  align-items: start;
+}
+
+.builderArgsGrid {
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 6px;
+  margin-top: 4px;
+  margin-left: 0;
+  padding: 8px;
+  background: var(--background-secondary);
+  border-radius: 4px;
+}
+
+.builderArgLabel {
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  font-size: 12px;
+  align-self: center;
+}
+
+.previewBlock {
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  font-size: 12px;
+  margin-top: 12px;
+  padding: 12px;
+  background: var(--background-secondary);
+  border: 1px solid var(--divider);
+  border-radius: 4px;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+}
+
+.footnote {
+  font-size: 11px;
+  color: var(--text-light-secondary);
+  margin-top: 4px;
+}

--- a/osprey_ui/src/components/rules/RuleEditorPage.tsx
+++ b/osprey_ui/src/components/rules/RuleEditorPage.tsx
@@ -1,0 +1,1213 @@
+import * as React from 'react';
+import {
+  Alert,
+  Button,
+  Card,
+  Descriptions,
+  Form,
+  Input,
+  Segmented,
+  Select,
+  Space,
+  Tag,
+  Tooltip,
+  Typography,
+  message,
+} from 'antd';
+import { DeleteOutlined, PlusOutlined, SaveOutlined } from '@ant-design/icons';
+import { Link, useHistory, useLocation } from 'react-router-dom';
+
+import {
+  createRuleDraft,
+  getRuleDraft,
+  getRuleDrafts,
+  getRuleSource,
+  getRuleVocabulary,
+  parseRuleDraftIntoBuilder,
+  validateRuleDraft,
+} from '../../actions/RulesActions';
+import usePromiseResult from '../../hooks/usePromiseResult';
+import useApplicationConfigStore from '../../stores/ApplicationConfigStore';
+import {
+  ParseIntoBuilderResponse,
+  RuleDraftSummary,
+  RuleDraftValidationMessage,
+  RuleDraftValidationResponse,
+  RuleRecord,
+  RuleVocabulary,
+} from '../../types/RulesTypes';
+import { renderFromPromiseResult } from '../../utils/PromiseResultUtils';
+
+import { DeployButton } from './DeployButton';
+
+import {
+  CONDITION_OPERATOR_OPTIONS,
+  Condition,
+  ConditionOperator,
+  EMPTY_BUILDER_MODEL,
+  Outcome,
+  OutcomeArg,
+  RuleBuilderModel,
+  SML_IDENTIFIER_RE,
+  applyMissingImports,
+  generateSmlFromBuilder,
+  outcomeArgsForEffect,
+} from './ruleBuilderSml';
+
+import styles from './RuleEditorPage.module.css';
+
+const { Title, Text, Paragraph } = Typography;
+
+// Two independent axes. `EditorView` is what the page is for right now — changing the
+// rule, or reading it back. `EditorMode` is which of the two editing surfaces you use to
+// do the changing, and only means anything inside the Edit view.
+type EditorView = 'edit' | 'preview';
+type EditorMode = 'builder' | 'code';
+
+// Saving stages the rule in the rules table for review. Deploying is a separate,
+// separately-permissioned step — see `DeployButton` — so saving never touches a
+// live rule whatever abilities the author holds.
+//
+// `rejected` is distinct from `error`: the API refused the save and said why in the same
+// structured envelope validation uses (SML that doesn't compile, a rule name another
+// draft holds, main.sml as the target), so those render through the validation panel
+// instead of as an opaque message.
+type SubmitState =
+  | { kind: 'idle' }
+  | { kind: 'saving' }
+  | { kind: 'saved' }
+  | { kind: 'rejected'; validation: RuleDraftValidationResponse }
+  | { kind: 'error'; message: string };
+
+// Long enough to sit out the pauses inside a sentence and fire between thoughts instead.
+// At 600ms an ordinary pause between words tripped it, so a minute of writing produced a
+// request per phrase — each one assembling the engine's sources server-side.
+const VALIDATE_DEBOUNCE_MS = 1000;
+
+const EDITOR_MODE_STORAGE_KEY = 'osprey-ui-rule-editor-mode';
+
+// Which editor someone last chose, remembered across reloads. Only ever written from an
+// explicit switch, never from the default a page happened to open with — otherwise merely
+// visiting "Add rule", which starts in the builder, would silently become a preference.
+function getStoredEditorMode(): EditorMode | null {
+  if (typeof window === 'undefined') return null;
+  const stored = window.localStorage.getItem(EDITOR_MODE_STORAGE_KEY);
+  return stored === 'builder' || stored === 'code' ? stored : null;
+}
+
+interface BootstrapData {
+  vocabulary: RuleVocabulary;
+  initialSource: string;
+  initialPath: string;
+  isNewRule: boolean;
+  // Every existing draft, used to warn about name/path collisions the server-side
+  // validator can't see (it only knows deployed rules, not other drafts). Summaries:
+  // only `path` and `rule_name` are read, and the list no longer carries SML.
+  existingDrafts: RuleDraftSummary[];
+  // The result of round-tripping the loaded source through the backend parser, when it
+  // was worth asking. `undefined` means "not checked", not "unsupported" — a new rule
+  // never needs checking, and neither does an editor opening in Code, which is why this
+  // is absent far more often than it is present.
+  initialBuilderParse?: ParseIntoBuilderResponse;
+  // The stored row, when this page was opened on an existing draft (`?draftId=`). Set
+  // so a deploy can be offered without a redundant save; absent for a new rule and for
+  // `?path=` edits, which read a file off disk that has no row behind it yet.
+  initialDraft?: RuleRecord;
+}
+
+export const RuleEditorPage: React.FC = () => {
+  // Two edit entry points, both via query params because react-router v5 has no
+  // clean repeating-segment param and rule paths contain slashes:
+  //   ?draftId=N  -> edit a saved draft (its SML lives in the rules table)
+  //   ?path=X     -> edit an existing rule file loaded from the rules directory
+  const history = useHistory();
+  const location = useLocation();
+  const isNewRule = location.pathname === '/rules/new';
+  const params = new URLSearchParams(location.search);
+  const draftId = isNewRule ? undefined : (params.get('draftId') ?? undefined);
+  const editPath = isNewRule ? undefined : (params.get('path') ?? undefined);
+  const canEditRules = useApplicationConfigStore((state) => state.canEditRules);
+
+  const result = usePromiseResult<BootstrapData>(async () => {
+    // The parse answers two things: what model the builder starts from, and whether the
+    // builder can represent this file at all. Only the first is needed at load, and only
+    // when the editor is about to open in the builder — the second can wait until someone
+    // asks for the builder, which `onModeChange` already handles by parsing and reporting
+    // the reason it can't. Skipping it removes a request, and a *serialised* round trip
+    // (it depends on the draft fetch above it), from every code-first editor open.
+    const wantsBuilder = getStoredEditorMode() === 'builder';
+    const [vocabulary, { drafts: existingDrafts }] = await Promise.all([getRuleVocabulary(), getRuleDrafts()]);
+    if (isNewRule) {
+      return {
+        vocabulary,
+        existingDrafts,
+        initialSource: '',
+        initialPath: 'rules/new_rule.sml',
+        isNewRule: true,
+      };
+    }
+    // A draft's SML is in the table, so load it from there rather than from disk.
+    if (draftId) {
+      // Passed through as the opaque string it arrives as: draft ids are serialised as
+      // strings because a 64-bit id would lose its low bits through a JS number.
+      const draft = await getRuleDraft(draftId);
+      const initialBuilderParse = wantsBuilder ? await parseRuleDraftIntoBuilder(draft.path, draft.source) : undefined;
+      return {
+        vocabulary,
+        existingDrafts,
+        initialSource: draft.source,
+        initialPath: draft.path,
+        isNewRule: false,
+        initialBuilderParse,
+        initialDraft: draft,
+      };
+    }
+    if (!editPath) {
+      throw new Error('Missing ?draftId= or ?path= query parameter; navigate from the Rules page.');
+    }
+
+    // A `?path=` editor is identified by file path, not by row — so once it saves, the
+    // draft it just created is indistinguishable to it from a stranger's draft at the same
+    // path. Reload and it reopens the file, warns about "an edit in progress", and the
+    // next save replaces the row it made a moment ago. That loop is reachable by one
+    // person doing nothing unusual: edit, save, deploy, edit again.
+    //
+    // Adopting the existing draft closes it. Same rule the registry's Edit link follows,
+    // and the file is not fetched at all in this case because the draft supersedes it.
+    const staged = existingDrafts.find((d) => {
+      return d.path === editPath && (d.status === 'draft' || d.status === 'deploy_requested');
+    });
+    if (staged) {
+      const draft = await getRuleDraft(staged.id);
+      const initialBuilderParse = wantsBuilder ? await parseRuleDraftIntoBuilder(draft.path, draft.source) : undefined;
+      return {
+        vocabulary,
+        existingDrafts,
+        initialSource: draft.source,
+        initialPath: draft.path,
+        isNewRule: false,
+        initialBuilderParse,
+        initialDraft: draft,
+      };
+    }
+
+    const source = await getRuleSource(editPath);
+    const initialBuilderParse = wantsBuilder
+      ? await parseRuleDraftIntoBuilder(source.path, source.contents)
+      : undefined;
+    return {
+      vocabulary,
+      existingDrafts,
+      initialSource: source.contents,
+      initialPath: source.path,
+      isNewRule: false,
+      initialBuilderParse,
+    };
+  }, [draftId, editPath, isNewRule]);
+
+  // RulesPage hides its authoring entry points without this ability, but the route is
+  // still reachable by URL — a bookmark, or a link shared by someone who does have it.
+  // Every request this page makes needs CAN_EDIT_RULES, so say so rather than letting
+  // the vocabulary fetch fail and render as a generic load error.
+  if (!canEditRules) {
+    return (
+      <div className={styles.viewContainer}>
+        <div className={styles.scrollArea}>
+          <Alert
+            type="warning"
+            showIcon
+            message="You can't author rules"
+            description="Editing rule drafts needs the CAN_EDIT_RULES ability. Ask an Osprey admin to grant it, or browse the Rules Registry instead."
+            action={
+              <Button size="small" onClick={() => history.push('/rules')}>
+                Back to rules
+              </Button>
+            }
+          />
+        </div>
+      </div>
+    );
+  }
+
+  return renderFromPromiseResult(result, (data) => {
+    return <RuleEditorView data={data} />;
+  });
+};
+
+const RuleEditorView: React.FC<{ data: BootstrapData }> = ({ data }) => {
+  const history = useHistory();
+  const currentUserEmail = useApplicationConfigStore((state) => state.currentUser.email);
+  // "Not known to be unsupported", rather than "confirmed supported". The bootstrap only
+  // parses when it is about to open the builder, so `undefined` is the common case and
+  // must not read as a refusal — it means nobody has asked yet. Someone who does ask goes
+  // through `onModeChange`, which parses then and reports the reason if it can't.
+  const builderAllowed = data.initialBuilderParse?.supported !== false;
+  const builderDisabledReason = data.initialBuilderParse?.supported === false ? data.initialBuilderParse.reason : '';
+  // Not persisted, unlike `mode`: arriving on the editor to edit is right every time,
+  // where which editing surface you prefer is a lasting preference.
+  const [view, setView] = React.useState<EditorView>('edit');
+  const [mode, setMode] = React.useState<EditorMode>(() => {
+    // A stored preference never overrides `builderAllowed`: the builder is off because
+    // this file's SML cannot be represented in it, which no preference can change.
+    if (!builderAllowed) return 'code';
+    return getStoredEditorMode() ?? (data.isNewRule ? 'builder' : 'code');
+  });
+  const [path, setPath] = React.useState<string>(data.initialPath);
+  const [codeSource, setCodeSource] = React.useState<string>(data.initialSource);
+  const [builder, setBuilder] = React.useState<RuleBuilderModel>(() => {
+    if (data.initialBuilderParse?.supported === true) {
+      return data.initialBuilderParse.model;
+    }
+    return EMPTY_BUILDER_MODEL;
+  });
+  // Seeded from the stored draft, not blank: it is a saved field like the path and the
+  // source, so opening a draft and re-saving it must not silently erase the note that
+  // explains why the rule exists. Blank for a new rule and for `?path=` edits, which have
+  // no row behind them yet.
+  const [summary, setSummary] = React.useState<string>(data.initialDraft?.summary ?? '');
+  // The stored row this editor is currently in sync with, or null when nothing has been
+  // saved yet. Deploying writes whatever the *table* holds, not what is in the textarea,
+  // so the deploy control is only offered while these agree.
+  const [savedDraft, setSavedDraft] = React.useState<RuleRecord | null>(data.initialDraft ?? null);
+  const [validation, setValidation] = React.useState<RuleDraftValidationResponse | null>(null);
+  const [isValidating, setIsValidating] = React.useState<boolean>(false);
+  const [submitState, setSubmitState] = React.useState<SubmitState>({ kind: 'idle' });
+
+  const effectiveSource = mode === 'builder' ? generateSmlFromBuilder(builder, data.vocabulary.features) : codeSource;
+
+  // What this editor rendered when it last agreed with the server, rather than the bytes
+  // the server holds. The Builder regenerates its SML from a model — its own indentation,
+  // quoting and trailing commas — so it practically never reproduces stored text byte for
+  // byte. Comparing against `savedDraft.source` therefore answers "would saving change
+  // the bytes?", which is true the instant an existing draft opens in the Builder,
+  // untouched. The baseline answers "has anything been changed?", which is the question
+  // the Save button is actually asking.
+  // State rather than a ref: it is read during render to decide whether Save is enabled,
+  // and a ref read in render would not re-render when it changes. The argument is
+  // evaluated every render but only used on the first, which is what seeds the baseline
+  // from whatever the initial mode rendered.
+  //
+  // All three saved fields are baselined, not just the source, so dirtiness never depends
+  // on whether a stored row happens to exist. A `?path=` edit has no row — it is a file on
+  // disk that was never staged — and keying off that made it permanently dirty, lighting
+  // up Save about a second after load on a page nobody had touched.
+  const [baseline, setBaseline] = React.useState<{ source: string; path: string; summary: string }>({
+    source: effectiveSource,
+    path: data.initialPath,
+    summary: data.initialDraft?.summary ?? '',
+  });
+
+  React.useEffect(() => {
+    let cancelled = false;
+    if (!effectiveSource.trim()) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- clearing stale validation on input empty
+      setValidation(null);
+      setIsValidating(false);
+      return;
+    }
+    setIsValidating(true);
+    // Aborted by the cleanup below, so a request already in flight when the source
+    // changes is dropped at the socket rather than merely having its reply discarded.
+    const controller = new AbortController();
+    const handle = window.setTimeout(async () => {
+      try {
+        const result = await validateRuleDraft(path, effectiveSource, controller.signal);
+        if (!cancelled) setValidation(result);
+      } catch (e) {
+        if (!cancelled) {
+          setValidation({
+            ok: false,
+            errors: [
+              {
+                message: e instanceof Error ? e.message : String(e),
+                hint: '',
+                source_path: path,
+                line: 0,
+                column: 0,
+                rendered: '',
+              },
+            ],
+            warnings: [],
+          });
+        }
+      } finally {
+        if (!cancelled) setIsValidating(false);
+      }
+    }, VALIDATE_DEBOUNCE_MS);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(handle);
+      controller.abort();
+    };
+  }, [effectiveSource, path]);
+
+  const ruleNameForSubmit = mode === 'builder' ? builder.ruleName : guessRuleNameFromSource(codeSource);
+
+  // Collisions the server-side validator can't see (it only knows deployed rules):
+  // a rule name already taken by another draft (a hard conflict — the server rejects
+  // it on save too), and — for a brand new rule — a path that would overwrite a live
+  // rule or another draft (a soft warning, since replacing can be intentional). Path
+  // is only editable for new rules, so path warnings are new-rule-only.
+  const nameConflictDraft = data.existingDrafts.find((d) => d.rule_name === ruleNameForSubmit && d.path !== path);
+  const pathOverwritesRule = data.isNewRule && data.vocabulary.source_files.includes(path);
+  // Another row at this path with work *not yet live* in it. Drafts are upserted by path,
+  // so saving here would replace it — and unlike the deployed case that is a real loss,
+  // because nothing else holds that text.
+  //
+  // Deployed rows are deliberately excluded. Editing a live rule and saving is the ordinary
+  // flow — the backend returns the row to `draft` for exactly that — so warning about it
+  // would cry conflict over the most common thing anyone does here.
+  const pathOverwritesDraft = data.existingDrafts.find((d) => {
+    return d.path === path && d.id !== savedDraft?.id && (d.status === 'draft' || d.status === 'deploy_requested');
+  });
+
+  // Whether anything differs from the row the editor last synced with. Compared field by
+  // field against the source we already hold rather than by re-hashing to compare `cid`:
+  // same answer, but exact and synchronous, and it catches a changed `path` or `summary`
+  // which the content hash by definition does not cover.
+  //
+  // Always dirty when there is no row yet — a new rule, or a `?path=` edit of a file that
+  // exists on disk but has never been staged as a draft.
+  const isDirty = effectiveSource !== baseline.source || path !== baseline.path || summary !== baseline.summary;
+
+  const canSave =
+    isDirty &&
+    !!validation?.ok &&
+    SML_IDENTIFIER_RE.test(ruleNameForSubmit) &&
+    submitState.kind !== 'saving' &&
+    !!effectiveSource.trim() &&
+    !nameConflictDraft;
+
+  // The builder and code editor hold independent state, so a tab switch has to
+  // carry content across: builder -> code dumps the generated SML into the
+  // textarea, code -> builder re-parses the (possibly hand-edited) source so
+  // the form never silently submits a stale model.
+  // Only switches that actually land are remembered, so a failed parse leaves the stored
+  // preference alone rather than recording a builder the user never got to.
+  const applyMode = (next: EditorMode) => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(EDITOR_MODE_STORAGE_KEY, next);
+    }
+    setMode(next);
+  };
+
+  const onModeChange = async (next: EditorMode) => {
+    if (next === mode) return;
+    if (next === 'code') {
+      setCodeSource(generateSmlFromBuilder(builder, data.vocabulary.features));
+      applyMode('code');
+      return;
+    }
+    if (!codeSource.trim()) {
+      applyMode('builder');
+      return;
+    }
+    try {
+      const parsed = await parseRuleDraftIntoBuilder(path, codeSource);
+      if (parsed.supported) {
+        setBuilder(parsed.model);
+        applyMode('builder');
+      } else {
+        message.warning(`Rule Builder can't represent this file: ${parsed.reason}. Keep editing in Code Editor.`);
+      }
+    } catch (e) {
+      message.warning(`Could not parse this file for Rule Builder: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  };
+
+  const onSave = async () => {
+    if (!canSave) return;
+    setSubmitState({ kind: 'saving' });
+    try {
+      const result = await createRuleDraft({
+        path,
+        source: effectiveSource,
+        rule_name: ruleNameForSubmit,
+        summary,
+      });
+      if (!result.ok) {
+        setSubmitState({ kind: 'rejected', validation: result.validation });
+        return;
+      }
+      setSavedDraft(result.draft);
+      // Re-baseline to what was just sent, not to `result.draft.source`: keeping the
+      // comparison against what this surface renders is what makes a clean save stay
+      // clean in the Builder, where the two are equal in meaning but not in bytes.
+      setBaseline({ source: effectiveSource, path, summary });
+      setSubmitState({ kind: 'saved' });
+      message.success('Draft saved.');
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setSubmitState({ kind: 'error', message: msg });
+    }
+  };
+
+  // Deploy acts on the stored row, so anything typed since the last save would be
+  // silently left behind. Rather than hide the control — which reads as "you can't
+  // deploy" — keep it in place and say what to do about it. Same `isDirty` the Save
+  // button uses, so the two controls can never disagree about whether there is work
+  // outstanding.
+  const deployDisabledReason =
+    savedDraft != null && isDirty
+      ? 'Save your changes first — deploying writes the last saved draft, not what is in the editor.'
+      : undefined;
+
+  // The header's blurb is orientation for someone arriving on the page, and dead weight
+  // once they are working — so it collapses on the first scroll, giving the height back
+  // to the editor. Driven off the scroll container rather than a media query because it
+  // is about where you are in the page, not how big the window is.
+  const bodyRef = React.useRef<HTMLDivElement>(null);
+  const [isScrolled, setIsScrolled] = React.useState<boolean>(false);
+
+  React.useEffect(() => {
+    const el = bodyRef.current;
+    if (el == null) return;
+    const onScroll = () => {
+      // A few pixels of slack so a trackpad's inertial overscroll doesn't flicker the
+      // blurb in and out at the very top of the page.
+      setIsScrolled(el.scrollTop > 8);
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => {
+      el.removeEventListener('scroll', onScroll);
+    };
+  }, []);
+
+  return (
+    <div className={styles.viewContainer}>
+      <header className={`${styles.header}${isScrolled ? ` ${styles.headerCompact}` : ''}`}>
+        <div className={styles.headerLeft}>
+          <Title level={3} style={{ margin: 0 }}>
+            {data.isNewRule ? 'Add rule' : 'Edit rule'}
+          </Title>
+          <Text type="secondary" className={styles.headerBlurb}>
+            Stages the rule as a draft for review. Saving never changes a live rule — deploying is a separate step, and
+            a separate ability.
+          </Text>
+        </div>
+        <div className={styles.headerActions}>
+          {/* Are you changing the rule, or looking at it? Builder-vs-Code sits a level
+              down, on the editing card, because both of those are ways of editing. */}
+          <Segmented<EditorView>
+            value={view}
+            onChange={setView}
+            options={[
+              { label: 'Edit', value: 'edit' },
+              { label: 'Preview', value: 'preview' },
+            ]}
+          />
+          <div className={styles.headerButtons}>
+            {/* Three weights for three kinds of action: leaving is incidental (text),
+                deploying is deliberate (outlined), saving is what you came to do (solid).
+                Cancel drops to text so Deploy is the only outlined control and the two
+                are not mistaken for each other. */}
+            <Button type="text" onClick={() => history.push('/rules')}>
+              Cancel
+            </Button>
+            <Button
+              type="primary"
+              icon={<SaveOutlined />}
+              disabled={!canSave}
+              onClick={onSave}
+              loading={submitState.kind === 'saving'}
+            >
+              Save draft
+            </Button>
+
+            <DeployButton
+              draft={savedDraft}
+              size="middle"
+              disabledReason={deployDisabledReason}
+              onDeployed={(deployment) => {
+                setSavedDraft(deployment.rule);
+              }}
+              onRequested={(rule) => {
+                setSavedDraft(rule);
+              }}
+            />
+          </div>
+        </div>
+      </header>
+
+      <div className={styles.body} ref={bodyRef}>
+        <div className={styles.editorColumn}>
+          <SubmitBanner submitState={submitState} />
+
+          {nameConflictDraft && (
+            <Alert
+              type="warning"
+              showIcon
+              style={{ marginBottom: 12 }}
+              message="Rule name already used by another draft"
+              description={`The draft at ${nameConflictDraft.path} already defines a rule named "${ruleNameForSubmit}". Rule names must be unique, so saving will be rejected until you rename this rule or edit that draft.`}
+            />
+          )}
+          {pathOverwritesRule && (
+            <Alert
+              type="warning"
+              showIcon
+              style={{ marginBottom: 12 }}
+              message="A live rule already exists at this path"
+              description={`Saving stages a draft that would replace ${path} when deployed. Pick a different path if you meant to add a new rule instead of changing that one.`}
+            />
+          )}
+          {pathOverwritesDraft && (
+            <Alert
+              type="warning"
+              showIcon
+              style={{ marginBottom: 12 }}
+              message={
+                pathOverwritesDraft.author === currentUserEmail
+                  ? 'You already have an edit in progress for this rule'
+                  : 'Someone is already editing this rule'
+              }
+              description={
+                <Space direction="vertical" size={4} style={{ width: '100%' }}>
+                  {/* Naming the current user back to themselves reads as a stranger; the
+                      advice also differs, since losing your own unsaved work is a mistake
+                      rather than a collision to coordinate around. */}
+                  <span>
+                    {pathOverwritesDraft.author === currentUserEmail ? (
+                      <>
+                        There is already a draft at <code>{path}</code>. Drafts are stored by path, so saving here
+                        replaces it — the work in that draft would be lost.
+                      </>
+                    ) : (
+                      <>
+                        {pathOverwritesDraft.author} has an edit in progress at <code>{path}</code>. Drafts are stored
+                        by path, so saving here replaces theirs — their changes would be lost.
+                      </>
+                    )}
+                  </span>
+                  <Link
+                    to={{ pathname: '/rules/edit', search: `?draftId=${encodeURIComponent(pathOverwritesDraft.id)}` }}
+                  >
+                    Open that draft instead
+                  </Link>
+                </Space>
+              }
+            />
+          )}
+
+          {view === 'preview' ? (
+            <DraftPreview
+              path={path}
+              summary={summary}
+              source={effectiveSource}
+              isNewRule={data.isNewRule}
+              savedDraft={savedDraft}
+              isDirty={isDirty}
+            />
+          ) : (
+            <>
+              <Card size="small" style={{ marginBottom: 12 }}>
+                <Form layout="vertical" size="small">
+                  <Form.Item label="File path" tooltip="Path inside the rules directory where this file will live.">
+                    <Input value={path} onChange={(e) => setPath(e.target.value)} disabled={!data.isNewRule} />
+                  </Form.Item>
+                  <Form.Item
+                    label={
+                      data.isNewRule ? 'Why this rule? (for the developer)' : "What's changing? (for the developer)"
+                    }
+                    tooltip="Saved alongside the draft to give the developer who deploys it context. Not written into the rule file itself."
+                    style={{ marginBottom: 0 }}
+                  >
+                    <Input.TextArea
+                      value={summary}
+                      onChange={(e) => setSummary(e.target.value)}
+                      placeholder={
+                        data.isNewRule
+                          ? 'Why do we need this rule? What behaviour does it target?'
+                          : 'What are you changing about this rule, and why?'
+                      }
+                      autoSize={{ minRows: 2, maxRows: 4 }}
+                    />
+                  </Form.Item>
+                </Form>
+              </Card>
+
+              <EditSurface
+                mode={mode}
+                onModeChange={onModeChange}
+                builderAllowed={builderAllowed}
+                builderDisabledReason={builderDisabledReason}
+                builder={builder}
+                setBuilder={setBuilder}
+                vocabulary={data.vocabulary}
+                codeSource={codeSource}
+                setCodeSource={setCodeSource}
+                validation={validation}
+              />
+            </>
+          )}
+        </div>
+
+        <aside className={styles.sidePanel}>
+          <ValidationPanel validation={validation} isValidating={isValidating} />
+          <VocabularyPanel vocabulary={data.vocabulary} />
+        </aside>
+      </div>
+    </div>
+  );
+};
+
+// The editing surface: one card, two interchangeable ways of authoring the same SML. The
+// Builder/Code choice lives on the card rather than in the page header because both are
+// editing — the header's axis is whether you are editing at all.
+const EditSurface: React.FC<{
+  mode: EditorMode;
+  onModeChange: (next: EditorMode) => void;
+  builderAllowed: boolean;
+  builderDisabledReason: string;
+  builder: RuleBuilderModel;
+  setBuilder: React.Dispatch<React.SetStateAction<RuleBuilderModel>>;
+  vocabulary: RuleVocabulary;
+  codeSource: string;
+  setCodeSource: React.Dispatch<React.SetStateAction<string>>;
+  validation: RuleDraftValidationResponse | null;
+}> = ({
+  mode,
+  onModeChange,
+  builderAllowed,
+  builderDisabledReason,
+  builder,
+  setBuilder,
+  vocabulary,
+  codeSource,
+  setCodeSource,
+  validation,
+}) => {
+  return (
+    <Card
+      size="small"
+      title={mode === 'builder' ? 'Rule' : 'SML source'}
+      extra={
+        <Tooltip
+          title={
+            builderAllowed ? '' : `Rule Builder can't represent this file: ${builderDisabledReason}. Edit as code.`
+          }
+        >
+          <Segmented<EditorMode>
+            size="small"
+            value={mode}
+            onChange={onModeChange}
+            options={[
+              { label: 'Builder', value: 'builder', disabled: !builderAllowed },
+              { label: 'Code', value: 'code' },
+            ]}
+          />
+        </Tooltip>
+      }
+    >
+      {mode === 'code' && validation?.suggested_imports && validation.suggested_imports.length > 0 && (
+        <Alert
+          type="warning"
+          showIcon
+          style={{ marginBottom: 12 }}
+          message="Missing imports"
+          description={
+            <Space direction="vertical" size={4} style={{ width: '100%' }}>
+              <span>This file references identifiers defined in: {validation.suggested_imports.join(', ')}</span>
+              <Button
+                size="small"
+                type="primary"
+                onClick={() => {
+                  return setCodeSource((prev) => {
+                    return applyMissingImports(prev, validation.suggested_imports ?? []);
+                  });
+                }}
+              >
+                Add missing imports
+              </Button>
+            </Space>
+          }
+        />
+      )}
+
+      {mode === 'builder' ? (
+        <RuleBuilderEditor model={builder} setModel={setBuilder} vocabulary={vocabulary} />
+      ) : (
+        <Input.TextArea
+          className={styles.codeArea}
+          value={codeSource}
+          onChange={(e) => setCodeSource(e.target.value)}
+          placeholder="MyRule = Rule(when_all=[PostText == 'hello'], description='...')"
+          autoSize={{ minRows: 24, maxRows: 60 }}
+          spellCheck={false}
+        />
+      )}
+    </Card>
+  );
+};
+
+// The draft exactly as it will be stored: the metadata alongside the SML, read-only. Not
+// the same thing as the Code editor even in code mode — that shows only the SML, and
+// shows it editable.
+const DraftPreview: React.FC<{
+  path: string;
+  summary: string;
+  source: string;
+  isNewRule: boolean;
+  savedDraft: RuleRecord | null;
+  isDirty: boolean;
+}> = ({ path, summary, source, isNewRule, savedDraft, isDirty }) => {
+  return (
+    <Card size="small" title="Draft preview">
+      {savedDraft != null && isDirty && (
+        <Alert
+          type="info"
+          showIcon
+          style={{ marginBottom: 12 }}
+          message="Showing your unsaved changes"
+          description="This is what saving would store. The version currently in the rules table is the one before your edits."
+        />
+      )}
+      <Descriptions size="small" column={1} colon={false} styles={{ label: { width: 150, fontWeight: 600 } }}>
+        <Descriptions.Item label="File path">
+          <code>{path}</code>
+        </Descriptions.Item>
+        <Descriptions.Item label={isNewRule ? 'Why this rule?' : "What's changing?"}>
+          {summary ? <Text>{summary}</Text> : <Text style={{ fontStyle: 'italic' }}>not given</Text>}
+        </Descriptions.Item>
+      </Descriptions>
+      <pre className={styles.previewBlock}>{source}</pre>
+    </Card>
+  );
+};
+
+const SubmitBanner: React.FC<{ submitState: SubmitState }> = ({ submitState }) => {
+  if (submitState.kind === 'idle') return null;
+  if (submitState.kind === 'saving') {
+    return <Alert type="info" message="Saving draft..." showIcon style={{ marginBottom: 12 }} />;
+  }
+  if (submitState.kind === 'saved') {
+    return (
+      <Alert
+        type="success"
+        showIcon
+        style={{ marginBottom: 12 }}
+        message="Draft saved"
+        description="Staged in the rules table for review. No live rules changed until someone deploys it."
+      />
+    );
+  }
+  if (submitState.kind === 'rejected') {
+    return (
+      <Alert
+        type="error"
+        showIcon
+        style={{ marginBottom: 12 }}
+        message="Draft not saved"
+        description={
+          <Space direction="vertical" size={4} style={{ width: '100%' }}>
+            {submitState.validation.errors.map((err, i) => {
+              return <ValidationMessageRow key={`reject-${i}`} kind="error" msg={err} />;
+            })}
+          </Space>
+        }
+      />
+    );
+  }
+  return (
+    <Alert type="error" showIcon style={{ marginBottom: 12 }} message="Failed" description={submitState.message} />
+  );
+};
+
+const ValidationPanel: React.FC<{
+  validation: RuleDraftValidationResponse | null;
+  isValidating: boolean;
+}> = ({ validation, isValidating }) => {
+  return (
+    <Card
+      size="small"
+      title={
+        <Space>
+          <span>Validation</span>
+          {isValidating && <Tag>checking…</Tag>}
+          {!isValidating && validation?.ok === true && <Tag color="green">valid</Tag>}
+          {!isValidating && validation?.ok === false && <Tag color="red">errors</Tag>}
+        </Space>
+      }
+    >
+      {!validation && <Text type="secondary">Start typing to see live validation against the engine.</Text>}
+      {validation?.assemble_error && (
+        <Alert
+          type="error"
+          showIcon
+          style={{ marginBottom: 8 }}
+          message="The engine's rules could not be assembled"
+          description="Nothing you write here will validate until that is fixed — it is a problem with the deployed rules, not with this draft."
+        />
+      )}
+      {validation?.ok === true && validation.warnings.length === 0 && (
+        <Text type="success">Engine accepts this draft.</Text>
+      )}
+      {validation?.errors && validation.errors.length > 0 && (
+        <div className={styles.errorList}>
+          {validation.errors.map((err, i) => {
+            return <ValidationMessageRow key={`err-${i}`} kind="error" msg={err} />;
+          })}
+        </div>
+      )}
+      {validation?.warnings && validation.warnings.length > 0 && (
+        <div className={styles.errorList} style={{ marginTop: 8 }}>
+          {validation.warnings.map((w, i) => {
+            return <ValidationMessageRow key={`warn-${i}`} kind="warning" msg={w} />;
+          })}
+        </div>
+      )}
+    </Card>
+  );
+};
+
+const ValidationMessageRow: React.FC<{ kind: 'error' | 'warning'; msg: RuleDraftValidationMessage }> = ({
+  kind,
+  msg,
+}) => {
+  return (
+    <div className={kind === 'error' ? styles.errorItem : styles.warningItem}>
+      <div style={{ fontWeight: 600 }}>{msg.message}</div>
+      {msg.hint && (
+        <div style={{ fontSize: 12, marginTop: 2 }}>
+          <Text type="secondary">{msg.hint}</Text>
+        </div>
+      )}
+      <div className={styles.errorLocation}>
+        {msg.source_path}:{msg.line}:{msg.column}
+      </div>
+    </div>
+  );
+};
+
+const VocabularyPanel: React.FC<{ vocabulary: RuleVocabulary }> = ({ vocabulary }) => {
+  return (
+    <Card size="small" title="Available in rules">
+      <Paragraph type="secondary" style={{ fontSize: 12, marginBottom: 6 }}>
+        Variables you can reference inside conditions.
+      </Paragraph>
+      <Space size={4} wrap>
+        {vocabulary.features.slice(0, 60).map((f) => {
+          return (
+            <Tag key={f.name} style={{ fontFamily: 'monospace' }}>
+              {f.name}
+            </Tag>
+          );
+        })}
+        {vocabulary.features.length > 60 && <Text type="secondary">+{vocabulary.features.length - 60} more</Text>}
+      </Space>
+      {vocabulary.effects.length > 0 && (
+        <>
+          <Paragraph type="secondary" style={{ fontSize: 12, marginTop: 12, marginBottom: 6 }}>
+            Effects used in existing rules.
+          </Paragraph>
+          <Space size={4} wrap>
+            {vocabulary.effects.map((name) => {
+              return (
+                <Tag key={name} color="blue" style={{ fontFamily: 'monospace' }}>
+                  {name}
+                </Tag>
+              );
+            })}
+          </Space>
+        </>
+      )}
+    </Card>
+  );
+};
+
+// The builder form itself. Renders no card of its own — `EditSurface` owns the card and
+// the Builder/Code switch, so this and the code textarea drop into the same frame.
+const RuleBuilderEditor: React.FC<{
+  model: RuleBuilderModel;
+  setModel: React.Dispatch<React.SetStateAction<RuleBuilderModel>>;
+  vocabulary: RuleVocabulary;
+}> = ({ model, setModel, vocabulary }) => {
+  const featureOptions = React.useMemo(() => {
+    return vocabulary.features.map((f) => {
+      return { label: f.name, value: f.name };
+    });
+  }, [vocabulary.features]);
+
+  const effectOptions = React.useMemo(() => {
+    return vocabulary.effects.map((name) => {
+      return { label: name, value: name };
+    });
+  }, [vocabulary.effects]);
+
+  const updateCondition = (idx: number, patch: Partial<Condition>) => {
+    setModel((prev) => {
+      const next = [...prev.conditions];
+      next[idx] = { ...next[idx], ...patch };
+      return { ...prev, conditions: next };
+    });
+  };
+  const addCondition = () => {
+    setModel((prev) => ({
+      ...prev,
+      conditions: [...prev.conditions, { feature: '', operator: '==', rhs: '', rhsIsFeature: false }],
+    }));
+  };
+  const removeCondition = (idx: number) => {
+    setModel((prev) => ({
+      ...prev,
+      conditions: prev.conditions.filter((_, i) => {
+        return i !== idx;
+      }),
+    }));
+  };
+
+  const updateOutcome = (idx: number, patch: Partial<Outcome>) => {
+    setModel((prev) => {
+      const next = [...prev.outcomes];
+      next[idx] = { ...next[idx], ...patch };
+      return { ...prev, outcomes: next };
+    });
+  };
+  const updateOutcomeArg = (oIdx: number, aIdx: number, patch: Partial<OutcomeArg>) => {
+    setModel((prev) => {
+      const outcomes = [...prev.outcomes];
+      const args = [...outcomes[oIdx].args];
+      args[aIdx] = { ...args[aIdx], ...patch };
+      outcomes[oIdx] = { ...outcomes[oIdx], args };
+      return { ...prev, outcomes };
+    });
+  };
+  const addOutcome = () => {
+    setModel((prev) => ({ ...prev, outcomes: [...prev.outcomes, { effect: '', args: [] }] }));
+  };
+  const removeOutcome = (idx: number) => {
+    setModel((prev) => ({
+      ...prev,
+      outcomes: prev.outcomes.filter((_, i) => {
+        return i !== idx;
+      }),
+    }));
+  };
+
+  return (
+    <RuleBuilderForm
+      model={model}
+      setModel={setModel}
+      featureOptions={featureOptions}
+      effectOptions={effectOptions}
+      vocabulary={vocabulary}
+      updateCondition={updateCondition}
+      addCondition={addCondition}
+      removeCondition={removeCondition}
+      updateOutcome={updateOutcome}
+      updateOutcomeArg={updateOutcomeArg}
+      addOutcome={addOutcome}
+      removeOutcome={removeOutcome}
+    />
+  );
+};
+
+const RuleBuilderForm: React.FC<{
+  model: RuleBuilderModel;
+  setModel: React.Dispatch<React.SetStateAction<RuleBuilderModel>>;
+  featureOptions: { label: string; value: string }[];
+  effectOptions: { label: string; value: string }[];
+  vocabulary: RuleVocabulary;
+  updateCondition: (idx: number, patch: Partial<Condition>) => void;
+  addCondition: () => void;
+  removeCondition: (idx: number) => void;
+  updateOutcome: (idx: number, patch: Partial<Outcome>) => void;
+  updateOutcomeArg: (oIdx: number, aIdx: number, patch: Partial<OutcomeArg>) => void;
+  addOutcome: () => void;
+  removeOutcome: (idx: number) => void;
+}> = ({
+  model,
+  setModel,
+  featureOptions,
+  effectOptions,
+  vocabulary,
+  updateCondition,
+  addCondition,
+  removeCondition,
+  updateOutcome,
+  updateOutcomeArg,
+  addOutcome,
+  removeOutcome,
+}) => {
+  return (
+    <>
+      <Form layout="vertical">
+        <Form.Item
+          label="Rule name"
+          tooltip="An SML identifier. This becomes the left-hand side of the Rule(...) assignment."
+          validateStatus={model.ruleName && !SML_IDENTIFIER_RE.test(model.ruleName) ? 'error' : ''}
+          help={
+            model.ruleName && !SML_IDENTIFIER_RE.test(model.ruleName)
+              ? 'Must be an SML identifier: letters, digits, and underscores, not starting with a digit.'
+              : undefined
+          }
+        >
+          <Input
+            value={model.ruleName}
+            onChange={(e) => setModel((prev) => ({ ...prev, ruleName: e.target.value }))}
+            placeholder="ContainsHello"
+          />
+        </Form.Item>
+        <Form.Item
+          label="Rule description"
+          tooltip="Saved into the rule file as `description='...'`. Shown in the Rules Registry."
+        >
+          <Input.TextArea
+            value={model.description}
+            onChange={(e) => setModel((prev) => ({ ...prev, description: e.target.value }))}
+            autoSize={{ minRows: 1, maxRows: 3 }}
+            placeholder="What does the rule detect?"
+          />
+        </Form.Item>
+      </Form>
+
+      <div className={styles.builderSection}>
+        <Title level={5}>Conditions</Title>
+        <Paragraph type="secondary" style={{ fontSize: 12 }}>
+          Every row must be true for the rule to fire. SML&apos;s <code>when_all</code> is AND-only. For OR, write the
+          extra rule in Code Editor.
+        </Paragraph>
+        {model.conditions.map((cond, idx) => {
+          return (
+            <div key={idx} className={styles.builderRow}>
+              <Select
+                showSearch
+                placeholder="Variable"
+                value={cond.feature || undefined}
+                onChange={(value) => updateCondition(idx, { feature: value })}
+                options={featureOptions}
+                filterOption={(input, opt) => {
+                  return String(opt?.label).toLowerCase().includes(input.toLowerCase());
+                }}
+              />
+              <Select<ConditionOperator>
+                value={cond.operator}
+                onChange={(value) => updateCondition(idx, { operator: value })}
+                options={CONDITION_OPERATOR_OPTIONS}
+              />
+              <Space.Compact style={{ width: '100%' }}>
+                {cond.rhsIsFeature ? (
+                  <Select
+                    showSearch
+                    placeholder="Variable"
+                    value={cond.rhs || undefined}
+                    onChange={(value) => updateCondition(idx, { rhs: value })}
+                    options={featureOptions}
+                    style={{ width: '100%' }}
+                    filterOption={(input, opt) => {
+                      return String(opt?.label).toLowerCase().includes(input.toLowerCase());
+                    }}
+                  />
+                ) : (
+                  <Input
+                    placeholder="Value"
+                    value={cond.rhs}
+                    onChange={(e) => updateCondition(idx, { rhs: e.target.value })}
+                  />
+                )}
+                <Button
+                  onClick={() => updateCondition(idx, { rhs: '', rhsIsFeature: !cond.rhsIsFeature })}
+                  title={cond.rhsIsFeature ? 'Use a literal value' : 'Use a defined variable'}
+                >
+                  {cond.rhsIsFeature ? 'var' : 'lit'}
+                </Button>
+              </Space.Compact>
+              <Button
+                type="text"
+                icon={<DeleteOutlined />}
+                onClick={() => removeCondition(idx)}
+                disabled={model.conditions.length === 1}
+              />
+            </div>
+          );
+        })}
+        <Button icon={<PlusOutlined />} onClick={addCondition}>
+          Add condition
+        </Button>
+      </div>
+
+      <div className={styles.builderSection}>
+        <Title level={5}>Outcomes</Title>
+        <Paragraph type="secondary" style={{ fontSize: 12 }}>
+          What Osprey does when the conditions above are met, like adding a label or banning the user.
+        </Paragraph>
+        {model.outcomes.map((outcome, oIdx) => {
+          return (
+            <div key={oIdx} className={styles.builderSection}>
+              <div className={styles.builderRowOutcome}>
+                <Select
+                  showSearch
+                  placeholder="Effect"
+                  value={outcome.effect || undefined}
+                  onChange={(value) => {
+                    return updateOutcome(oIdx, { effect: value, args: outcomeArgsForEffect(value, vocabulary.udfs) });
+                  }}
+                  options={effectOptions}
+                  filterOption={(input, opt) => {
+                    return String(opt?.label).toLowerCase().includes(input.toLowerCase());
+                  }}
+                />
+                <Button
+                  type="text"
+                  icon={<DeleteOutlined />}
+                  onClick={() => removeOutcome(oIdx)}
+                  disabled={model.outcomes.length === 1}
+                />
+              </div>
+              {outcome.args.length > 0 && (
+                <div className={styles.builderArgsGrid}>
+                  {outcome.args.map((arg, aIdx) => {
+                    return (
+                      // Keyed by index, not by name: a positional argument has no name,
+                      // and two of them would collide on a null key.
+                      <React.Fragment key={aIdx}>
+                        <div className={styles.builderArgLabel}>
+                          {arg.name ?? <Text type="secondary">#{aIdx + 1}</Text>}
+                        </div>
+                        <Space.Compact style={{ width: '100%' }}>
+                          {arg.isFeature ? (
+                            <Select
+                              showSearch
+                              placeholder="Variable"
+                              value={arg.value || undefined}
+                              onChange={(value) => updateOutcomeArg(oIdx, aIdx, { value })}
+                              options={featureOptions}
+                              style={{ width: '100%' }}
+                              filterOption={(input, opt) => {
+                                return String(opt?.label).toLowerCase().includes(input.toLowerCase());
+                              }}
+                            />
+                          ) : (
+                            <Input
+                              placeholder="Value"
+                              value={arg.value}
+                              onChange={(e) => updateOutcomeArg(oIdx, aIdx, { value: e.target.value })}
+                            />
+                          )}
+                          <Button
+                            onClick={() => updateOutcomeArg(oIdx, aIdx, { value: '', isFeature: !arg.isFeature })}
+                            title={arg.isFeature ? 'Use a literal value' : 'Use a defined variable'}
+                          >
+                            {arg.isFeature ? 'var' : 'lit'}
+                          </Button>
+                        </Space.Compact>
+                      </React.Fragment>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          );
+        })}
+        <Button icon={<PlusOutlined />} onClick={addOutcome}>
+          Add outcome
+        </Button>
+      </div>
+    </>
+  );
+};
+
+function guessRuleNameFromSource(source: string): string {
+  const m = source.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*Rule\s*\(/m);
+  return m?.[1] ?? '';
+}

--- a/osprey_ui/src/components/rules/RulesPage.module.css
+++ b/osprey_ui/src/components/rules/RulesPage.module.css
@@ -64,3 +64,54 @@
   overflow-wrap: break-word;
   margin: 0;
 }
+
+.draftRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+/* The path is the only part that should give up width; the tag and author keep their
+   intrinsic size, so a long path truncates rather than pushing them off the row.
+
+   Uses the app's own link token rather than antd's default, which renders #1668dc here —
+   3.35:1 against the alert panel, below WCAG AA for text. The token is themed, so it
+   stays correct in light mode where a hardcoded dark-theme blue would not.
+
+   Monospace rather than an underline. The text is a file path full of underscores, and an
+   underline sits exactly where they do, making them ambiguous. The family shift is a
+   persistent non-colour cue that this is a distinct, actionable element — which the link
+   needs, because its contrast against the surrounding prose is under the 3:1 that would
+   let colour carry that on its own — and it matches how paths are set everywhere else on
+   the page. */
+.draftRow > a {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+  color: var(--link-primary);
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  /* Negative margin cancels the padding, so adding a hover surface does not shift the row
+     when idle — the highlight grows outward from where the text already sits. */
+  padding: 0 3px;
+  margin: 0 -3px;
+  border-radius: 3px;
+  transition: background-color 0.18s ease;
+}
+
+/* A background tint, matching how the rest of the app marks a hovered link target
+   (`DropdownMenu`, `PropertyTable`, `CustomFeaturesFilter`). It is also the one hover cue
+   available here: the usual underline would land on the underscores in a file path, and a
+   colour shift alone would be a second thing for the eye to judge against a background
+   this link is already relying on colour to stand out from. */
+.draftRow > a:hover,
+.draftRow > a:focus-visible {
+  background-color: var(--link-light-hover);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .draftRow > a {
+    transition: none;
+  }
+}

--- a/osprey_ui/src/components/rules/RulesPage.tsx
+++ b/osprey_ui/src/components/rules/RulesPage.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import {
+  Alert,
+  Button,
   Card,
   Collapse,
   Descriptions,
@@ -14,11 +16,20 @@ import {
   Tooltip,
   Typography,
 } from 'antd';
-import { SearchOutlined } from '@ant-design/icons';
+import { EditOutlined, PlusOutlined, SearchOutlined } from '@ant-design/icons';
+import { Link } from 'react-router-dom';
 
-import { getRulesList } from '../../actions/RulesActions';
-import usePromiseResult from '../../hooks/usePromiseResult';
-import { RuleInfo, RulesListResponse, SortKey } from '../../types/RulesTypes';
+import { getRuleDrafts, getRulesList } from '../../actions/RulesActions';
+import usePromiseResult, { PromiseResultStatus } from '../../hooks/usePromiseResult';
+import useApplicationConfigStore from '../../stores/ApplicationConfigStore';
+import {
+  RuleDraftSummary,
+  RuleDraftsListResponse,
+  RuleInfo,
+  RuleRecordStatus,
+  RulesListResponse,
+  SortKey,
+} from '../../types/RulesTypes';
 import { renderFromPromiseResult } from '../../utils/PromiseResultUtils';
 
 import styles from './RulesPage.module.css';
@@ -73,16 +84,43 @@ export const RulesPage: React.FC = () => {
   const result = usePromiseResult(() => {
     return getRulesList();
   });
+  const draftsResult = usePromiseResult<RuleDraftsListResponse>(() => {
+    return getRuleDrafts();
+  });
 
   return renderFromPromiseResult(result, (data) => {
-    return <RulesPageContent data={data} />;
+    return <RulesPageContent data={data} draftsResult={draftsResult} />;
   });
 };
 
-const RulesPageContent: React.FC<{ data: RulesListResponse }> = ({ data }) => {
+const RulesPageContent: React.FC<{
+  data: RulesListResponse;
+  draftsResult: ReturnType<typeof usePromiseResult<RuleDraftsListResponse>>;
+}> = ({ data, draftsResult }) => {
   const [filters, dispatch] = React.useReducer(filtersReducer, INITIAL_FILTERS);
+  const canEditRules = useApplicationConfigStore((state) => state.canEditRules);
   const { rules, total, when_rules_total, unused_total } = data;
   const { search, unusedOnly, sortKey, page, pageSize } = filters;
+
+  // Rows with an edit already underway, keyed by the path they will deploy to. Editing a
+  // rule that has one has to open *that*, not the file on disk: drafts are upserted by
+  // path, so an editor opened on the deployed copy would overwrite the in-progress work
+  // the moment it saved, with nothing on screen to say so.
+  //
+  // Deployed rows are deliberately excluded. Their content is what is on disk, so opening
+  // the file is the same thing, and it stays correct if the file was edited underneath.
+  const draftsByPath = React.useMemo(() => {
+    if (draftsResult.status !== PromiseResultStatus.Resolved) return new Map<string, RuleDraftSummary>();
+    return new Map(
+      draftsResult.value.drafts
+        .filter((row) => {
+          return row.status === 'draft' || row.status === 'deploy_requested';
+        })
+        .map((row) => {
+          return [row.path, row] as const;
+        })
+    );
+  }, [draftsResult]);
 
   const filtered = React.useMemo(() => {
     const query = search.trim().toLowerCase();
@@ -123,22 +161,53 @@ const RulesPageContent: React.FC<{ data: RulesListResponse }> = ({ data }) => {
     return paginated.map((r) => {
       return {
         key: r.name,
-        label: <RuleHeader rule={r} />,
+        label: <RuleHeader rule={r} draft={draftsByPath.get(r.source_file)} />,
         children: <RuleDetail rule={r} />,
       };
     });
-  }, [paginated]);
+  }, [paginated, draftsByPath]);
 
   return (
     <div className={styles.viewContainer}>
       <div className={styles.scrollArea}>
-        <Title level={3} style={{ marginBottom: 4 }}>
-          Rules Registry
-        </Title>
-        <Paragraph type="secondary">
-          Named rule definitions across the engine — conditions, descriptions, the features each rule references, and
-          how many WhenRules blocks include it.
-        </Paragraph>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'flex-start',
+            gap: 16,
+            marginBottom: 4,
+          }}
+        >
+          <div>
+            <Title level={3} style={{ marginBottom: 4 }}>
+              Rules Registry
+            </Title>
+            <Paragraph type="secondary">
+              Named rule definitions across the engine — conditions, descriptions, the features each rule references,
+              and how many WhenRules blocks include it.
+            </Paragraph>
+          </div>
+          {canEditRules ? (
+            <Link to="/rules/new">
+              <Button type="primary" icon={<PlusOutlined />}>
+                Add rule
+              </Button>
+            </Link>
+          ) : (
+            // Disabled rather than absent: this is the page's one prominent authoring
+            // control, so it is the right place to say the ability is missing. The
+            // per-rule Edit buttons below are hidden instead — repeating the same
+            // explanation on every row would be noise, and this button already gave it.
+            <Tooltip title="Authoring rules needs the CAN_EDIT_RULES ability. Ask an Osprey admin to grant it.">
+              <Button type="primary" icon={<PlusOutlined />} disabled>
+                Add rule
+              </Button>
+            </Tooltip>
+          )}
+        </div>
+
+        <DraftsBanner draftsResult={draftsResult} />
 
         <div className={styles.statsRow}>
           <Card size="small">
@@ -245,8 +314,22 @@ const RulesPageContent: React.FC<{ data: RulesListResponse }> = ({ data }) => {
   );
 };
 
-const RuleHeader: React.FC<{ rule: RuleInfo }> = ({ rule }) => {
+const RuleHeader: React.FC<{ rule: RuleInfo; draft?: RuleDraftSummary }> = ({ rule, draft }) => {
+  // Read from the store rather than threaded down through `collapseItems`, which builds
+  // these inside a memo that would otherwise need the flag as a dependency.
+  const canEditRules = useApplicationConfigStore((state) => state.canEditRules);
   const isUnused = rule.referenced_by_whenrules === 0;
+  // An edit already in progress for this rule is the thing to open. Drafts are upserted
+  // by path, so opening the file instead would let a save quietly replace it.
+  const editTarget = draft
+    ? {
+        search: `?draftId=${encodeURIComponent(draft.id)}`,
+        tip: 'Continue the edit already in progress for this rule.',
+      }
+    : {
+        search: `?path=${encodeURIComponent(rule.source_file)}`,
+        tip: "Open this rule's source file in the editor.",
+      };
   return (
     <div className={styles.headerRow}>
       <code className={styles.ruleName}>{rule.name}</code>
@@ -262,7 +345,120 @@ const RuleHeader: React.FC<{ rule: RuleInfo }> = ({ rule }) => {
             <strong>{rule.referenced_by_whenrules}</strong> when-rules
           </Text>
         )}
+        {draft && (
+          <Tooltip title={`This rule has an edit in progress (${STATUS_LABEL[draft.status] ?? draft.status}).`}>
+            <Tag color={STATUS_TAG_COLOUR[draft.status] ?? 'default'}>edit in progress</Tag>
+          </Tooltip>
+        )}
+        {canEditRules && (
+          <Tooltip title={editTarget.tip}>
+            <Link
+              to={{ pathname: '/rules/edit', search: editTarget.search }}
+              onClick={(e) => {
+                // Prevent the surrounding Collapse panel from toggling open.
+                e.stopPropagation();
+              }}
+            >
+              <Button type="text" size="small" icon={<EditOutlined />}>
+                Edit
+              </Button>
+            </Link>
+          </Tooltip>
+        )}
       </Space>
+    </div>
+  );
+};
+
+const DraftsBanner: React.FC<{
+  draftsResult: ReturnType<typeof usePromiseResult<RuleDraftsListResponse>>;
+}> = ({ draftsResult }) => {
+  if (draftsResult.status !== PromiseResultStatus.Resolved) return null;
+  // The endpoint returns every row in the rules table, deployed ones included — a row is a
+  // rule at some point in its lifecycle, not a permanently separate kind of thing. This
+  // banner is only about the part of that lifecycle that is *not yet live*, which is what
+  // "drafts" means and what makes it worth a panel above the registry.
+  //
+  // Deployed rows are dropped rather than listed last: they are already below in the
+  // registry, so keeping them here shows the same rule twice, the second time under a
+  // heading that contradicts its status.
+  const rows = draftsResult.value.drafts.filter((row) => {
+    return row.status === 'deploy_requested' || row.status === 'draft';
+  });
+  if (rows.length === 0) return null;
+  // Ordered by how much they want someone's attention: a draft whose author has said it is
+  // ready is a queue entry waiting on a person, so it sorts and counts ahead of work still
+  // in progress.
+  const awaiting = rows.filter((row) => {
+    return row.status === 'deploy_requested';
+  });
+  const inProgress = rows.filter((row) => {
+    return row.status === 'draft';
+  });
+  const ordered = [...awaiting, ...inProgress];
+  const headline = [
+    awaiting.length > 0 ? `${awaiting.length} awaiting deployment` : null,
+    inProgress.length > 0 ? `${inProgress.length} in progress` : null,
+  ]
+    .filter(Boolean)
+    .join(' · ');
+  return (
+    <Alert
+      // Always informational. A queue of drafts waiting on someone is not a fault, and
+      // colouring it as one means the page is amber whenever anybody has finished a
+      // draft — which is most of the time, at which point the colour stops being read.
+      // The count carries the emphasis instead, and the per-row status tag says which.
+      type="info"
+      showIcon
+      style={{ marginBottom: 16 }}
+      // No empty case: the banner returns null when nothing is pending, so reaching here
+      // guarantees at least one of the two counts is non-zero.
+      message={`Rule drafts — ${headline}`}
+      description={
+        <Space direction="vertical" size={4} style={{ width: '100%' }}>
+          {ordered.slice(0, 8).map((row) => {
+            return <DraftRow key={row.id} draft={row} />;
+          })}
+          {ordered.length > 8 && <Text type="secondary">+{ordered.length - 8} more.</Text>}
+        </Space>
+      }
+    />
+  );
+};
+
+// `deploy_requested` reads as a queue entry rather than a state of the file, so it gets
+// the label a reviewer is scanning for. Looked up rather than nested ternaries, and with a
+// fallback, so a status added server-side renders its raw value instead of nothing.
+const STATUS_LABEL: Partial<Record<RuleRecordStatus, string>> = {
+  draft: 'draft',
+  deploy_requested: 'awaiting deployment',
+  deployed: 'deployed',
+};
+
+// Colour tracks "does this want someone's attention", not "is this good". Green marks the
+// one row a reviewer is looking for; gold marks work still moving; `deployed` drops to the
+// neutral tag because a live rule is the resting state and needs nothing from anyone.
+//
+// `deployed` cannot also be green — two states sharing a colour is the same as neither
+// having one, and these two are opposites in the only way that matters here: one is live,
+// the other is explicitly not live yet.
+const STATUS_TAG_COLOUR: Partial<Record<RuleRecordStatus, string>> = {
+  draft: 'gold',
+  deploy_requested: 'green',
+  deployed: 'default',
+};
+
+// Deploying is deliberately not offered here. It happens in the editor, where the draft's
+// SML is on screen — a deploy button next to a filename asks someone to publish a rule
+// they are not currently looking at.
+const DraftRow: React.FC<{ draft: RuleDraftSummary }> = ({ draft }) => {
+  return (
+    <div className={styles.draftRow}>
+      <Link to={{ pathname: '/rules/edit', search: `?draftId=${encodeURIComponent(draft.id)}` }}>{draft.path}</Link>
+      <Tag color={STATUS_TAG_COLOUR[draft.status] ?? 'default'}>{STATUS_LABEL[draft.status] ?? draft.status}</Tag>
+      <Text type="secondary" style={{ fontSize: 12 }}>
+        by {draft.author}
+      </Text>
     </div>
   );
 };

--- a/osprey_ui/src/components/rules/ruleBuilderSml.ts
+++ b/osprey_ui/src/components/rules/ruleBuilderSml.ts
@@ -1,0 +1,213 @@
+import {
+  ConditionOperator,
+  RuleBuilderCondition,
+  RuleBuilderModel,
+  RuleBuilderOutcome,
+  RuleBuilderOutcomeArg,
+  RuleVocabularyFeature,
+  RuleVocabularyUdf,
+} from '../../types/RulesTypes';
+
+// Re-export shared types so existing imports from this module keep working.
+export type {
+  ConditionOperator,
+  RuleBuilderCondition as Condition,
+  RuleBuilderModel,
+  RuleBuilderOutcome as Outcome,
+  RuleBuilderOutcomeArg as OutcomeArg,
+} from '../../types/RulesTypes';
+
+export const CONDITION_OPERATOR_OPTIONS: { value: ConditionOperator; label: string }[] = [
+  { value: '==', label: 'is equal to' },
+  { value: '!=', label: 'is not equal to' },
+  { value: '>', label: 'is greater than' },
+  { value: '<', label: 'is less than' },
+  { value: '>=', label: 'is greater than or equal to' },
+  { value: '<=', label: 'is less than or equal to' },
+  { value: 'includes', label: 'includes' },
+  { value: 'excludes', label: 'excludes' },
+];
+
+export const EMPTY_BUILDER_MODEL: RuleBuilderModel = {
+  ruleName: '',
+  description: '',
+  conditions: [{ feature: '', operator: '==', rhs: '', rhsIsFeature: false }],
+  outcomes: [{ effect: '', args: [] }],
+};
+
+export const SML_IDENTIFIER_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+// SML string literals follow Python escaping rules (the parser is Python's ast
+// module), so backslashes must be escaped before quotes or a trailing `\` in
+// user input would swallow the closing quote and inject raw SML.
+function smlString(value: string): string {
+  const escaped = value.replace(/\\/g, '\\\\').replace(/'/g, "\\'").replace(/\r/g, '\\r').replace(/\n/g, '\\n');
+  return `'${escaped}'`;
+}
+
+function renderRhs(rhs: string, isFeature: boolean): string {
+  if (isFeature) return rhs;
+  if (rhs === '') return "''";
+  if (/^-?\d+(\.\d+)?$/.test(rhs)) return rhs;
+  if (rhs === 'true' || rhs === 'false') return rhs;
+  return smlString(rhs);
+}
+
+function renderConditionExpression(c: RuleBuilderCondition): string {
+  const lhs = c.feature || '__missing_feature__';
+  const rhs = renderRhs(c.rhs, c.rhsIsFeature);
+  switch (c.operator) {
+    case 'includes':
+      return `TextContains(text=${lhs}, phrase=${rhs})`;
+    case 'excludes':
+      return `not TextContains(text=${lhs}, phrase=${rhs})`;
+    default:
+      return `${lhs} ${c.operator} ${rhs}`;
+  }
+}
+
+function renderOutcomeCall(o: RuleBuilderOutcome): string {
+  const effect = o.effect || '__missing_effect__';
+  // Skip args left blank: emitting `entity=` is a syntax error, and emitting `expires_after=''`
+  // forces an empty literal where the UDF would otherwise use its default.
+  const parts = o.args
+    .filter((arg) => {
+      return arg.value !== '';
+    })
+    .map((arg) => {
+      const rendered = renderRhs(arg.value, arg.isFeature);
+      // A null name is a positional argument, which the parser produces for calls the
+      // effect's signature doesn't name. Emitting `null=value` for those would not parse.
+      return arg.name == null ? rendered : `${arg.name}=${rendered}`;
+    });
+  return `${effect}(${parts.join(', ')})`;
+}
+
+function collectReferencedFeatures(model: RuleBuilderModel): Set<string> {
+  const refs = new Set<string>();
+  for (const c of model.conditions) {
+    if (c.feature) refs.add(c.feature);
+    if (c.rhsIsFeature && c.rhs) refs.add(c.rhs);
+  }
+  for (const o of model.outcomes) {
+    for (const arg of o.args) {
+      if (arg.isFeature && arg.value) refs.add(arg.value);
+    }
+  }
+  return refs;
+}
+
+function buildImportBlock(refs: Set<string>, features: RuleVocabularyFeature[]): string {
+  // Map each referenced identifier to the SML file it's defined in, drop main.sml
+  // (the entry point cannot import itself), dedupe, and emit a single Import block.
+  const paths = new Set<string>();
+  for (const ref of refs) {
+    const feat = features.find((f) => {
+      return f.name === ref;
+    });
+    if (!feat) continue;
+    if (feat.source_path === 'main.sml') continue;
+    paths.add(feat.source_path);
+  }
+  if (paths.size === 0) return '';
+  const sorted = [...paths].sort();
+  const entries = sorted
+    .map((p) => {
+      return `    '${p}',`;
+    })
+    .join('\n');
+  return `Import(
+  rules=[
+${entries}
+  ]
+)
+
+`;
+}
+
+export function generateSmlFromBuilder(model: RuleBuilderModel, features: RuleVocabularyFeature[] = []): string {
+  // Never interpolate a non-identifier rule name: `Foo = Rule(...) # ` as a
+  // "name" would otherwise inject arbitrary SML that still validates.
+  const ruleName = SML_IDENTIFIER_RE.test(model.ruleName) ? model.ruleName : 'UnnamedRule';
+  const whenAll = model.conditions
+    .map((c) => {
+      return `    ${renderConditionExpression(c)},`;
+    })
+    .join('\n');
+  const ruleBlock = `${ruleName} = Rule(
+  when_all=[
+${whenAll}
+  ],
+  description=${smlString(model.description)},
+)`;
+
+  const imports = buildImportBlock(collectReferencedFeatures(model), features);
+
+  if (model.outcomes.length === 0) {
+    return `${imports}${ruleBlock}\n`;
+  }
+
+  const thenBlock = model.outcomes
+    .map((o) => {
+      return `    ${renderOutcomeCall(o)},`;
+    })
+    .join('\n');
+
+  return `${imports}${ruleBlock}
+
+WhenRules(
+  rules_any=[${ruleName}],
+  then=[
+${thenBlock}
+  ],
+)
+`;
+}
+
+/**
+ * Insert or merge the given source paths into the file's top-level
+ * `Import(rules=[...])` block. If an Import block already exists, missing
+ * entries are added in-place; otherwise a new block is prepended.
+ */
+export function applyMissingImports(source: string, pathsToAdd: string[]): string {
+  if (pathsToAdd.length === 0) return source;
+  const existingMatch = source.match(/Import\s*\(\s*rules\s*=\s*\[([^\]]*)\]\s*\)/m);
+  if (existingMatch) {
+    const existingPathsBlock = existingMatch[1];
+    const existing = new Set(
+      Array.from(existingPathsBlock.matchAll(/['"]([^'"]+)['"]/g)).map((m) => {
+        return m[1];
+      })
+    );
+    const merged = new Set(existing);
+    for (const p of pathsToAdd) merged.add(p);
+    if (merged.size === existing.size) return source;
+    const sorted = [...merged].sort();
+    const entries = sorted
+      .map((p) => {
+        return `    '${p}',`;
+      })
+      .join('\n');
+    const replacement = `Import(\n  rules=[\n${entries}\n  ]\n)`;
+    return source.replace(existingMatch[0], replacement);
+  }
+  const sorted = [...pathsToAdd].sort();
+  const entries = sorted
+    .map((p) => {
+      return `    '${p}',`;
+    })
+    .join('\n');
+  return `Import(\n  rules=[\n${entries}\n  ]\n)\n\n${source}`;
+}
+
+export function outcomeArgsForEffect(effectName: string, udfs: RuleVocabularyUdf[]): RuleBuilderOutcomeArg[] {
+  const match = udfs.find((u) => {
+    return u.name === effectName;
+  });
+  if (!match) return [];
+  return match.arguments.map((arg) => {
+    // Defaults the value-vs-feature toggle for the form. Wrong guesses are one click to flip.
+    const looksLikeFeature = arg.name === 'entity' || /Id$|DID$/i.test(arg.name);
+    return { name: arg.name, value: '', isFeature: looksLikeFeature };
+  });
+}

--- a/osprey_ui/src/stores/ApplicationConfigStore.tsx
+++ b/osprey_ui/src/stores/ApplicationConfigStore.tsx
@@ -41,6 +41,14 @@ export interface ApplicationConfig {
   knownFeatureCategories: KnownFeatureCategories;
   knownActionNames: Set<string>;
   currentUser: { email?: string };
+  // Whether this deployment has a usable rules directory, and whether the current user
+  // holds CAN_DEPLOY_RULES. Kept apart rather than collapsed into one "can I deploy?"
+  // flag: the first hides the deploy control, the second disables it with a reason.
+  ruleDeploymentEnabled: boolean;
+  canDeployRules: boolean;
+  // Whether the current user may author rule drafts. Gates the authoring entry points;
+  // reading the rules catalog needs only CAN_VIEW_RULES.
+  canEditRules: boolean;
 }
 
 type ApplicationConfigStore = {
@@ -62,6 +70,10 @@ const useApplicationConfigStore = create<ApplicationConfigStore>((set) => ({
   updateApplicationConfig: (config: ApplicationConfig) => set(() => ({ ...config })),
   isRecordingClicks: false,
   currentUser: {},
+  // Off until the real config lands, so nothing offers a deploy during the first render.
+  ruleDeploymentEnabled: false,
+  canDeployRules: false,
+  canEditRules: false,
 }));
 
 export default useApplicationConfigStore;

--- a/osprey_ui/src/types/ConfigTypes.tsx
+++ b/osprey_ui/src/types/ConfigTypes.tsx
@@ -43,4 +43,16 @@ export interface RawUIConfig {
   label_info_mapping: RawLabelInfoMapping;
   rule_info_mapping: RawRuleInfoMapping;
   current_user: { email: string };
+  // The two independent things that both have to hold before deploying a rule draft can
+  // succeed, reported separately because they want different UI. A deployment with no
+  // rules directory has no deploy story at all and hides the control; a user without the
+  // ability is looking at a deployment that does deploy, and is better served by a
+  // disabled control that says why than by one that silently isn't there.
+  rule_deployment_enabled: boolean;
+  can_deploy_rules: boolean;
+  // Whether the current user may author drafts at all. Separate from deploying because
+  // the blast radius differs: a draft is reversible and private to the UI, a deploy is
+  // neither. There is no deployment-level counterpart the way `rule_deployment_enabled`
+  // pairs with `can_deploy_rules` — every deployment can hold drafts.
+  can_edit_rules: boolean;
 }

--- a/osprey_ui/src/types/RulesTypes.tsx
+++ b/osprey_ui/src/types/RulesTypes.tsx
@@ -19,3 +19,223 @@ export enum SortKey {
   MostReferenced = 'most-referenced',
   LeastReferenced = 'least-referenced',
 }
+
+export interface RuleDraftValidationMessage {
+  message: string;
+  hint?: string | null;
+  source_path: string;
+  line: number;
+  column: number;
+  rendered: string;
+  identifier?: string | null;
+  defined_in_source_paths?: string[];
+}
+
+export interface RuleDraftValidationResponse {
+  ok: boolean;
+  errors: RuleDraftValidationMessage[];
+  warnings: RuleDraftValidationMessage[];
+  suggested_imports?: string[];
+  // Set when the engine's sources couldn't be assembled at all (e.g. a broken
+  // main.sml), which is distinct from this draft's SML failing validation — nothing
+  // the author types will fix it.
+  assemble_error?: string | null;
+}
+
+export interface RuleSourceResponse {
+  path: string;
+  contents: string;
+}
+
+export interface RuleVocabularyFeature {
+  name: string;
+  source_path: string;
+  source_line: number;
+}
+
+export interface RuleVocabularyUdfArgument {
+  name: string;
+  type_name: string;
+}
+
+export interface RuleVocabularyUdf {
+  name: string;
+  return_type: string;
+  arguments: RuleVocabularyUdfArgument[];
+}
+
+export interface RuleVocabulary {
+  features: RuleVocabularyFeature[];
+  udfs: RuleVocabularyUdf[];
+  effects: string[];
+  source_files: string[];
+}
+
+// `deploy_requested` exists because CAN_EDIT_RULES alone can write a draft but not ship
+// it. Without it the table shows `draft` for both work in progress and work waiting on
+// someone else. Reachable from `deployed` too, which reads as "a redeploy is wanted";
+// `deployed_at` stays set, so the two remain distinguishable.
+export type RuleRecordStatus = 'draft' | 'deploy_requested' | 'deployed';
+
+// A row of the rules table without its SML — what `GET /rules/drafts` lists. Named for
+// the row rather than for `draft` because a row is a rule at some point in its lifecycle:
+// deploying marks it deployed, and editing a deployed rule returns it to draft. `status`
+// is the only thing separating the two, so there is no distinct deployed-rule type.
+//
+// This is the shape anything rendering *about* a rule should ask for. Only the editor
+// needs the SML, and it opens one draft at a time.
+export interface RuleDraftSummary {
+  // A string on the wire, not a number. Osprey mints ids as snowflakes in places, and a
+  // 64-bit id exceeds JavaScript's exact integer range — parsing one as a number would
+  // silently drop its low bits. Pass it through as an opaque string.
+  id: string;
+  path: string;
+  rule_name: string;
+  // Content address of the SML: SHA-256 of its UTF-8 bytes, hex, with no normalisation —
+  // so it answers "is this the same text?", not "is this the same program". Deploy writes
+  // the source verbatim, which is what lets the server tell a rule that is deployed and
+  // current from one edited on disk since, without keeping a second copy to diff.
+  //
+  // Not used for the editor's own dirty check: that holds the source already, and a
+  // direct comparison is exact and synchronous where hashing would be neither.
+  cid: string;
+  author: string;
+  status: RuleRecordStatus;
+  // The list is ordered by this.
+  updated_at: string | null;
+}
+
+// A full row: the summary plus the SML itself. Served where one specific draft is the
+// subject — fetching it into the editor, and the responses to creating or deploying it.
+//
+// Extends rather than duplicates, mirroring the API, so anything needing only summary
+// fields can be typed `RuleDraftSummary` and still accept a full record.
+export interface RuleRecord extends RuleDraftSummary {
+  source: string;
+  summary: string;
+  created_at: string | null;
+  deployed_at: string | null;
+}
+
+export interface RuleDraftsListResponse {
+  drafts: RuleDraftSummary[];
+}
+
+// `GET /rules/drafts/<id>/deploy-plan` — what a deploy would actually do, computed by the
+// side that can see the rules directory. The client cannot derive any of this: it never
+// sees the filesystem, and `cid` only answers "is this the same text?" once something has
+// hashed the file to compare against.
+export type RuleSourcePlanState = 'valid' | 'invalid';
+export type RuleFilePlanState = 'new' | 'identical' | 'differs';
+export type MainSmlPlanState = 'would_append' | 'already_required' | 'missing' | 'unparseable';
+
+export interface RuleDeployPlan {
+  // Whether the draft still compiles against the engine's current sources.
+  source: { state: RuleSourcePlanState };
+  rule_file: { path: string; state: RuleFilePlanState };
+  main_sml: {
+    state: MainSmlPlanState;
+    // The exact line deploy would add, when `state` is `would_append` — so the dialog can
+    // show what it writes rather than paraphrase it.
+    require_line: string | null;
+  };
+  // Two independent facts, not one verdict. `deployable` is about writing the rule file:
+  // the draft compiles and the rules directory is usable. `wireable_into_main` is about
+  // the Require line: main.sml exists and parses. A broken draft with a fine main.sml is
+  // `false, true`; a good draft with a broken main.sml is the reverse.
+  //
+  // Deploy is possible when `deployable && (!wireIntoMain || wireable_into_main)`.
+  deployable: boolean;
+  // Server-derived rather than inferred from `main_sml.state`, so a state added later
+  // disables the checkbox on an old client instead of leaving it wrongly enabled.
+  wireable_into_main: boolean;
+}
+
+// The result of POST /rules/drafts/<id>/deploy. `path_on_disk` is relative to the
+// configured rules directory; `main_sml_updated` says whether a `Require(...)` line was
+// appended to main.sml, which is what makes the deployed file take effect at all.
+export interface RuleDeployment {
+  rule: RuleRecord;
+  main_sml_updated: boolean;
+  path_on_disk: string;
+}
+
+export type ConditionOperator = '==' | '!=' | '>' | '<' | '>=' | '<=' | 'includes' | 'excludes';
+
+// --------------------------------------------------------------------------- //
+// Rule Builder — wire shapes
+//
+// The API serialises every response snake_case with no exceptions. These models used to
+// carry camelCase aliases and were the single exception to that, so the conversion is
+// now the client's. The `Raw*` types below are what comes off the wire — mirroring
+// `RawUIConfig` — and `RulesActions` converts them into the view models beneath.
+// --------------------------------------------------------------------------- //
+
+export interface RawRuleBuilderCondition {
+  feature: string;
+  operator: ConditionOperator;
+  rhs: string;
+  rhs_is_feature: boolean;
+}
+
+export interface RawRuleBuilderOutcomeArg {
+  // Null for a positional argument.
+  name: string | null;
+  value: string;
+  is_feature: boolean;
+}
+
+export interface RawRuleBuilderOutcome {
+  effect: string;
+  args: RawRuleBuilderOutcomeArg[];
+}
+
+export interface RawRuleBuilderModel {
+  rule_name: string;
+  description: string;
+  conditions: RawRuleBuilderCondition[];
+  outcomes: RawRuleBuilderOutcome[];
+}
+
+// The API emits all three keys every time, so `supported` is the discriminant and the
+// other two are nullable rather than absent.
+export interface RawParseIntoBuilderResponse {
+  supported: boolean;
+  reason: string | null;
+  model: RawRuleBuilderModel | null;
+}
+
+// --------------------------------------------------------------------------- //
+// Rule Builder — view models
+// --------------------------------------------------------------------------- //
+
+export interface RuleBuilderCondition {
+  feature: string;
+  operator: ConditionOperator;
+  rhs: string;
+  rhsIsFeature: boolean;
+}
+
+export interface RuleBuilderOutcomeArg {
+  // Null for a positional argument: the SML generator emits a bare value for these
+  // rather than `name=value`, so a call the parser read positionally round-trips.
+  name: string | null;
+  value: string;
+  isFeature: boolean;
+}
+
+export interface RuleBuilderOutcome {
+  effect: string;
+  args: RuleBuilderOutcomeArg[];
+}
+
+export interface RuleBuilderModel {
+  ruleName: string;
+  description: string;
+  conditions: RuleBuilderCondition[];
+  outcomes: RuleBuilderOutcome[];
+}
+
+export type ParseIntoBuilderResponse =
+  | { supported: true; model: RuleBuilderModel }
+  | { supported: false; reason: string };

--- a/osprey_ui/tsconfig.json
+++ b/osprey_ui/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
+    "types": [],
     "downlevelIteration": true,
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
- Related to #58

## Description

This is the UI side of the work in #489, it was originally the #403 branch, but I've ended up heavily reworking the UI to hopefully feel better.

@julietshen if you're wanting to check out a branch to take for a spin, then it's this branch. You can add a `osprey_worker/src/osprey/worker/lib/acls/dev_acl_assignments.json` to give you two users to test with:
```
{
  "local-dev@localhost": { "roles": ["SUPER_USER"] },
  "author@example.com": { "roles": ["RULE_AUTHOR"] }
}
```

## Checklist

- [ ] Tests pass locally
- [ ] `uv run ruff check .` passes (no unused imports or other lint errors)
- [ ] `uv tool run fawltydeps --check-unused --pyenv .venv` passes (no unused dependencies)
- [ ] Updated `CHANGELOG.md` with my changes, if notable (refer to [Keep a Changelog](https://keepachangelog.com/en/2.0.0/) conventions)
