### PR TITLE
Fix tests deleting osprey database

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,17 @@ Pass pytest args through:
 ./run-tests.sh --junitxml=/tmp/test-results/junit-pytest.xml
 ```
 
+The dependency containers stay up between runs so they don't have to become healthy
+again each time. Stop them when you want the resources back:
+
+```bash
+./stop-tests.sh
+```
+
+Don't reach for `docker compose down` directly: without `-p osprey-test` compose derives
+the project name from the directory, which is the *dev* stack, and tears that down
+instead.
+
 Python lint / format / type-check (no Docker needed):
 
 ```bash

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -8,13 +8,6 @@ services:
     container_name: !reset null
     ports: !reset []
     volumes: !reset []
-    # The container creates this at init, so it exists before any test runs. The
-    # session fixture in test_utils would otherwise create it, but that fixture is
-    # only installed in the `lib`, `sinks` and `ui_api` conftests -- and tests under
-    # `osprey/engine/` sort earlier and reach the database first, so relying on it
-    # leaves the first database-touching test with nowhere to connect.
-    environment:
-      - POSTGRES_DB=osprey_test
 
   osprey-kafka:
     container_name: !reset null

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -93,7 +93,11 @@ services:
       - OSPREY_RULES_PATH=./example_rules
       - OSPREY_DISABLE_VALIDATION_EXPORTER=true
       - DRUID_URL=http://druid-broker:8082
-      - POSTGRES_HOSTS={"osprey_db":"postgresql://osprey:FoolishPassword@postgres:5432/osprey"}
+      # A database of its own, not the `osprey` one the dev stack uses. The session
+      # fixture creates this database on setup and drops it on teardown, so pointing it
+      # at `osprey` means running the tests destroys the local development database and
+      # leaves osprey-ui-api unable to start until it is recreated by hand.
+      - POSTGRES_HOSTS={"osprey_db":"postgresql://osprey:FoolishPassword@postgres:5432/osprey_test"}
       - ETCD_PEERS=http://etcd:2379
       - TESTING=true
     volumes:

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -8,6 +8,13 @@ services:
     container_name: !reset null
     ports: !reset []
     volumes: !reset []
+    # The container creates this at init, so it exists before any test runs. The
+    # session fixture in test_utils would otherwise create it, but that fixture is
+    # only installed in the `lib`, `sinks` and `ui_api` conftests -- and tests under
+    # `osprey/engine/` sort earlier and reach the database first, so relying on it
+    # leaves the first database-touching test with nowhere to connect.
+    environment:
+      - POSTGRES_DB=osprey_test
 
   osprey-kafka:
     container_name: !reset null

--- a/osprey_worker/conftest.py
+++ b/osprey_worker/conftest.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 from gevent import monkey
+from osprey.worker.lib.tests import test_utils
 
 if TYPE_CHECKING:
     from _pytest.config import Config
@@ -31,8 +32,6 @@ _STARTED_PREPATCHED = monkey.is_module_patched('socket')
 #
 # Defined once, here: a fixture of the same name in a nearer conftest would shadow this
 # one for that package while both still ran, giving one session two database lifecycles.
-from osprey.worker.lib.tests import test_utils  # noqa: E402
-
 postgres_database_config = test_utils.make_postgres_database_config_fixture()
 
 

--- a/osprey_worker/conftest.py
+++ b/osprey_worker/conftest.py
@@ -21,6 +21,21 @@ if TYPE_CHECKING:
 _STARTED_PREPATCHED = monkey.is_module_patched('socket')
 
 
+# The database is set up here, at the root, rather than in the `lib`, `sinks` and
+# `ui_api` conftests, because tests under `osprey/engine/` use it too --
+# `stdlib/udfs/tests/test_labels.py` reaches the labels storage -- and had no fixture
+# providing it. `docker-compose.test.yaml` covered that by pre-creating the database
+# via POSTGRES_DB, which meant the fixture always found one already there, never
+# considered it its own, and so never dropped it. That is why a schema change could
+# silently fail to apply.
+#
+# Defined once, here: a fixture of the same name in a nearer conftest would shadow this
+# one for that package while both still ran, giving one session two database lifecycles.
+from osprey.worker.lib.tests import test_utils  # noqa: E402
+
+postgres_database_config = test_utils.make_postgres_database_config_fixture()
+
+
 def pytest_addoption(parser: 'Parser') -> None:
     """Register custom pytest options.
 

--- a/osprey_worker/src/osprey/worker/lib/conftest.py
+++ b/osprey_worker/src/osprey/worker/lib/conftest.py
@@ -7,10 +7,6 @@ patch_all(patch_gevent=False, patch_ddtrace=False)
 
 from osprey.engine import conftest as rules_conftest  # noqa: E402
 
-from .tests import test_utils  # noqa: E402
-
-postgres_database_config = test_utils.make_postgres_database_config_fixture()
-
 # Take some fixtures from the rules package
 execute = rules_conftest.execute
 execute_with_result = rules_conftest.execute_with_result

--- a/osprey_worker/src/osprey/worker/lib/tests/test_disposable_database.py
+++ b/osprey_worker/src/osprey/worker/lib/tests/test_disposable_database.py
@@ -10,8 +10,15 @@ The function is pure, so these need no database. They still pay for one: the ses
 fixture in the root conftest is autouse for the whole repository.
 """
 
