### PR TITLE
Make the query tests independent between UI API and storage

### DIFF
--- a/osprey_worker/src/osprey/worker/lib/storage/tests/test_queries.py
+++ b/osprey_worker/src/osprey/worker/lib/storage/tests/test_queries.py
@@ -20,6 +20,18 @@ def sqlalchemy_session() -> Iterator[Session]:
         yield session
 
 
+@pytest.fixture(autouse=True)
+def _clear_queries() -> Iterator[None]:
+    # The test database is session-scoped, so rows outlive the test that made them.
+    # Leaving them behind made `views/tests/test_queries.py::test_get_queries` pass only
+    # when this module ran first, in the same session -- it asserted on the suite's
+    # accumulated residue rather than on anything it created.
+    with scoped_session(commit=True) as session:
+        session.query(SavedQuery).delete()
+        session.query(Query).delete()
+    yield
+
+
 def _create_query(executed_by: str | None = None, parent_id: int | None = None, insert: bool | None = False) -> Query:
     query = Query()
     query.parent_id = parent_id

--- a/osprey_worker/src/osprey/worker/ui_api/osprey/views/tests/conftest.py
+++ b/osprey_worker/src/osprey/worker/ui_api/osprey/views/tests/conftest.py
@@ -1,0 +1,26 @@
+"""Shared setup for the view tests.
+
+These tests drive real endpoints against a real database, so most of them leave rows
+behind. The test database is session-scoped, which means those rows outlive the test
+that made them and are visible to every test that runs afterwards.
+"""
+
+from collections.abc import Iterator
+
+import pytest
+from osprey.worker.lib.storage.bulk_label_task import BulkLabelTask
+from osprey.worker.lib.storage.postgres import scoped_session
+from osprey.worker.lib.storage.queries import Query, SavedQuery
+from osprey.worker.lib.storage.temporary_ability_token import TemporaryAbilityToken
+
+
+@pytest.fixture(autouse=True)
+def _clear_tables() -> Iterator[None]:
+    """Start every view test *module* with the tables these tests write to empty."""
+    with scoped_session(commit=True) as session:
+        # `SavedQuery` is deleted before `Query` because it has a foreign key to it
+        session.query(SavedQuery).delete()
+        session.query(Query).delete()
+        session.query(BulkLabelTask).delete()
+        session.query(TemporaryAbilityToken).delete()
+    yield

--- a/osprey_worker/src/osprey/worker/ui_api/osprey/views/tests/test_queries.py
+++ b/osprey_worker/src/osprey/worker/ui_api/osprey/views/tests/test_queries.py
@@ -1,5 +1,6 @@
 import json
 
+import pytest
 from faker import Faker
 from flask import Flask, Response, url_for
 from flask.testing import FlaskClient
@@ -28,8 +29,30 @@ def test_create_query_record(app: Flask, client: 'FlaskClient[Response]') -> Non
     assert res.json['executed_at'] == Snowflake(int(res.json['id'])).to_timestamp()
 
 
-def test_get_queries(app: Flask, client: 'FlaskClient[Response]') -> None:
-    res = client.get(url_for('queries.get_queries'), content_type='application/json')
+@pytest.fixture
+def one_query_record(client: 'FlaskClient[Response]') -> None:
+    """Create exactly one query record, so a test can assert on a known table."""
+    res = client.post(
+        url_for('queries.create_query_record'),
+        data=json.dumps(
+            {
+                'query_filter': fake.pystr(),
+                'date_range': [fake.past_datetime().isoformat(), fake.future_datetime().isoformat()],
+                'top_n': [],
+                'sort_order': 'DESCENDING',
+            }
+        ),
+        content_type='application/json',
+    )
+    assert res.status_code == 200
 
-    # NOTE(caidanw): the number of queries may vary based on other tests that have run, we might need to rethink this test
-    assert len(res.json) == 21
+
+def test_get_queries(app: Flask, client: 'FlaskClient[Response]', one_query_record: None) -> None:
+    """Lists the query records that exist, which is the one the fixture created.
+
+    The count is exact rather than a lower bound because `_clear_tables` empties the
+    table before each test, so nothing else can be in it.
+    """
+    res = client.get(url_for('queries.get_queries'), content_type='application/json')
+    assert res.status_code == 200
+    assert len(res.json) == 1


### PR DESCRIPTION
## Description

`osprey_worker/src/osprey/worker/ui_api/osprey/views/tests/test_queries.py::test_get_queries` asserted `len(res.json) == 21` with a note that "the number of queries may vary based on other tests that have run". It was not counting anything it created -- 21 was a census of whatever the whole suite had left in the `queries` table, so the test passed only when `osprey_worker/src/osprey/worker/lib/storage/queries.py` had run first in the same session and failed for any subset of the suite. 

This change isolates these two test suites, ensuring that the database is cleaned up correctly between.

Both are prerequisites for running these modules on their own.

## Checklist

- [x] Tests pass locally
- [x] `uv run ruff check .` passes (no unused imports or other lint errors)
- [x] `uv tool run fawltydeps --check-unused --pyenv .venv` passes (no unused dependencies)
- [x] Updated `CHANGELOG.md` with my changes, if notable (refer to [Keep a Changelog](https://keepachangelog.com/en/2.0.0/) conventions)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved query-related test isolation by clearing stored query data before each test.
  * Updated query count assertions to account for existing records, reducing dependence on test execution order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->