### PR TITLE
Fix crash loading a ruleset that has no config

### DIFF
--- a/osprey_worker/src/osprey/engine/ast/sources.py
+++ b/osprey_worker/src/osprey/engine/ast/sources.py
@@ -138,6 +138,10 @@ class SourcesBuilder:
         return self
 
     def add_config(self, *sources: Source) -> 'SourcesBuilder':
+        # No-op: a ruleset need not have a config, and `Sources` substitutes an empty one.
+        if not sources:
+            return self
+
         if self._config is not None:
             raise ValueError('A configuration already exists for this builder.')
 
@@ -165,10 +169,15 @@ class SourcesConfig(dict[str, Any]):
     that validation."""
 
     def __init__(self, *sources: Source):
-        assert sources, 'sources can not be empty'
+        if not sources:
+            raise ValueError(
+                f'SourcesConfig requires at least one source; pass an empty `{CONFIG_PATH}` for no config.'
+            )
         self._sources = sorted(sources, key=lambda source: source.path)
 
         if not all(_.contents for _ in self._sources):
+            # Still set `_source`; `source` is read unconditionally, e.g. by `Sources.to_dict()`.
+            self._source = Source(path=CONFIG_PATH, contents='')
             super().__init__()
             return
 

--- a/osprey_worker/src/osprey/engine/ast/tests/test_sources.py
+++ b/osprey_worker/src/osprey/engine/ast/tests/test_sources.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+
+import pytest
+from osprey.engine.ast.grammar import Source
+from osprey.engine.ast.sources import CONFIG_PATH, Sources, SourcesBuilder, SourcesConfig
+
+
+def _write_ruleset(root: Path) -> None:
+    root.joinpath('main.sml').write_text('Foo = 1\n')
+
+
+def test_from_path_without_any_config(tmp_path: Path) -> None:
+    _write_ruleset(tmp_path)
+
+    sources = Sources.from_path(tmp_path)
+
+    assert sources.paths() == {'main.sml'}
+    assert dict(sources.config) == {}
+
+
+def test_from_path_with_root_config(tmp_path: Path) -> None:
+    _write_ruleset(tmp_path)
+    tmp_path.joinpath(CONFIG_PATH).write_text('sample_rate: 0.5\n')
+
+    sources = Sources.from_path(tmp_path)
+
+    assert dict(sources.config) == {'sample_rate': 0.5}
+
+
+def test_from_path_with_config_directory(tmp_path: Path) -> None:
+    _write_ruleset(tmp_path)
+    config_dir = tmp_path.joinpath('config')
+    config_dir.mkdir()
+    config_dir.joinpath('sampling.yaml').write_text('sample_rate: 0.5\n')
+
+    sources = Sources.from_path(tmp_path)
+
+    assert dict(sources.config) == {'sample_rate': 0.5}
+
+
+def test_add_config_with_no_sources_is_a_noop() -> None:
+    builder = SourcesBuilder().add_source(Source(path='main.sml', contents='Foo = 1\n'))
+
+    builder.add_config()
+
+    assert dict(builder.build().config) == {}
+
+
+def test_add_config_after_an_empty_add_config_still_works() -> None:
+    builder = SourcesBuilder().add_source(Source(path='main.sml', contents='Foo = 1\n'))
+
+    builder.add_config()
+    builder.add_config(Source(path=CONFIG_PATH, contents='sample_rate: 0.5\n'))
+
+    assert dict(builder.build().config) == {'sample_rate': 0.5}
+
+
+def test_add_config_twice_still_raises() -> None:
+    builder = SourcesBuilder().add_source(Source(path='main.sml', contents='Foo = 1\n'))
+    builder.add_config(Source(path=CONFIG_PATH, contents='sample_rate: 0.5\n'))
+
+    with pytest.raises(ValueError, match='A configuration already exists'):
+        builder.add_config(Source(path='config/other.yaml', contents='other: 1\n'))
+
+
+def test_sources_config_rejects_zero_sources() -> None:
+    with pytest.raises(ValueError, match='requires at least one source'):
+        SourcesConfig()
+
+
+def test_to_dict_without_any_config(tmp_path: Path) -> None:
+    _write_ruleset(tmp_path)
+
+    sources = Sources.from_path(tmp_path)
+
+    assert sources.to_dict() == {'main.sml': 'Foo = 1\n'}
+
+
+def test_to_dict_round_trips_without_any_config() -> None:
+    sources = Sources.from_dict({'main.sml': 'Foo = 1\n'})
+
+    assert Sources.from_dict(sources.to_dict()).to_dict() == sources.to_dict()
+
+
+def test_config_source_is_available_when_config_is_empty() -> None:
+    config = SourcesConfig(Source(path=CONFIG_PATH, contents=''))
+
+    assert config.source.contents == ''


### PR DESCRIPTION
`Sources.from_path()` calls `add_config()` unconditionally, so a ruleset with no `config.yaml` and no `config/*.yaml` passes zero sources to `SourcesConfig` and trips `assert sources, 'sources can not be empty'`.

A config is not required: `Sources.__init__` already substitutes an empty one. Make `add_config()` a no-op when given no sources so that default applies, and replace the assert with a `ValueError` (asserts are stripped under `-O`).

## Description

<!-- What does this PR do? -->

Two crashes on a ruleset that has no `config.yaml` and no `config/*.yaml`.

**1. Loading fails.** `Sources.from_path()` calls `add_config()` unconditionally, so
zero sources reach `SourcesConfig` and trip a bare assert:

    $ mkdir -p ruleset && echo 'Foo = 1' > ruleset/main.sml
    $ python -c "from pathlib import Path; from osprey.engine.ast.sources import Sources; Sources.from_path(Path('ruleset'))"
    AssertionError: sources can not be empty

A config is not required — `Sources.__init__` already substitutes an empty
`SourcesConfig` when none is supplied; `from_path` just defeated that fallback.
`add_config()` is now a no-op when given no sources, so the existing default applies.
The assert also becomes a `ValueError`, since asserts are stripped under `-O`.

**2. Serialising fails.** `SourcesConfig.__init__` returns early when contents are
empty without setting `_source`, so the `source` property raises:

    AttributeError: 'SourcesConfig' object has no attribute '_source'

That breaks `Sources.to_dict()`, which `EtcdSourcesPublisher.publish_sources()` calls
to push rules to etcd. `_source` is now set on that path too.

The second crash was previously masked by the first: `from_path` blew up before
anything could reach `to_dict()`. Fixing only the first would move the failure from
load time to publish time, so both belong together.

### Tests

Adds `osprey_worker/src/osprey/engine/ast/tests/test_sources.py` (10 tests) covering
config-less loading, root `config.yaml`, `config/*.yaml`, `to_dict()` round-tripping,


## Checklist

- [x] Tests pass locally
- [x] `uv run ruff check .` passes (no unused imports or other lint errors)
- [x] `uv tool run fawltydeps --check-unused --pyenv .venv` passes (no unused dependencies)
- [x] Updated `CHANGELOG.md` with my changes, if notable (refer to [Keep a Changelog](https://keepachangelog.com/en/2.0.0/) conventions)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Rulesets without a configuration source are now accepted.
  - Configuration validation now reports a clear error when no sources are provided.
  - Duplicate configuration sources continue to be rejected with an explicit error.

- **Tests**
  - Added coverage for source discovery, optional configuration loading, empty configurations, and duplicate configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->