+import contextlib
+
 import pytest
-from osprey.worker.lib.tests.test_utils import _is_disposable_database
+from osprey.worker.lib.storage import postgres
+from osprey.worker.lib.tests.test_utils import _drop_database, _is_disposable_database
+from psycopg2.errors import ObjectInUse
+from sqlalchemy import create_engine
+from sqlalchemy.exc import OperationalError
+from sqlalchemy_utils import create_database
 
 #: The two URLs that actually appear in this repo's compose files. Named rather than
 #: inlined, because the whole point of the guard is telling these two apart.
@@ -68,3 +75,45 @@ def test_a_name_merely_containing_test_is_not_enough() -> None:
     """
     assert _is_disposable_database('postgresql://u:p@h:5432/osprey_testing') is False
     assert _is_disposable_database('postgresql://u:p@h:5432/latest') is False
+
+
+def test_dropping_a_database_that_is_in_use_is_refused() -> None:
+    """A database with a connection open is not destroyed, and the refusal is Postgres's.
+
+    This is the assertion that would catch a regression to
+    `sqlalchemy_utils.drop_database`, which does not refuse: for Postgres it runs
+    `pg_terminate_backend` against every other session and drops the database anyway,
+    so a concurrent test run would be killed and left failing with connection errors
+    that point nowhere near the cause.
+
+    Runs against a scratch database rather than the suite's own, for the obvious reason
+    that the success path here destroys whatever it is pointed at.
+    """
+    bound_engine = postgres.sessions['osprey_db'].kw['bind']
+    scratch_url = bound_engine.url.set(database='osprey_drop_guard_test').render_as_string(hide_password=False)
+
+    # Dropped first and last: a failure part way through this test would otherwise leave
+    # the scratch database behind, and the next run's `create_database` would collide
+    # with it rather than reporting whatever actually went wrong.
+    with contextlib.suppress(Exception):
+        _drop_database(scratch_url)
+
+    scratch_engine = None
+    try:
+        create_database(scratch_url)
+        scratch_engine = create_engine(scratch_url)
+
+        with scratch_engine.connect():
+            with pytest.raises(OperationalError) as excinfo:
+                _drop_database(scratch_url)
+            assert isinstance(excinfo.value.orig, ObjectInUse)
+
+        # And once nothing is attached it drops -- so the refusal is about the
+        # connection, not about the drop being broken.
+        scratch_engine.dispose()
+        _drop_database(scratch_url)
+    finally:
+        if scratch_engine is not None:
+            scratch_engine.dispose()
+        with contextlib.suppress(Exception):
+            _drop_database(scratch_url)

--- a/osprey_worker/src/osprey/worker/lib/tests/test_disposable_database.py
+++ b/osprey_worker/src/osprey/worker/lib/tests/test_disposable_database.py
@@ -1,13 +1,13 @@
-"""`_is_disposable_database`: which database the session teardown may drop.
+"""`_is_disposable_database`: which database the session fixture may destroy.
 
-Untested until now, and the one guard in the suite whose failure mode is destroying a
-developer's data rather than reporting a failure. The fixture it protects used to drop
-whatever `POSTGRES_HOSTS` pointed at, and the compose files pointed the tests and the dev
-stack at the same `osprey` database -- so running the suite deleted the local development
-database, and it surfaced later and elsewhere as `osprey-ui-api` refusing to start.
+The one check in the suite whose failure mode is destroying a developer's data rather
+than reporting a failure. The fixture it protects used to drop whatever `POSTGRES_HOSTS`
+pointed at, and the compose files pointed the tests and the dev stack at the same
+`osprey` database -- so running the suite deleted the local development database, and it
+surfaced later and elsewhere as `osprey-ui-api` refusing to start.
 
 The function is pure, so these need no database. They still pay for one: the session
-fixture in `lib/conftest.py` is autouse, so anything under `lib/` creates it regardless.
+fixture in the root conftest is autouse for the whole repository.
 """
 
 import pytest
@@ -20,40 +20,34 @@ TEST_URL = 'postgresql://osprey:FoolishPassword@postgres:5432/osprey_test'
 
 
 @pytest.mark.parametrize(
-    ('name', 'url', 'created_by_this_run', 'expected'),
+    ('name', 'url', 'expected'),
     [
-        ('created it, and it is named like a test database', TEST_URL, True, True),
-        ('named like a test database, but was already there', TEST_URL, False, False),
-        ('created it, but it is the development database', DEV_URL, True, False),
-        ('the development database, already there', DEV_URL, False, False),
+        ('named like a test database', TEST_URL, True),
+        ('the development database', DEV_URL, False),
     ],
-    ids=['created-test', 'existing-test', 'created-dev', 'existing-dev'],
+    ids=['test-database', 'dev-database'],
 )
