### PR TITLE
Simplify request body handling

### DIFF
--- a/osprey_worker/src/osprey/worker/ui_api/osprey/lib/marshal.py
+++ b/osprey_worker/src/osprey/worker/ui_api/osprey/lib/marshal.py
@@ -12,12 +12,98 @@ from typing_extensions import Protocol
 T = TypeVar('T', bound='Marshallable')
 
 
+class UnreadableRequestBody(Exception):
+    """The request didn't arrive as JSON this API can read.
+
+    Raised by `json_object_body`, mapped to a 400 by `marshal_with`, so a marshaller
+    stays out of the business of building responses.
+
+    `message` is what the client is told, and it is a class attribute rather than a
+    constructor argument so that every string a caller can see is written here. Sending
+    `str(err)` instead would put the text under the control of whichever raise site ran,
+    and the natural thing to interpolate at a raise site is something off the request --
+    which is how an error message becomes a way to read server state back out. The same
+    reasoning keeps the configured path off `RulesDirNotADirectory`'s message in
+    `lib/rule_deployment`, where CodeQL flagged it as code-scanning/26.
+
+    Subclassed per failure so the client learns which of the two it hit without any of
+    them being assembled from the request.
+    """
+
+    message = 'Request body could not be read as JSON.'
+
+
+class RequestBodyNotDeclaredJson(UnreadableRequestBody):
+    message = 'A request body must be sent with Content-Type: application/json.'
+
+
+class RequestBodyNotAnObject(UnreadableRequestBody):
+    message = 'Request body must be a JSON object.'
+
+
+# The methods that carry no body, so nothing sent on one is read. Written as the
+# bodyless set rather than the submitting one so the default is to check: a method not
+# named here is treated as able to carry a body, and anything it sends has to hold up.
+_BODYLESS_METHODS = frozenset({'GET', 'HEAD', 'DELETE'})
+
+
+def json_object_body(flask_request: Request) -> dict[str, Any]:
+    """The request's JSON object body, or `{}` if it carried none.
+
+    Every marshaller that reads a body reads it through here, because "what counts as a
+    body" is the same question every time and it is easy to answer differently by
+    accident. It used to be answered separately in four places, which between them
+    dropped unlabelled bodies on the floor, returned 200 for bodies that never parsed,
+    and raised `TypeError` -- a 500 -- on a body that was a JSON list.
+
+    The difficulty is that `get_json` answers `None` to three different questions: a
+    body that wasn't labelled `application/json`, a body that didn't parse, and no body
+    at all. Reading `None` as "the caller sent nothing" collapses the first two into the
+    third, so a request whose body was dropped is answered as though it had asked for
+    the defaults -- and the endpoint reports success for work it did not do.
+
+    So the question asked here is whether bytes arrived, not which method carried them.
+    If they did, they must be declared JSON and must parse to an object. If they didn't,
+    the model's own fields decide whether that was allowed: a field with a default is
+    satisfied, and a required one produces pydantic's own error without this function
+    having an opinion about it.
+
+    GET, HEAD and DELETE carry no body, so anything sent on one is not read at all.
+    """
+    if flask_request.method in _BODYLESS_METHODS or not flask_request.get_data().strip():
+        return {}
+
+    if not flask_request.is_json:
+        raise RequestBodyNotDeclaredJson()
+
+    body = flask_request.get_json()
+    if not isinstance(body, dict):
+        raise RequestBodyNotAnObject()
+
+    return body
+
+
 class Marshallable(Protocol):
     @classmethod
     def marshal(cls: Type[T], flask_request: Request) -> T: ...
 
     @classmethod
     def parse_obj(cls: Type[T], obj: Any) -> T: ...
+
+
+class MarshallableWithOverrides(Marshallable, Protocol):
+    """A `Marshallable` that also says which of its fields don't come from the body.
+
+    Separate from `Marshallable` so that arg-only marshallers -- which never read a body
+    and so have nothing to override it with -- aren't made to declare a hook they don't
+    use. `marshal_with` only ever needs `Marshallable`.
+    """
+
+    @classmethod
+    def overrides(cls, flask_request: Request) -> dict[str, Any]: ...
+
+
+TOverriding = TypeVar('TOverriding', bound='MarshallableWithOverrides')
 
 
 class FlaskRequestMarshaller(ABC):
