### PR TITLE
Improve dev user selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -309,3 +309,7 @@ Cargo.lock
 
 # docs output
 book/
+
+# Local ACL role assignments for development. Absent, every email resolves to
+# SUPER_USER; present, only the emails listed get anything at all.
+osprey_worker/src/osprey/worker/lib/acls/dev_acl_assignments.json

--- a/osprey_worker/src/osprey/worker/ui_api/osprey/lib/auth.py
+++ b/osprey_worker/src/osprey/worker/ui_api/osprey/lib/auth.py
@@ -2,13 +2,39 @@ from __future__ import annotations
 
 from flask import Flask, request
 from osprey.worker.lib.osprey_shared.logging import get_logger
+from osprey.worker.lib.singletons import CONFIG
 from osprey.worker.ui_api.osprey.lib.users import User
 
 logger = get_logger(__name__)
 
 
+#: Who a request is from when nothing says otherwise. Every test fixture grants its
+#: abilities to this address, so changing the constant breaks the whole suite -- set
+#: `OSPREY_DEV_USER_EMAIL` instead.
+DEFAULT_DEV_USER_EMAIL = 'local-dev@localhost'
+
+
 def set_dummy_claim() -> None:
-    set_claims({'email': request.headers.get('X-Test-Email', 'local-dev@localhost')})
+    """Attach an identity to the request. There is no authentication here.
+
+    Two ways to be someone else, in order of precedence:
+
+    - `X-Test-Email` on the request, which changes the caller for that one request. Good
+      for driving a second role from curl while a browser stays signed in as the first.
+    - `OSPREY_DEV_USER_EMAIL`, which changes the default for the whole process. Good for
+      booting the stack *as* a particular user, e.g. to see the UI an author without
+      `CAN_DEPLOY_RULES` actually gets.
+
+    Both exist so nobody has to edit this function to switch user. Editing it changes
+    the default the test suite depends on, and every fixture grants abilities to
+    `DEFAULT_DEV_USER_EMAIL` -- so a local edit here fails ~78 tests that have nothing
+    to do with auth, which is a genuinely confusing hour.
+
+    Note this trusts a client-supplied header: identity here is asserted, not verified.
+    Abilities are enforced against whatever the caller claims to be.
+    """
+    default_email = CONFIG.instance().get_str('OSPREY_DEV_USER_EMAIL', DEFAULT_DEV_USER_EMAIL)
+    set_claims({'email': request.headers.get('X-Test-Email', default_email)})
 
 
 def set_claims(claims: dict[object, object]) -> None:


### PR DESCRIPTION
## Description

There is no authentication in the UI API: `set_dummy_claim` attaches whatever identity the request claims, defaulting to local-dev@localhost. Testing what a less-privileged user sees therefore meant editing that default in place, which breaks every authz test in the suite -- they all grant their abilities to `local-dev@localhost`, so the change lands as ~78 failures in tests that have nothing to do with auth.

There are now two ways to be someone else without touching the source: `OSPREY_DEV_USER_EMAIL` changes the default for the process, so the stack can be booted as a particular user and the browser follows; `X-Test-Email` still changes it for one request, so a second role can be driven from curl alongside.

`dev_acl_assignments.json` is gitignored: committing it would silently stop every developer being a super user, and its absence is what makes a fresh checkout work.

I'm considering this a somewhat temporary fix until we properly address authn/authz in osprey in general, I just needed a quick way to switch between two different users to test out UI only being accessible to some users.

## Checklist

- [x] Tests pass locally
- [x] `uv run ruff check .` passes (no unused imports or other lint errors)
- [x] `uv tool run fawltydeps --check-unused --pyenv .venv` passes (no unused dependencies)
- [x] Updated `CHANGELOG.md` with my changes, if notable (refer to [Keep a Changelog](https://keepachangelog.com/en/2.0.0/) conventions)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Local development authentication now supports configuring the default user identity through an environment setting.
  - Individual test requests can continue to specify a different identity, taking precedence over the configured default.
  - Added clearer guidance for unauthenticated development requests and identity configuration.
- **Chores**
  - Local development access-assignment files are now excluded from version control to help prevent environment-specific permissions from being committed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->