-def test_only_a_test_database_this_run_created_may_be_dropped(
-    name: str, url: str, created_by_this_run: bool, expected: bool
-) -> None:
-    """Both conditions are required, and each covers a hole the other leaves.
+def test_only_a_test_database_may_be_destroyed(name: str, url: str, expected: bool) -> None:
+    """The name decides it, and the dev URL is the accident this was written for.
 
-    Dropping only what this run created still destroys a developer's database when the
-    run happens to be the thing that created it -- a fresh Postgres volume, or tests run
-    before the app has ever started. Trusting only the name still drops a `*_test`
-    database somebody else was using.
-
-    The `created-dev` row is the accident that motivated the guard: the suite created the
-    database it was pointed at, which was the dev one, and then felt entitled to drop it.
+    An earlier version also required that this run had created the database. That was
+    standing in for "somebody else may be using it", and it stopped meaning anything
+    once the fixture began recreating an existing database at setup -- which destroys a
+    database in use just as thoroughly as dropping it at teardown would. The fixture
+    asks `_sessions_on_database` instead, which checks that condition directly.
     """
-    assert _is_disposable_database(url, created_by_this_run) is expected, name
+    assert _is_disposable_database(url) is expected, name
 
 
 def test_a_query_string_is_not_part_of_the_database_name() -> None:
     """Connection URLs carry parameters in deployments, and the suffix check must not see them.
 
     `urlsplit` keeps the query out of `.path`, so this passes -- but the check reads as
-    though it operates on the whole URL, and a later rewrite that used `url.endswith(...)`
-    would refuse to drop a legitimate test database and leave it behind for the next run
-    to silently reuse.
+    though it operates on the whole URL, and a later rewrite using `url.endswith(...)`
+    would refuse to recreate a legitimate test database, leaving the stale schema that
+    this fixture exists to prevent.
     """
-    assert _is_disposable_database(f'{TEST_URL}?sslmode=require', True) is True
+    assert _is_disposable_database(f'{TEST_URL}?sslmode=require') is True
 
 
 def test_a_database_named_only_test_is_still_a_test_database() -> None:
@@ -63,14 +57,14 @@ def test_a_database_named_only_test_is_still_a_test_database() -> None:
     it documents that the rule is "ends with `_test`" rather than "has a `_test` suffix
     after some other name".
     """
-    assert _is_disposable_database('postgresql://u:p@h:5432/_test', True) is True
+    assert _is_disposable_database('postgresql://u:p@h:5432/_test') is True
 
 
 def test_a_name_merely_containing_test_is_not_enough() -> None:
     """`osprey_testing` is not a test database, and neither is `latest`.
 
     Guards against the suffix check being loosened to a substring one, which would make
-    every database with `test` anywhere in its name a candidate for deletion.
+    every database with "test" anywhere in its name a candidate for destruction.
     """
-    assert _is_disposable_database('postgresql://u:p@h:5432/osprey_testing', True) is False
-    assert _is_disposable_database('postgresql://u:p@h:5432/latest', True) is False
+    assert _is_disposable_database('postgresql://u:p@h:5432/osprey_testing') is False
+    assert _is_disposable_database('postgresql://u:p@h:5432/latest') is False

--- a/osprey_worker/src/osprey/worker/lib/tests/test_disposable_database.py
+++ b/osprey_worker/src/osprey/worker/lib/tests/test_disposable_database.py
@@ -1,0 +1,76 @@
+"""`_is_disposable_database`: which database the session teardown may drop.
+
+Untested until now, and the one guard in the suite whose failure mode is destroying a
+developer's data rather than reporting a failure. The fixture it protects used to drop
+whatever `POSTGRES_HOSTS` pointed at, and the compose files pointed the tests and the dev
+stack at the same `osprey` database -- so running the suite deleted the local development
+database, and it surfaced later and elsewhere as `osprey-ui-api` refusing to start.
+
+The function is pure, so these need no database. They still pay for one: the session
+fixture in `lib/conftest.py` is autouse, so anything under `lib/` creates it regardless.
+"""
+
+import pytest
+from osprey.worker.lib.tests.test_utils import _is_disposable_database
+
+#: The two URLs that actually appear in this repo's compose files. Named rather than
+#: inlined, because the whole point of the guard is telling these two apart.
+DEV_URL = 'postgresql://osprey:FoolishPassword@postgres:5432/osprey'
+TEST_URL = 'postgresql://osprey:FoolishPassword@postgres:5432/osprey_test'
+
+
+@pytest.mark.parametrize(
+    ('name', 'url', 'created_by_this_run', 'expected'),
+    [
+        ('created it, and it is named like a test database', TEST_URL, True, True),
+        ('named like a test database, but was already there', TEST_URL, False, False),
+        ('created it, but it is the development database', DEV_URL, True, False),
+        ('the development database, already there', DEV_URL, False, False),
+    ],
+    ids=['created-test', 'existing-test', 'created-dev', 'existing-dev'],
+)
+def test_only_a_test_database_this_run_created_may_be_dropped(
+    name: str, url: str, created_by_this_run: bool, expected: bool
+) -> None:
+    """Both conditions are required, and each covers a hole the other leaves.
+
+    Dropping only what this run created still destroys a developer's database when the
+    run happens to be the thing that created it -- a fresh Postgres volume, or tests run
+    before the app has ever started. Trusting only the name still drops a `*_test`
+    database somebody else was using.
+
+    The `created-dev` row is the accident that motivated the guard: the suite created the
+    database it was pointed at, which was the dev one, and then felt entitled to drop it.
+    """
+    assert _is_disposable_database(url, created_by_this_run) is expected, name
+
+
+def test_a_query_string_is_not_part_of_the_database_name() -> None:
+    """Connection URLs carry parameters in deployments, and the suffix check must not see them.
+
+    `urlsplit` keeps the query out of `.path`, so this passes -- but the check reads as
+    though it operates on the whole URL, and a later rewrite that used `url.endswith(...)`
+    would refuse to drop a legitimate test database and leave it behind for the next run
+    to silently reuse.
+    """
+    assert _is_disposable_database(f'{TEST_URL}?sslmode=require', True) is True
+
+
+def test_a_database_named_only_test_is_still_a_test_database() -> None:
+    """The suffix is matched, not a separator-plus-suffix, so a bare `_test` qualifies.
+
+    Degenerate but worth pinning: it is the boundary of what the name check accepts, and
+    it documents that the rule is "ends with `_test`" rather than "has a `_test` suffix
+    after some other name".
+    """
+    assert _is_disposable_database('postgresql://u:p@h:5432/_test', True) is True
+
+
+def test_a_name_merely_containing_test_is_not_enough() -> None:
+    """`osprey_testing` is not a test database, and neither is `latest`.
+
+    Guards against the suffix check being loosened to a substring one, which would make
+    every database with `test` anywhere in its name a candidate for deletion.
+    """
+    assert _is_disposable_database('postgresql://u:p@h:5432/osprey_testing', True) is False
+    assert _is_disposable_database('postgresql://u:p@h:5432/latest', True) is False