@@ -31,9 +117,26 @@ class FlaskRequestMarshaller(ABC):
 
 
 class JsonBodyMarshaller(FlaskRequestMarshaller):
+    """A JSON object body, with whatever `overrides` reads elsewhere merged over it.
+
+    Subclasses supply `overrides` rather than a `marshal` of their own, so reading the
+    body is not a question anyone has to answer twice: a marshaller written against this
+    base never touches the body API, and so cannot get it wrong. What varies between
+    marshallers is only where their *other* fields come from.
+
+    `overrides` wins collisions. What it reads comes from the URL, which is what a
+    reviewer reads and what the audit log records, so a body key must not be able to
+    disagree with it.
+    """
+
     @classmethod
-    def marshal(cls: Type[T], flask_request: Request) -> T:
-        return cls.parse_obj(request.get_json(force=True))
+    def overrides(cls, flask_request: Request) -> dict[str, Any]:
+        """Fields read from somewhere other than the body -- the URL, usually."""
+        return {}
+
+    @classmethod
+    def marshal(cls: Type[TOverriding], flask_request: Request) -> TOverriding:
+        return cls.parse_obj({**json_object_body(flask_request), **cls.overrides(flask_request)})
 
 
 class ArgMarshaller(FlaskRequestMarshaller):
@@ -48,10 +151,12 @@ class ViewArgMarshaller(FlaskRequestMarshaller):
         return cls.parse_obj(request.view_args)
 
 
-class ViewArgAndJsonBodyMarshaller(FlaskRequestMarshaller):
+class ViewArgAndOptionalJsonBodyMarshaller(JsonBodyMarshaller):
+    """A JSON object body addressed by URL: the view args win any collision."""
+
     @classmethod
-    def marshal(cls: Type[T], flask_request: Request) -> T:
-        return cls.parse_obj({**request.view_args, **request.get_json(force=True)})
+    def overrides(cls, flask_request: Request) -> dict[str, Any]:
+        return flask_request.view_args or {}
 
 
 class ArgAndViewArgMarshaller(FlaskRequestMarshaller):
@@ -62,7 +167,7 @@ class ArgAndViewArgMarshaller(FlaskRequestMarshaller):
 
 def marshal_with(model: Type[T]) -> Callable[[Callable[[T], Any]], Callable[[T], Any]]:
     """
-    Decorator for flask view functions that marshals the incomming request data into a validated pydantic model
+    Decorator for flask view functions that marshals the incoming request data into a validated pydantic model
 
     The pydantic `model` must be mixed in with a `FlaskRequestMarshaller`
     """
