### PR TITLE
Improve editor tooling

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,36 @@
+# https://editorconfig.org
+#
+# Mirrors the formatters that already enforce these, so an editor without the
+# relevant plugin still produces conforming files:
+#   - Python           ruff format  (pyproject.toml [tool.ruff]: line-length 120,
+#                                    indent-style space, indent-width defaults to 4)
+#   - osprey_ui/src/** prettier     (osprey_ui/.prettierrc: tabWidth 2, printWidth 120)
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+max_line_length = 120
+
+[*.py]
+indent_size = 4
+
+# SML is a Python-derived subset, but rules are written 2-space in this repo --
+# including the ones the in-app rule editor generates.
+[*.sml]
+indent_size = 2
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.md]
+# Two trailing spaces are a hard line break in Markdown.
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+  "recommendations": [
+    "ms-python.python",
+    "ms-python.vscode-pylance",
+    "charliermarsh.ruff",
+    "esbenp.prettier-vscode",
+    "dbaeumer.vscode-eslint",
+    "editorconfig.editorconfig"
+  ]
+}


### PR DESCRIPTION
## Description

- Adds `.editorconfig` to ensure files are consistently indented (I noticed the python files used four-space indentation, whilst sml files used two space).
- Adds recommended vscode extensions for this repository.

The latter was something I hit into where my editor wasn't correctly surfacing code issues as I worked, and autocomplete wasn't working correctly because I'd defaulted to using jedi for intellisense over pylance.

No user-facing changes, only developer-facing

## Checklist

- [x] Tests pass locally
- [x] `uv run ruff check .` passes (no unused imports or other lint errors)
- [x] `uv tool run fawltydeps --check-unused --pyenv .venv` passes (no unused dependencies)
- [x] Updated `CHANGELOG.md` with my changes, if notable (refer to [Keep a Changelog](https://keepachangelog.com/en/2.0.0/) conventions)