--- a/osprey_worker/src/osprey/worker/lib/tests/test_disposable_database.py
+++ b/osprey_worker/src/osprey/worker/lib/tests/test_disposable_database.py
@@ -10,20 +10,33 @@ The function is pure, so these need no database. They still pay for one: the ses
 fixture in the root conftest is autouse for the whole repository.
 """
 
-import contextlib
-
 import pytest
 from osprey.worker.lib.storage import postgres
 from osprey.worker.lib.tests.test_utils import _drop_database, _is_disposable_database
-from psycopg2.errors import ObjectInUse
+from psycopg2.errors import InvalidCatalogName, ObjectInUse
 from sqlalchemy import create_engine
-from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import OperationalError, ProgrammingError
 from sqlalchemy_utils import create_database
 
 #: The two URLs that actually appear in this repo's compose files. Named rather than
 #: inlined, because the whole point of the guard is telling these two apart.
 DEV_URL = 'postgresql://osprey:FoolishPassword@postgres:5432/osprey'
 TEST_URL = 'postgresql://osprey:FoolishPassword@postgres:5432/osprey_test'
+
+
+def _drop_if_present(url: str) -> None:
+    """Drop the database at `url`, tolerating it not being there.
+
+    Only that. A cleanup step that swallows everything hides the failure it should be
+    reporting -- a refused connection or a missing permission would surface later as a
+    confusing `DuplicateDatabase` from the next `create_database`, pointing at the wrong
+    thing entirely.
+    """
+    try:
+        _drop_database(url)
+    except ProgrammingError as error:
+        if not isinstance(error.orig, InvalidCatalogName):
+            raise
 
 
 @pytest.mark.parametrize(
@@ -95,8 +108,7 @@ def test_dropping_a_database_that_is_in_use_is_refused() -> None:
     # Dropped first and last: a failure part way through this test would otherwise leave
     # the scratch database behind, and the next run's `create_database` would collide
     # with it rather than reporting whatever actually went wrong.
-    with contextlib.suppress(Exception):
-        _drop_database(scratch_url)
+    _drop_if_present(scratch_url)
 
     scratch_engine = None
     try:
@@ -115,5 +127,4 @@ def test_dropping_a_database_that_is_in_use_is_refused() -> None:
     finally:
         if scratch_engine is not None:
             scratch_engine.dispose()
-        with contextlib.suppress(Exception):
-            _drop_database(scratch_url)
+        _drop_if_present(scratch_url)

--- a/osprey_worker/src/osprey/worker/lib/tests/test_utils.py
+++ b/osprey_worker/src/osprey/worker/lib/tests/test_utils.py
@@ -2,7 +2,7 @@ import os
 import textwrap
 from collections.abc import Callable, Iterator
 from typing import TYPE_CHECKING
-from urllib.parse import urlsplit
+from urllib.parse import urlsplit, urlunsplit
 
 import pytest
 from flask import Flask
@@ -13,6 +13,7 @@ from osprey.worker.lib.sources_provider import StaticSourcesProvider
 from osprey.worker.lib.sources_publisher import validate_and_push
 from osprey.worker.lib.storage import postgres
 from psycopg2.errors import DuplicateDatabase
+from sqlalchemy import create_engine, text
 from sqlalchemy.exc import ProgrammingError
 from sqlalchemy_utils import create_database, drop_database
 
@@ -26,25 +27,47 @@ if TYPE_CHECKING:
 _TEST_DATABASE_SUFFIX = '_test'
 
 
-def _is_disposable_database(url: str, created_by_this_run: bool) -> bool:
-    """Whether the session teardown may drop the database at `url`.
-
-    Both conditions are needed, because each alone leaves a hole. Dropping only what
-    this run created still destroys a developer's database when the run happens to be
-    the thing that created it -- a fresh Postgres volume, tests before first app start.
-    Trusting only the name still drops a `*_test` database somebody else was using.
+def _is_disposable_database(url: str) -> bool:
+    """Whether this fixture may destroy the database at `url`.
 
     This exists because the fixture used to drop whatever `POSTGRES_HOSTS` pointed at,
     and the compose files pointed the tests and the dev stack at the same `osprey`
     database. Running the suite therefore deleted the local development database, and
     the failure surfaced later and elsewhere -- as `osprey-ui-api` refusing to start --
     rather than as a test failure.
-    """
-    if not created_by_this_run:
-        return False
 