@@ -72,6 +177,17 @@ def marshal_with(model: Type[T]) -> Callable[[Callable[[T], Any]], Callable[[T],
         def decorated_function(*args: Any, **kwargs: Any) -> Any:
             try:
                 model_instance = model.marshal(request)
+            except UnreadableRequestBody as err:
+                # `err.message`, not `str(err)`: the text sent back is a class attribute
+                # on the exception, so nothing read off the request can be reflected into
+                # a response body. See `UnreadableRequestBody`.
+                #
+                # Not reported to Sentry, unlike the validation errors below: a request
+                # that isn't JSON never reached the model, so there is no field-level
+                # detail to capture, and it says nothing about this service.
+                response = jsonify({'error': err.message})
+                response.status_code = HTTPStatus.BAD_REQUEST
+                abort(response)
             except ValidationError as err:
                 response = jsonify(err.errors())
                 capture_exception(err)

--- a/osprey_worker/src/osprey/worker/ui_api/osprey/lib/marshal.py
+++ b/osprey_worker/src/osprey/worker/ui_api/osprey/lib/marshal.py
@@ -84,11 +84,22 @@ def json_object_body(flask_request: Request) -> dict[str, Any]:
 
 
 class Marshallable(Protocol):
-    @classmethod
-    def marshal(cls: Type[T], flask_request: Request) -> T: ...
+    """What `marshal_with` needs of a request model: something that can read a request.
+
+    The methods below are bodied by their docstrings rather than by `...`. Both are
+    valid, and neither ever runs -- a `Protocol` is structural, so nothing dispatches to
+    these -- but CodeQL reads a bare `...` as a statement with no effect, and a docstring
+    says what the method is for while it satisfies the checker. Not `raise
+    NotImplementedError`, which would imply a runtime dispatch that cannot happen here.
+    """
 
     @classmethod
-    def parse_obj(cls: Type[T], obj: Any) -> T: ...
+    def marshal(cls: Type[T], flask_request: Request) -> T:
+        """Build the model from `flask_request`, however this model sources its fields."""
+
+    @classmethod
+    def parse_obj(cls: Type[T], obj: Any) -> T:
+        """Validate a mapping into the model. Supplied by pydantic's `BaseModel`."""
 
 
 class MarshallableWithOverrides(Marshallable, Protocol):
@@ -100,7 +111,8 @@ class MarshallableWithOverrides(Marshallable, Protocol):
     """
 
     @classmethod
-    def overrides(cls, flask_request: Request) -> dict[str, Any]: ...
+    def overrides(cls, flask_request: Request) -> dict[str, Any]:
+        """Fields read from somewhere other than the body -- the URL, usually."""
 
 
 TOverriding = TypeVar('TOverriding', bound='MarshallableWithOverrides')

--- a/osprey_worker/src/osprey/worker/ui_api/osprey/lib/tests/test_marshal.py
+++ b/osprey_worker/src/osprey/worker/ui_api/osprey/lib/tests/test_marshal.py
@@ -11,6 +11,8 @@ The app here is a bare `Flask`, not the osprey one: none of this needs a databas
 engine, or an authenticated user.
 """
 
+from typing import Any
+
 import pytest
 from flask import Flask, jsonify, request
 from osprey.worker.ui_api.osprey.lib.marshal import (
@@ -55,8 +57,8 @@ def _by_url_view(model: _AddressedByUrl) -> object:
     return jsonify(model.dict())
 
 
-def _read_body(**request_kwargs: object) -> dict:
-    with app.test_request_context('/', **request_kwargs):  # type: ignore[arg-type]
+def _read_body(**request_kwargs: Any) -> dict:
+    with app.test_request_context('/', **request_kwargs):
         return json_object_body(request)
 
 

--- a/osprey_worker/src/osprey/worker/ui_api/osprey/lib/tests/test_marshal.py
+++ b/osprey_worker/src/osprey/worker/ui_api/osprey/lib/tests/test_marshal.py
@@ -1,0 +1,221 @@
+"""`lib/marshal`: what counts as a request body, and which source wins a collision.
+
+Unit tests rather than endpoint tests. Every marshaller in this API reads its body
+through `json_object_body`, so the rules are proved here once instead of being
+re-proved against whichever endpoint happens to use them -- which is how four
+hand-rolled `marshal()` implementations came to disagree with each other in the first
+place. `views/tests` keeps only the thin checks that the wiring is in place: that a
+refusal reaches the client as a 400 with no side effect behind it.
+
+The app here is a bare `Flask`, not the osprey one: none of this needs a database, an
+engine, or an authenticated user.
+"""
+
+import pytest
+from flask import Flask, jsonify, request
+from osprey.worker.ui_api.osprey.lib.marshal import (
+    JsonBodyMarshaller,
+    RequestBodyNotAnObject,
+    RequestBodyNotDeclaredJson,
+    ViewArgAndOptionalJsonBodyMarshaller,
+    json_object_body,
+    marshal_with,
+)
+from pydantic import BaseModel
+from werkzeug.exceptions import BadRequest
+
+JSON = 'application/json'
+FORM = 'application/x-www-form-urlencoded'
+
+app = Flask(__name__)
+
+
+class _BodyOnly(BaseModel, JsonBodyMarshaller):
+    """No overrides: every field comes from the body."""
+
+    name: str = 'unset'
+
+
+class _AddressedByUrl(BaseModel, ViewArgAndOptionalJsonBodyMarshaller):
+    """`thing_id` is in the path, so the body must not be able to choose it."""
+
+    thing_id: int
+    name: str = 'unset'
+
+
+@app.route('/body', methods=['POST'])
+@marshal_with(_BodyOnly)
+def _body_view(model: _BodyOnly) -> object:
+    return jsonify(model.dict())
+
+
+@app.route('/thing/<int:thing_id>', methods=['POST'])
+@marshal_with(_AddressedByUrl)
+def _by_url_view(model: _AddressedByUrl) -> object:
+    return jsonify(model.dict())
+
+
+def _read_body(**request_kwargs: object) -> dict:
+    with app.test_request_context('/', **request_kwargs):  # type: ignore[arg-type]
+        return json_object_body(request)
+
+
+# --------------------------------------------------------------------------- #
+# json_object_body
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ('name', 'request_kwargs', 'expected'),
+    [
+        ('no body at all', {'method': 'POST'}, {}),
+        ('declared JSON, empty body', {'method': 'POST', 'content_type': JSON, 'data': ''}, {}),
+        ('declared JSON, whitespace body', {'method': 'POST', 'content_type': JSON, 'data': ' \n '}, {}),
+        ('declared JSON, object body', {'method': 'POST', 'content_type': JSON, 'data': '{"a": 1}'}, {'a': 1}),
+        ('empty JSON object', {'method': 'POST', 'content_type': JSON, 'data': '{}'}, {}),
+        ('GET carrying a body', {'method': 'GET', 'content_type': JSON, 'data': '{"a": 1}'}, {}),
+        ('HEAD carrying a body', {'method': 'HEAD', 'content_type': JSON, 'data': '{"a": 1}'}, {}),
+        ('DELETE carrying a body', {'method': 'DELETE', 'content_type': JSON, 'data': '{"a": 1}'}, {}),
+    ],
+    ids=[
+        'no-body',
+        'declared-empty',
+        'declared-whitespace',
+        'object',
+        'empty-object',
+        'get-with-body',
+        'head-with-body',
+        'delete-with-body',
+    ],
+)
+def test_json_object_body_reads_an_object_or_answers_nothing(name: str, request_kwargs: dict, expected: dict) -> None:
+    """Sending nothing is allowed; what "nothing" means is decided here, not per model.
+
+    An empty body is not a parse failure even though `json.loads('')` raises like one --
+    a caller that set the content type out of habit and sent nothing is still a caller
+    who sent nothing. Whether that was permitted is then the model's business: a field
+    with a default is satisfied and a required one produces pydantic's own error.
+
+    GET, HEAD and DELETE carry no body, so one sent anyway is not read at all rather
+    than read and merged.
+    """
+    assert _read_body(**request_kwargs) == expected, name
+
+
+@pytest.mark.parametrize(
+    ('name', 'request_kwargs', 'raises'),
+    [
+        ('object body with no content type', {'data': '{"a": 1}'}, RequestBodyNotDeclaredJson),
+        (
+            'object body declared text/plain',
+            {'content_type': 'text/plain', 'data': '{"a": 1}'},
+            RequestBodyNotDeclaredJson,
+        ),
+        ('form-encoded body', {'content_type': FORM, 'data': 'a=1'}, RequestBodyNotDeclaredJson),
+        ('declared JSON that does not parse', {'content_type': JSON, 'data': '{"a": tru'}, BadRequest),
+        ('JSON array', {'content_type': JSON, 'data': '[1, 2]'}, RequestBodyNotAnObject),
+        ('JSON string', {'content_type': JSON, 'data': '"a"'}, RequestBodyNotAnObject),
+        ('JSON number', {'content_type': JSON, 'data': '1'}, RequestBodyNotAnObject),
+        ('JSON null', {'content_type': JSON, 'data': 'null'}, RequestBodyNotAnObject),
+    ],
+    ids=['undeclared', 'text-plain', 'form', 'unparseable', 'array', 'string', 'number', 'null'],
+)
+def test_json_object_body_refuses_a_body_it_cannot_use(
+    name: str, request_kwargs: dict, raises: type[Exception]
+) -> None:
+    """Bytes arrived and could not be applied, so the request is refused, not defaulted.
+
+    Each of these used to end as a silent success somewhere in this app: `get_json`
+    answers `None` for the first three, which read as "no body" and dropped what the
+    caller sent, and the last four parsed into something that could not be spread into a
+    model -- which `EntityMarshaller` did anyway, raising `TypeError` for a 500.
+
+    The unparseable case raises werkzeug's `BadRequest` rather than
+    `UnreadableRequestBody`, because it comes from `get_json` itself. Both end as a 400,
+    but by different routes and with different response bodies; unifying that means
+    overriding `Request.on_json_loading_failed` app-wide.
+    """
+    with pytest.raises(raises):
+        _read_body(method='POST', **request_kwargs)
+
+
+# --------------------------------------------------------------------------- #
+# The marshaller family
+# --------------------------------------------------------------------------- #
+
+
+def test_a_marshaller_with_no_overrides_takes_everything_from_the_body() -> None:
+    with app.test_client() as client:
+        res = client.post('/body', json={'name': 'from-body'})
+
+    assert res.status_code == 200, res.data
+    assert res.json == {'name': 'from-body'}
+
+
+def test_a_marshaller_falls_back_to_its_defaults_when_no_body_is_sent() -> None:
+    """The optional-body case: nothing sent, so every field keeps its default."""
+    with app.test_client() as client:
+        res = client.post('/body')
+
+    assert res.status_code == 200, res.data
+    assert res.json == {'name': 'unset'}
+
+
+def test_overrides_win_a_collision_with_the_body() -> None:
+    """The URL selects the row; a body key of the same name must not be able to move it.
+
+    `overrides` is merged last for exactly this reason. With the body last, a request to
+    `/thing/1` carrying `{"thing_id": 2}` would act on 2 while the URL, the logs and any
+    audit record all said 1.
+    """
+    with app.test_client() as client:
+        res = client.post('/thing/1', json={'thing_id': 2, 'name': 'from-body'})
+
+    assert res.status_code == 200, res.data
+    assert res.json == {'thing_id': 1, 'name': 'from-body'}
+
+
+def test_overrides_still_apply_when_no_body_is_sent() -> None:
+    with app.test_client() as client:
+        res = client.post('/thing/7')
+
+    assert res.status_code == 200, res.data
+    assert res.json == {'thing_id': 7, 'name': 'unset'}
+
+
+@pytest.mark.parametrize(
+    ('name', 'post_kwargs'),
+    [
+        ('a body that is not an object', {'data': '[1, 2]', 'content_type': JSON}),
+        ('a body that does not parse', {'data': '{"a": tru', 'content_type': JSON}),
+        ('a body with no content type', {'data': '{"name": "x"}'}),
+    ],
+    ids=['array', 'unparseable', 'undeclared'],
+)
+def test_marshal_with_turns_an_unusable_body_into_a_400(name: str, post_kwargs: dict) -> None:
+    """The refusal reaches the client as a 400 rather than escaping as a 500.
+
+    `UnreadableRequestBody` is not an `HTTPException`, so this pins that `marshal_with`
+    catches it -- without that, every refusal above would be an unhandled exception.
+    """
+    with app.test_client() as client:
+        res = client.post('/body', **post_kwargs)
+
+    assert res.status_code == 400, (name, res.data)
+
+
+def test_the_error_a_client_is_shown_is_a_constant_not_the_request() -> None:
+    """The 400 body is the exception's class attribute, so it can't reflect the request.
+
+    `str(err)` here would make the response text whatever a raise site passed in, and the
+    tempting thing to pass in is something read off the request. That is the shape CodeQL
+    flagged as code-scanning/26 elsewhere in this API, so this pins that the message a
+    client sees is fixed text and that nothing sent in the request comes back out.
+    """
+    with app.test_client() as client:
+        res = client.post('/body', data='{"secret": "hunter2"}', content_type='text/plain')
+
+    assert res.status_code == 400
+    assert res.json == {'error': RequestBodyNotDeclaredJson.message}
+    assert b'hunter2' not in res.data
+    assert b'text/plain' not in res.data

--- a/osprey_worker/src/osprey/worker/ui_api/osprey/validators/entities.py
+++ b/osprey_worker/src/osprey/worker/ui_api/osprey/validators/entities.py
@@ -1,22 +1,28 @@
 from datetime import datetime
-from typing import Type
+from typing import Any
 
 from flask import Request
 from osprey.engine.language_types.entities import EntityT
 from osprey.worker.lib.osprey_shared.labels import LabelStatus
 from osprey.worker.ui_api.osprey.lib.druid import TimeseriesDruidQuery
-from osprey.worker.ui_api.osprey.lib.marshal import FlaskRequestMarshaller, T
+from osprey.worker.ui_api.osprey.lib.marshal import JsonBodyMarshaller
 from pydantic import BaseModel
 
 
-class EntityMarshaller(FlaskRequestMarshaller):
+class EntityMarshaller(JsonBodyMarshaller):
+    """The entity is addressed by query string; everything else comes from the body.
+
+    Only the reshaping of `entity_id` and `entity_type` into the nested `entity` field
+    is this marshaller's own business -- the body is read by `JsonBodyMarshaller`, which
+    is why this no longer has to know what a body is. When it did, it read one body key
+    at a time from `get_json()` and spread the result: an unlabelled body was dropped in
+    silence, and a body that parsed to a list raised `TypeError` on the spread, turning
+    a two-character request into a 500.
+    """
+
     @classmethod
-    def marshal(cls: Type[T], flask_request: Request) -> T:
-        body = flask_request.get_json()
-        entity = {'entity': {'id': flask_request.args['entity_id'], 'type': flask_request.args['entity_type']}}
-        if not body:
-            return cls.parse_obj(entity)
-        return cls.parse_obj({**body, **entity})
+    def overrides(cls, flask_request: Request) -> dict[str, Any]:
+        return {'entity': {'id': flask_request.args['entity_id'], 'type': flask_request.args['entity_type']}}
 
 
 class GetLabelsForEntityRequest(BaseModel, EntityMarshaller):


### PR DESCRIPTION
Read request bodies in one place

## What this changes

Every marshaller in `ui_api` decided for itself what a request body was. There were four
implementations of that decision and they disagreed with each other:

| | `JsonBodyMarshaller` | `ViewArgAndJsonBodyMarshaller` | `EntityMarshaller` |
|---|---|---|---|
| body under a non-JSON content type | parsed (`force=True`) | parsed | **dropped in silence** |
| body that is a JSON list | parsed, then `parse_obj` errors | **`TypeError` → 500** | **`TypeError` → 500** |
| no body at all | 400 | 400 | defaults applied |

This adds one `json_object_body(request)` that answers the question once, and gives
`JsonBodyMarshaller` an `overrides()` hook so a marshaller says only *where its other
fields come from*. A marshaller written against the base never touches the body API, so
it cannot get this wrong.

## Bugs fixed

- **A reachable 500.** `EntityMarshaller` did `{**body, **entity}`, so any client could
  crash an entity endpoint by POSTing `[1,2,3]`. Now a 400.
- **Silently dropped bodies.** `get_json()` returns `None` for a body sent without
  `Content-Type: application/json`, which read as "no body" — so a request's contents
  were discarded and the endpoint reported success for work it had not done. Now a 400.
- **Dead code with a live bug.** `ViewArgAndJsonBodyMarshaller` had no users and merged
  the *body* last, so a body key could override the URL's own path parameter — a request
  to `/thing/1` carrying `{"thing_id": 2}` would have acted on 2 while the URL, the logs
  and any audit record said 1. Deleted, and replaced by
  `ViewArgAndOptionalJsonBodyMarshaller`, which merges view args last so the URL wins.
  That replacement has no callers on `main` yet; the rules-API branch is its first
  consumer, and it ships here so the broken version can be removed rather than left in
  place for something to find.

## Behaviour changes

`JsonBodyMarshaller` no longer passes `force=True`. A body sent to any endpoint using it
(create draft, validate, bulk actions, druid queries) must now declare
`Content-Type: application/json`. Requests that already send the header are unaffected;
every existing test did.

An empty body is no longer a parse failure. `json.loads('')` raises like malformed JSON
does, but a caller that set the content type and sent nothing is a caller who sent
nothing — whether that was allowed is then the model's business, via its own required
fields.

## Testing

`lib/tests/test_marshal.py` covers the matrix directly against the helper rather than
through whichever endpoint happens to use it: 8 shapes that read as an object or as
nothing, 8 that are refused, plus the `overrides` hook and `marshal_with`'s 400. The
tests use a bare Flask app — no database, engine, or authenticated user.

---

## The underlying problem this does not fix

**A request is being treated as one flat namespace.** Body, view args and query args are
merged into a single dict before validation, so a model cannot say which field comes from
where. Everything awkward here follows from that:

- The source of a field is encoded in the *class* (which marshaller mixin you inherit)
  rather than in the field. N sources means a mixin per combination — which is why there
  were five hand-rolled ones.
- Collisions have to be resolved by a precedence rule (`overrides` wins), and that rule
  has to be remembered, documented and tested. A body key that shadows a path parameter
  is a real risk — see the deleted `ViewArgAndJsonBodyMarshaller` — rather than something
  the type system makes unrepresentable.
- Models mix `BaseModel` with a marshaller mixin, so expressing `cls` correctly needs a
  `Protocol` and two `TypeVar`s.
- Errors come back in three shapes: pydantic's error list, `{"error": ...}`, and
  werkzeug's plain-text sentence served under an `application/json` mimetype.

The fix is to stop merging: let each source be named, and let path parameters arrive as
ordinary view-function arguments. FastAPI does this per field (`Path(...)`, `Query(...)`,
`Body(...)`); `flask-pydantic` does it by reading the view's type annotations.

### Why we are not doing that here

We are on **Flask 1.1.4** and **pydantic 1.10.26**, which excludes every current option:

| Library | Requires | Usable today |
|---|---|---|
| `webargs` 8.7 | Flask ≥ 0.12.5, marshmallow 3 | Yes — but marshmallow, a second validation library beside pydantic |
| `flask-pydantic` 0.11 | pydantic ≥ 1.7 | Yes — but it is the last pydantic-v1 release, Sept 2022 |
| `flask-pydantic` 0.12+ | pydantic ≥ 2 | No |
| `spectree` 2.0 | Flask ≥ 2, pydantic ≥ 2.11 | No |
| `apiflask` 3.1 | Flask ≥ 2.1, pydantic ≥ 2 | No |
| `flask-smorest` 0.47 | Flask ≥ 3.0.2, marshmallow | No |

So the hand-rolled marshallers are not a wrong turn so much as a reimplementation of a
library the stack cannot currently install.

### Options, roughly in order of lift

**1. Flask 1.1.4 → 3.x.** Routes and views barely move — `@blueprint.route` is stable
across the majors. The cost is dependency bumps, a handful of removed APIs
(`before_first_request`, `JSONEncoder` → the `app.json` provider), Werkzeug's majors, and
test-fixture plumbing. Note that Flask 2.1 changed `get_json()` to raise 415 rather than
return `None` for a non-JSON content type — `json_object_body` is insulated because it
checks `is_json` first, but the bare `get_json()` calls in `views/queries.py` and
`views/saved_queries.py` are not. Unblocks every library in the table above. Flask 1.1.4
has also been out of security support for years, which is an argument for this on its own.

**2. pydantic 1 → 2.** Independent of the above and independently shippable, but touches
every schema in the repo. Required for `flask-pydantic` 0.12+, `spectree` and `apiflask`.

**3. Rewrite in FastAPI.** Gets the per-field source declaration natively, and it is the
right destination *if* async I/O in `ui_api` is the goal. But it bundles: all 50 routes
rewritten; `lib/auth.py` rewritten, since identity is stashed as attributes on Flask's
request object (`request.claims`, `request.current_user`) and would become dependencies,
changing every view's decorator stack; ~348 test call sites moved off the Flask test
client; `OspreyFlask.make_response` reimplemented, including the `bigint_as_string`
encoding that exists because JS loses integer precision above 2^53; gunicorn → uvicorn;
and pydantic 2 as a hard requirement.

It also opens a question the codebase has so far avoided. `ui_api` is served by gunicorn's
gevent worker (`entrypoint.sh`), and is almost entirely storage-bound — nearly every
request reads or writes `osprey.worker.lib.storage.*`, which is synchronous SQLAlchemy
with a `scoped_session`. Notably, `osprey_async_worker` — the asyncio rewrite of the
event-processing path — contains no SQLAlchemy or storage code at all. The async work has
routed around exactly the layer `ui_api` is built on, so an async `ui_api` would have to
open that separately, and it could not be solved inside `ui_api` alone.

**Suggested order: 1, then adopt a validation library, then 2 if wanted.** Three
independently shippable, independently revertible steps that arrive at per-field source
declaration without a rewrite. Option 3 bundles all of it plus a concurrency-model change
into one commit that cannot be partially reverted.

Either way, `json_object_body` is throwaway in the good sense: whichever path is taken, it
is deleted in favour of the library's equivalent rather than needing to be unpicked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of JSON request bodies across the UI API.
  - Empty or bodyless requests now use safe defaults where applicable.
  - GET, HEAD, and DELETE request bodies are ignored.
  - Invalid, missing, malformed, or non-object JSON bodies return clear 400 errors instead of unexpected server errors.
  - URL-provided values now correctly take precedence over conflicting body values.
  - Error responses no longer expose request content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->