+    The name is the whole test. An earlier version also required that this run had
+    created the database, which was standing in for "somebody else may be using it" --
+    but the fixture now recreates an existing database at *setup* to guarantee the
+    schema matches the code, and that destroys a database in use just as thoroughly as
+    dropping it at teardown would. `_sessions_on_database` checks that condition
+    directly instead, which is both stronger and honest about what it is protecting.
+    """
     database_name = urlsplit(url).path.lstrip('/')
     return database_name.endswith(_TEST_DATABASE_SUFFIX)
+
+
+def _sessions_on_database(url: str) -> int:
+    """How many sessions other than ours are connected to the database at `url`.
+
+    Asked before dropping, because `sqlalchemy_utils.drop_database` does not fail when
+    a database is in use -- for Postgres it runs `pg_terminate_backend` against every
+    other session first and then drops it regardless. A second test run would be killed
+    silently and fail with connection errors that point nowhere near the cause.
+    """
+    parts = urlsplit(url)
+    maintenance_engine = create_engine(urlunsplit(parts._replace(path='/postgres')), isolation_level='AUTOCOMMIT')
+    try:
+        with maintenance_engine.connect() as connection:
+            return int(
+                connection.execute(
+                    text('SELECT count(*) FROM pg_stat_activity WHERE datname = :database AND pid <> pg_backend_pid()'),
+                    {'database': parts.path.lstrip('/')},
+                ).scalar()
+                or 0
+            )
+    finally:
+        maintenance_engine.dispose()
 
 
 def make_postgres_database_config_fixture() -> object:
@@ -65,16 +88,32 @@ def make_postgres_database_config_fixture() -> object:
         if url is None:
             pytest.fail('POSTGRES_HOSTS not configured')
 
-        created_by_this_run = True
         try:
             create_database(url)
         except ProgrammingError as e:
-            # If the database already exists, we're chill and have nothing left to do!
-            # This is a workaround to avoid calling `database_exists` as it is currently broken,
-            # see: https://github.com/kvesteri/sqlalchemy-utils/issues/472
+            # `create_database` is asked first and the failure inspected, rather than
+            # calling `database_exists`, which is broken:
+            # https://github.com/kvesteri/sqlalchemy-utils/issues/472
             if not isinstance(e.orig, DuplicateDatabase):
                 raise
-            created_by_this_run = False
+
+            # An existing database is recreated rather than reused. `metadata.create_all`
+            # below creates missing tables and never alters existing ones, so reusing one
+            # means every schema change since it was made is silently absent -- the tests
+            # then pass or fail against a schema nobody chose, and the cause is invisible.
+            if not _is_disposable_database(url):
+                pytest.fail(
+                    f'Refusing to run against an existing database that is not named '
+                    f'*{_TEST_DATABASE_SUFFIX}. Point POSTGRES_HOSTS at a test database.'
+                )
+            in_use = _sessions_on_database(url)
+            if in_use:
+                pytest.fail(
+                    f'The test database has {in_use} other session(s) connected, so it is '
+                    f'probably in use by another test run. Refusing to drop it.'
+                )
+            drop_database(url)
+            create_database(url)
 
         postgres.init_from_config('osprey_db')
 
@@ -82,7 +121,9 @@ def make_postgres_database_config_fixture() -> object:
 
         yield
 
-        if not _is_disposable_database(url, created_by_this_run):
+        # Always ours to drop by this point: setup either created the database or
+        # recreated it, so the only question left is the name.
+        if not _is_disposable_database(url):
             return
 
         try:

--- a/osprey_worker/src/osprey/worker/lib/tests/test_utils.py
+++ b/osprey_worker/src/osprey/worker/lib/tests/test_utils.py
@@ -1,5 +1,6 @@
 import os
 import textwrap
+import warnings
 from collections.abc import Callable, Iterator
 from typing import TYPE_CHECKING
 from urllib.parse import urlsplit, urlunsplit
@@ -12,10 +13,11 @@ from osprey.worker.lib.singletons import CONFIG, ENGINE
 from osprey.worker.lib.sources_provider import StaticSourcesProvider
 from osprey.worker.lib.sources_publisher import validate_and_push
 from osprey.worker.lib.storage import postgres
-from psycopg2.errors import DuplicateDatabase
+from psycopg2.errors import DuplicateDatabase, InvalidCatalogName, ObjectInUse
 from sqlalchemy import create_engine, text
-from sqlalchemy.exc import ProgrammingError
-from sqlalchemy_utils import create_database, drop_database
+from sqlalchemy.exc import OperationalError, ProgrammingError
+from sqlalchemy_utils import create_database
+from sqlalchemy_utils.functions.database import quote
 
 if TYPE_CHECKING:
     from _pytest.config import Config
@@ -40,32 +42,36 @@ def _is_disposable_database(url: str) -> bool:
     created the database, which was standing in for "somebody else may be using it" --
     but the fixture now recreates an existing database at *setup* to guarantee the
     schema matches the code, and that destroys a database in use just as thoroughly as
-    dropping it at teardown would. `_sessions_on_database` checks that condition
-    directly instead, which is both stronger and honest about what it is protecting.
+    dropping it at teardown would. `_drop_database` asks Postgres to refuse instead,
+    which is stronger than either: it is atomic, so there is no window between the
+    decision and the destruction.
     """
     database_name = urlsplit(url).path.lstrip('/')
     return database_name.endswith(_TEST_DATABASE_SUFFIX)
 
 
-def _sessions_on_database(url: str) -> int:
-    """How many sessions other than ours are connected to the database at `url`.
+def _drop_database(url: str) -> None:
+    """Drop the database at `url`, refusing if anything else is connected to it.
 
-    Asked before dropping, because `sqlalchemy_utils.drop_database` does not fail when
-    a database is in use -- for Postgres it runs `pg_terminate_backend` against every
-    other session first and then drops it regardless. A second test run would be killed
-    silently and fail with connection errors that point nowhere near the cause.
+    Deliberately not `sqlalchemy_utils.drop_database`: for Postgres that runs
+    `pg_terminate_backend` against every other session and then drops the database
+    anyway. A second test run would be killed and left failing with connection errors
+    that point nowhere near the cause.
+
+    Issuing `DROP DATABASE` ourselves lets Postgres refuse instead, and refuse
+    *atomically* -- there is no window between deciding the database is unused and
+    destroying it, which a check followed by a drop would leave open.
+
+    The two failure modes arrive as different SQLAlchemy wrappers, which is easy to get
+    wrong: in use raises `OperationalError` around `psycopg2.errors.ObjectInUse`, while
+    already-gone raises `ProgrammingError` around `InvalidCatalogName`.
     """
     parts = urlsplit(url)
+    database = parts.path.lstrip('/')
     maintenance_engine = create_engine(urlunsplit(parts._replace(path='/postgres')), isolation_level='AUTOCOMMIT')
     try:
         with maintenance_engine.connect() as connection:
-            return int(
-                connection.execute(
-                    text('SELECT count(*) FROM pg_stat_activity WHERE datname = :database AND pid <> pg_backend_pid()'),
-                    {'database': parts.path.lstrip('/')},
-                ).scalar()
-                or 0
-            )
+            connection.execute(text(f'DROP DATABASE {quote(connection, database)}'))
     finally:
         maintenance_engine.dispose()
 
@@ -106,13 +112,16 @@ def make_postgres_database_config_fixture() -> object:
                     f'Refusing to run against an existing database that is not named '
                     f'*{_TEST_DATABASE_SUFFIX}. Point POSTGRES_HOSTS at a test database.'
                 )
-            in_use = _sessions_on_database(url)
-            if in_use:
+            try:
+                _drop_database(url)
+            except OperationalError as drop_error:
+                if not isinstance(drop_error.orig, ObjectInUse):
+                    raise
                 pytest.fail(
-                    f'The test database has {in_use} other session(s) connected, so it is '
-                    f'probably in use by another test run. Refusing to drop it.'
+                    'The test database is in use, so another test run probably has it. Only '
+                    'one run at a time is supported: run-tests.sh pins a single compose '
+                    'project, so concurrent runs share the containers as well as this database.'
                 )
-            drop_database(url)
             create_database(url)
 
         postgres.init_from_config('osprey_db')
@@ -126,14 +135,28 @@ def make_postgres_database_config_fixture() -> object:
         if not _is_disposable_database(url):
             return
 
-        try:
-            drop_database(url)
-        except ProgrammingError as e:
-            # Don't fail if the database is already closed
-            from psycopg2.errors import InvalidCatalogName
+        # Our own pooled connections are connections like any other, and `_drop_database`
+        # refuses rather than terminating them, so they have to go first. Whatever is
+        # still attached after this belongs to somebody else.
+        session_maker = postgres.sessions.get('osprey_db')
+        engine = session_maker.kw.get('bind') if session_maker is not None else None
+        if engine is not None:
+            engine.dispose()
 
-            if not isinstance(e.orig, InvalidCatalogName):
-                raise
+        try:
+            _drop_database(url)
+        except (OperationalError, ProgrammingError) as e:
+            if isinstance(e.orig, InvalidCatalogName):
+                return  # already gone; nothing to do
+            if isinstance(e.orig, ObjectInUse):
+                # Left behind rather than destroyed. The next run recreates it at setup,
+                # so this costs nothing but is worth saying out loud.
+                warnings.warn(
+                    f'Leaving the test database in place: something is still connected to it. {e.orig}',
+                    stacklevel=2,
+                )
+                return
+            raise
 
     return postgres_database_config
 

--- a/osprey_worker/src/osprey/worker/lib/tests/test_utils.py
+++ b/osprey_worker/src/osprey/worker/lib/tests/test_utils.py
@@ -2,6 +2,7 @@ import os
 import textwrap
 from collections.abc import Callable, Iterator
 from typing import TYPE_CHECKING
+from urllib.parse import urlsplit
 
 import pytest
 from flask import Flask
@@ -18,6 +19,32 @@ from sqlalchemy_utils import create_database, drop_database
 if TYPE_CHECKING:
     from _pytest.config import Config
     from _pytest.fixtures import FixtureRequest
+
+
+#: Databases this fixture is willing to destroy. Anything not named like this is
+#: assumed to belong to a human.
+_TEST_DATABASE_SUFFIX = '_test'
+
+
+def _is_disposable_database(url: str, created_by_this_run: bool) -> bool:
+    """Whether the session teardown may drop the database at `url`.
+
+    Both conditions are needed, because each alone leaves a hole. Dropping only what
+    this run created still destroys a developer's database when the run happens to be
+    the thing that created it -- a fresh Postgres volume, tests before first app start.
+    Trusting only the name still drops a `*_test` database somebody else was using.
+
+    This exists because the fixture used to drop whatever `POSTGRES_HOSTS` pointed at,
+    and the compose files pointed the tests and the dev stack at the same `osprey`
+    database. Running the suite therefore deleted the local development database, and
+    the failure surfaced later and elsewhere -- as `osprey-ui-api` refusing to start --
+    rather than as a test failure.
+    """
+    if not created_by_this_run:
+        return False
+
+    database_name = urlsplit(url).path.lstrip('/')
+    return database_name.endswith(_TEST_DATABASE_SUFFIX)
 
 
 def make_postgres_database_config_fixture() -> object:
@@ -38,6 +65,7 @@ def make_postgres_database_config_fixture() -> object:
         if url is None:
             pytest.fail('POSTGRES_HOSTS not configured')
 
+        created_by_this_run = True
         try:
             create_database(url)
         except ProgrammingError as e:
@@ -46,12 +74,16 @@ def make_postgres_database_config_fixture() -> object:
             # see: https://github.com/kvesteri/sqlalchemy-utils/issues/472
             if not isinstance(e.orig, DuplicateDatabase):
                 raise
+            created_by_this_run = False
 
         postgres.init_from_config('osprey_db')
 
         config.unconfigure_for_tests()
 
         yield
+
+        if not _is_disposable_database(url, created_by_this_run):
+            return
 
         try:
             drop_database(url)

--- a/osprey_worker/src/osprey/worker/sinks/conftest.py
+++ b/osprey_worker/src/osprey/worker/sinks/conftest.py
@@ -2,8 +2,3 @@
 from osprey.worker.lib.patcher import patch_all
 
 patch_all(patch_gevent=False, patch_ddtrace=False)  # please ensure this occurs before *any* other imports !
-
-
-from osprey.worker.lib.tests import test_utils
-
-postgres_database_config = test_utils.make_postgres_database_config_fixture()

--- a/osprey_worker/src/osprey/worker/ui_api/osprey/conftest.py
+++ b/osprey_worker/src/osprey/worker/ui_api/osprey/conftest.py
@@ -67,9 +67,6 @@ def app_with_rules_sources(request: 'FixtureRequest') -> Iterator[Flask]:
         CONFIG.instance().unconfigure_for_tests()
 
 
-postgres_database_config = test_utils.make_postgres_database_config_fixture()
-
-
 def pytest_configure(config: 'Config') -> None:
     test_utils.add_use_rules_sources(config)
 

--- a/run-tests-local.sh
+++ b/run-tests-local.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Run the Python tests on the host, against an already-running dev stack.
+#
+# Contrast ./run-tests.sh, which runs them inside a container in an isolated compose
+# project -- that is what CI does, and it is the one to use when you want the tests to
+# be unaffected by local state. This script is for a fast edit-run loop: it reuses the
+# stack you already have up and talks to its exposed ports.
+#
+# The database is `osprey_test`, NOT the `osprey` one the dev stack runs on. The
+# session fixture in lib/tests/test_utils.py drops the database it created, so pointing
+# this at `osprey` would delete your development data and leave osprey-ui-api unable to
+# start. The fixture refuses to drop a database that isn't named `*_test`, but there is
+# no reason to rely on that.
+#
+# Usage: ./run-tests-local.sh [pytest args...]
+#   ./run-tests-local.sh osprey_worker/src/osprey/worker/ui_api -q
+
+set -euo pipefail
+
+export PYTHONPATH=.
+export TESTING=true
+export POSTGRES_HOSTS='{"osprey_db":"postgresql://osprey:FoolishPassword@127.0.0.1:5432/osprey_test"}'
+export SNOWFLAKE_API_ENDPOINT=http://127.0.0.1:8088
+export SNOWFLAKE_EPOCH=1420070400000
+export OSPREY_RULES_PATH=./example_rules
+export OSPREY_DISABLE_VALIDATION_EXPORTER=true
+export OSPREY_EXECUTION_RESULT_STORAGE_BACKEND=minio
+export OSPREY_MINIO_ENDPOINT=127.0.0.1:9000
+export OSPREY_MINIO_ACCESS_KEY=minioadmin
+export OSPREY_MINIO_SECRET_KEY=minioadmin123
+export OSPREY_MINIO_SECURE=false
+export OSPREY_MINIO_EXECUTION_RESULTS_BUCKET=execution-output
+
+exec uv run pytest "${@}"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,3 +1,11 @@
 #!/bin/bash
 
-docker compose -f docker-compose.yaml -f docker-compose.test.yaml --profile test run --rm -T test_runner run-tests "${@}"
+# `-p osprey-test` is load-bearing. docker-compose.test.yaml clears `container_name`,
+# `ports` and `volumes` on the shared services so a test stack can coexist with a
+# running dev stack -- but that only works if the two are separate compose *projects*.
+# Without an explicit project name, compose derives one from the directory (`osprey`),
+# which is the dev stack's project, so the overrides are applied to the dev containers:
+# postgres gets recreated with no host port and, worse, no volume. That silently
+# destroys the local development database and leaves osprey-ui-api unable to connect.
+docker compose -p osprey-test -f docker-compose.yaml -f docker-compose.test.yaml \
+  --profile test run --rm -T test_runner run-tests "${@}"

--- a/stop-tests.sh
+++ b/stop-tests.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Stops the isolated test stack that ./run-tests.sh leaves running.
+#
+# `-p osprey-test` is load-bearing here for the same reason it is in run-tests.sh, and
+# omitting it is worse on this side: without an explicit project name compose derives
+# one from the directory (`osprey`), which is the dev stack's project -- so this would
+# tear down your running development containers instead of the test ones.
+#
+# `docker compose run --rm` removes only test_runner, so postgres, kafka, etcd, minio
+# and snowflake-id-worker stay up between runs. That is usually what you want, since
+# they take tens of seconds to become healthy again and the test database is recreated
+# per session regardless. This is for when you want the resources back.
+#
+# `--volumes` is deliberately not passed: docker-compose.test.yaml resets `volumes` on
+# postgres and minio, so their data lives in the container layer and there are no
+# `osprey-test_*` volumes to remove. Pass it yourself if that ever stops being true.
+docker compose -p osprey-test -f docker-compose.yaml -f docker-compose.test.yaml \
+  --profile test down --remove-orphans "${@}"


### PR DESCRIPTION
## Description

Noticed whilst I was working on #490, that running the tests with `./run-tests.sh` was actually resulting in the running development servers' postgresql database being deleted. This completely isolates tests from development by using a separate database `osprey_test` instead of `osprey`, and gives the test suite ownership of that database's lifecycle rather than reusing whatever it finds.

Also adds a `./run-tests-local.sh` which allows running the tests against an already running test compose setup, which runs in the local python interpreter set by uv, which makes running the tests a bit quicker as you're not waiting for the docker compose setup to report status.

### What changed

- **Test containers run in their own Compose project** (`-p osprey-test`), so the test overrides can't be applied to the dev stack's containers. Without an explicit project name, Compose derives one from the directory — which is the dev project — and postgres gets recreated with no volume.
- **A guard on which database may be destroyed.** Only a database whose name ends in `_test` is ever dropped, so pointing `POSTGRES_HOSTS` at `osprey` can't delete it. Covered by `test_disposable_database.py`.
- **The session fixture owns the database.** It now lives in the root `conftest.py` and recreates an existing test database rather than reusing it, so the schema always matches the code.
- **`POSTGRES_DB=osprey_test` removed from `docker-compose.test.yaml`**, since the ordering problem it worked around is gone.
- **`./stop-tests.sh`** to tear the test stack down, so stopping it is as safe as starting it — the `-p osprey-test` hazard is symmetric, and previously only the running side was wrapped.

## Checklist

- [x] Tests pass locally
- [x] `uv run ruff check .` passes (no unused imports or other lint errors)
- [x] `uv tool run fawltydeps --check-unused --pyenv .venv` passes (no unused dependencies)
- [x] Updated `CHANGELOG.md` with my changes, if notable (refer to [Keep a Changelog](https://keepachangelog.com/en/2.0.0/) conventions)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Test environments now use a dedicated database, preventing accidental connections to development data.
  - Test database setup and cleanup now safely handle active connections and failed test runs.
  - Test configuration cleanup now runs reliably even when tests fail.

- **Chores**
  - Added scripts for running tests against local services and stopping the isolated test stack.
  - Test containers now use a separate Compose project.

- **Documentation**
  - Added guidance for safely managing persistent test containers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
